### PR TITLE
fix: hide invoice quick action for doctors

### DIFF
--- a/apps/web/src/app/dashboard/patients/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/patients/[id]/page.tsx
@@ -791,6 +791,7 @@ export default function PatientDetailPage() {
           patient={patient}
           stats={stats}
           canEdit={canEdit}
+          canCreateInvoice={isReception || isAdmin}
           onBookAppt={() => setQuickModal("book")}
         />
       )}
@@ -3731,12 +3732,14 @@ function Patient360Tab({
   patient,
   stats,
   canEdit,
+  canCreateInvoice,
   onBookAppt,
 }: {
   patientId: string;
   patient: PatientDetail & { photoUrl?: string | null };
   stats: PatientStats | null;
   canEdit: boolean;
+  canCreateInvoice: boolean;
   onBookAppt: () => void;
 }) {
   const [timeline, setTimeline] = useState<TimelineEntry[]>([]);
@@ -3947,12 +3950,14 @@ function Patient360Tab({
                 color="bg-green-600"
                 Icon={Pill}
               />
-              <QuickLink
-                href={`/dashboard/billing/new?patientId=${patientId}`}
-                label="Generate Bill"
-                color="bg-amber-600"
-                Icon={Receipt}
-              />
+              {canCreateInvoice && (
+                <QuickLink
+                  href={`/dashboard/billing/new?patientId=${patientId}`}
+                  label="Generate Bill"
+                  color="bg-amber-600"
+                  Icon={Receipt}
+                />
+              )}
             </div>
           </div>
 


### PR DESCRIPTION
Fixes #176.

## Summary
- keeps the existing billing/new quick action for Reception/Admin users
- passes an explicit `canCreateInvoice` capability into the 360° patient tab
- hides the 360° tab's `Generate Bill` shortcut for Doctor users so patient charts no longer route doctors into the billing dead-end

## Verification
- `git diff --check` passed
- package-manager checks were not run in this runner because only `node` is available here (`npm`/`pnpm`/`yarn` are unavailable)

Safety: public UI code only; no patient data, production access, credentials, billing/admin login, deploy, or spend used.
