### PR TITLE
fix: derive invoice status from payments

### DIFF
--- a/apps/web/src/app/dashboard/__tests__/billing.detail.page.test.tsx
+++ b/apps/web/src/app/dashboard/__tests__/billing.detail.page.test.tsx
@@ -101,6 +101,37 @@ describe("InvoiceDetailPage", () => {
     expect(screen.getAllByText(/consultation/i).length).toBeGreaterThan(0);
   });
 
+  it("derives invoice status from payments when the API status is stale", async () => {
+    apiMock.get.mockImplementation((url: string) => {
+      if (url.includes("/billing/invoices/test-id"))
+        return Promise.resolve({
+          data: {
+            ...sampleInvoice,
+            invoiceNumber: "INV000228",
+            paymentStatus: "PAID",
+            totalAmount: 1180,
+            payments: [
+              {
+                id: "pay1",
+                amount: 500,
+                mode: "CASH",
+                paidAt: new Date().toISOString(),
+                transactionId: null,
+              },
+            ],
+          },
+        });
+      return Promise.resolve({ data: [] });
+    });
+
+    render(<InvoiceDetailPage />);
+
+    await waitFor(() =>
+      expect(screen.getAllByText(/INV000228/).length).toBeGreaterThan(0)
+    );
+    expect(screen.getByText("PARTIAL")).toBeInTheDocument();
+  });
+
   it("opens Record Payment modal when button clicked", async () => {
     apiMock.get.mockImplementation((url: string) => {
       if (url.includes("/billing/invoices/test-id"))

--- a/apps/web/src/app/dashboard/__tests__/billing.page.test.tsx
+++ b/apps/web/src/app/dashboard/__tests__/billing.page.test.tsx
@@ -110,6 +110,38 @@ describe("BillingPage", () => {
     });
   });
 
+  it("derives a partial status when the API marks an outstanding invoice paid", async () => {
+    apiMock.get.mockImplementation((url: string) => {
+      if (url.startsWith("/billing/invoices"))
+        return Promise.resolve({
+          data: [
+            {
+              ...sampleInvoices[1],
+              id: "inv-mismatch",
+              invoiceNumber: "INV000228",
+              totalAmount: 2500,
+              paymentStatus: "PAID",
+              payments: [
+                {
+                  id: "pay1",
+                  amount: 1000,
+                  mode: "CASH",
+                  paidAt: new Date().toISOString(),
+                },
+              ],
+            },
+          ],
+        });
+      return Promise.resolve(defaultGet(url));
+    });
+
+    render(<BillingPage />);
+
+    await waitFor(() => expect(screen.getByText("INV000228")).toBeInTheDocument());
+    expect(screen.getByText("PARTIAL")).toBeInTheDocument();
+    expect(screen.queryByText("PAID")).not.toBeInTheDocument();
+  });
+
   it("calls /billing/reports/outstanding when Outstanding tab is active", async () => {
     const user = userEvent.setup();
     render(<BillingPage />);

--- a/apps/web/src/app/dashboard/billing/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/billing/[id]/page.tsx
@@ -95,6 +95,19 @@ function fmtMoney(n: number) {
   })}`;
 }
 
+function derivePaymentStatus(
+  paymentStatus: string,
+  totalAmount: number,
+  netPaid: number
+) {
+  if (paymentStatus === "REFUNDED") return paymentStatus;
+
+  const balance = Math.max(0, totalAmount - netPaid);
+  if (balance <= 0) return "PAID";
+  if (netPaid > 0) return "PARTIAL";
+  return paymentStatus === "PAID" ? "PENDING" : paymentStatus;
+}
+
 export default function InvoiceDetailPage() {
   const params = useParams();
   const id = params.id as string;
@@ -324,6 +337,11 @@ export default function InvoiceDetailPage() {
   const totalRefunded = refunds.reduce((s, p) => s + Math.abs(p.amount), 0);
   const netPaid = grossPaid - totalRefunded;
   const balance = Math.max(0, invoice.totalAmount - netPaid);
+  const displayStatus = derivePaymentStatus(
+    invoice.paymentStatus,
+    invoice.totalAmount,
+    netPaid
+  );
 
   // Compute per-line GST at render time via the shared helper. We do NOT
   // persist these columns in this pass — flagged as a follow-up to add
@@ -352,7 +370,7 @@ export default function InvoiceDetailPage() {
     (a, b) => new Date(a.paidAt).getTime() - new Date(b.paidAt).getTime()
   );
 
-  const isPending = invoice.paymentStatus === "PENDING";
+  const isPending = displayStatus === "PENDING";
 
   return (
     <>
@@ -387,8 +405,8 @@ export default function InvoiceDetailPage() {
           <ArrowLeft size={16} /> Back to Billing
         </Link>
         <div className="flex flex-wrap items-center gap-2">
-          {invoice.paymentStatus !== "PAID" &&
-            invoice.paymentStatus !== "REFUNDED" && (
+          {displayStatus !== "PAID" &&
+            displayStatus !== "REFUNDED" && (
               <button
                 onClick={() => setDiscOpen(true)}
                 className="flex items-center gap-1 rounded-lg border bg-white px-3 py-1.5 text-sm hover:bg-gray-50"
@@ -461,14 +479,14 @@ export default function InvoiceDetailPage() {
         className="relative mx-auto max-w-3xl overflow-hidden rounded-xl bg-white p-8 shadow-sm"
       >
         {/* Watermark overlays */}
-        {invoice.paymentStatus === "CANCELLED" && (
+        {displayStatus === "CANCELLED" && (
           <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center">
             <span className="select-none rotate-[-30deg] text-[8rem] font-black text-red-500/20">
               CANCELLED
             </span>
           </div>
         )}
-        {invoice.paymentStatus === "PAID" && (
+        {displayStatus === "PAID" && (
           <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center">
             <span className="select-none rotate-[-30deg] text-[8rem] font-black text-green-500/15">
               PAID
@@ -521,9 +539,9 @@ export default function InvoiceDetailPage() {
                 })}
               </p>
               <span
-                className={`mt-2 inline-block rounded-full px-3 py-0.5 text-xs font-medium ${statusColors[invoice.paymentStatus] || ""}`}
+                className={`mt-2 inline-block rounded-full px-3 py-0.5 text-xs font-medium ${statusColors[displayStatus] || ""}`}
               >
-                {invoice.paymentStatus}
+                {displayStatus}
               </span>
             </div>
           </div>

--- a/apps/web/src/app/dashboard/billing/page.tsx
+++ b/apps/web/src/app/dashboard/billing/page.tsx
@@ -74,6 +74,19 @@ function overdueClass(days: number) {
   return "text-gray-500";
 }
 
+function derivePaymentStatus(
+  paymentStatus: string,
+  totalAmount: number,
+  netPaid: number
+) {
+  if (paymentStatus === "REFUNDED") return paymentStatus;
+
+  const balance = Math.max(0, totalAmount - netPaid);
+  if (balance <= 0) return "PAID";
+  if (netPaid > 0) return "PARTIAL";
+  return paymentStatus === "PAID" ? "PENDING" : paymentStatus;
+}
+
 export default function BillingPage() {
   const { user, isLoading } = useAuthStore();
   const router = useRouter();
@@ -389,8 +402,13 @@ export default function BillingPage() {
           .reduce((s, p) => s + Math.abs(p.amount), 0);
         const netPaid = paid - refunded;
         const balance = Math.max(0, inv.totalAmount - netPaid);
+        const displayStatus = derivePaymentStatus(
+          inv.paymentStatus,
+          inv.totalAmount,
+          netPaid
+        );
         const age = daysAgo(inv.createdAt);
-        return { ...inv, paid, refunded, netPaid, balance, age };
+        return { ...inv, paid, refunded, netPaid, balance, displayStatus, age };
       }),
     [invoices]
   );
@@ -599,9 +617,9 @@ export default function BillingPage() {
                   </td>
                   <td className="px-4 py-3">
                     <span
-                      className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${statusColors[inv.paymentStatus] || ""}`}
+                      className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${statusColors[inv.displayStatus] || ""}`}
                     >
-                      {inv.paymentStatus}
+                      {inv.displayStatus}
                     </span>
                   </td>
                   {isStaff && (
@@ -621,7 +639,7 @@ export default function BillingPage() {
                           onClick={(e) => e.stopPropagation()}
                           className="absolute right-4 top-10 z-10 w-52 rounded-lg border bg-white py-1 shadow-lg"
                         >
-                          {inv.paymentStatus !== "PAID" && (
+                          {inv.displayStatus !== "PAID" && (
                             <button
                               onClick={() => {
                                 setPayInv(inv);
@@ -632,7 +650,7 @@ export default function BillingPage() {
                               <Receipt size={14} /> Record Payment
                             </button>
                           )}
-                          {inv.paymentStatus !== "PAID" && (
+                          {inv.displayStatus !== "PAID" && (
                             <button
                               onClick={() => {
                                 openPayOnlineModal(inv);
@@ -655,8 +673,8 @@ export default function BillingPage() {
                               <Undo2 size={14} /> Record Refund
                             </button>
                           )}
-                          {inv.paymentStatus !== "PAID" &&
-                            inv.paymentStatus !== "REFUNDED" && (
+                          {inv.displayStatus !== "PAID" &&
+                            inv.displayStatus !== "REFUNDED" && (
                               <button
                                 onClick={() => {
                                   setDiscInv(inv);


### PR DESCRIPTION
Addresses #235 (and the duplicate report #386).

## Summary
- derives the visible billing status from `totalAmount - netPaid` on the Bills table
- applies the same derived status to the invoice detail badge/watermark/action gating
- adds regression coverage for an API-stale `PAID` invoice that still has an outstanding balance

## Verification
- `git diff --check` passed
- static assertion for derived-status helper usage passed
- `npm run test:web -- apps/web/src/app/dashboard/__tests__/billing.page.test.tsx apps/web/src/app/dashboard/__tests__/billing.detail.page.test.tsx` could not run because this runner does not currently have `vitest` installed; `npm ci --ignore-scripts` timed out before installing it
- CI note: PR branch typecheck passes; current API/web test failures match failures on upstream `main`, so this branch is unchanged until reviewer feedback points to an invoice-status-specific failure

Safety: public UI/test code only; no patient data, production access, credentials, deploy, spend, account/KYC/payment setup, wallet/on-chain action, or gateway action used.
