### PR TITLE
Fix billing amount overflow

### DIFF
--- a/apps/web/src/app/dashboard/__tests__/billing.page.test.tsx
+++ b/apps/web/src/app/dashboard/__tests__/billing.page.test.tsx
@@ -213,4 +213,38 @@ describe("BillingPage", () => {
       "PARTIAL"
     );
   });
+
+  it("contains large paid amounts in a truncated money cell (#568)", async () => {
+    const inv = {
+      id: "inv-568",
+      invoiceNumber: "INV000373",
+      totalAmount: 999999999,
+      paymentStatus: "PAID",
+      createdAt: new Date().toISOString(),
+      patientId: "p568",
+      patient: { user: { name: "Seema Rawat", phone: "9000000373" } },
+      payments: [
+        {
+          id: "pm-568",
+          amount: 999999999,
+          mode: "CASH",
+          paidAt: new Date().toISOString(),
+        },
+      ],
+    };
+    apiMock.get.mockImplementation((url: string) => {
+      if (url.startsWith("/billing/invoices"))
+        return Promise.resolve({ data: [inv] });
+      return Promise.resolve(defaultGet(url));
+    });
+    render(<BillingPage />);
+    await waitFor(() =>
+      expect(screen.getByText("INV000373")).toBeInTheDocument()
+    );
+
+    const paidAmount = screen.getAllByTitle("Rs. 99,99,99,999.00")[1];
+    expect(paidAmount).toHaveClass("truncate");
+    expect(paidAmount).toHaveClass("text-right");
+    expect(paidAmount).toHaveClass("tabular-nums");
+  });
 });

--- a/apps/web/src/app/dashboard/billing/page.tsx
+++ b/apps/web/src/app/dashboard/billing/page.tsx
@@ -65,6 +65,18 @@ function fmtMoney(n: number) {
   })}`;
 }
 
+function MoneyValue({ amount, tone = "" }: { amount: number; tone?: string }) {
+  const formatted = fmtMoney(amount);
+  return (
+    <span
+      title={formatted}
+      className={`ml-auto block max-w-[9.5rem] truncate text-right tabular-nums ${tone}`}
+    >
+      {formatted}
+    </span>
+  );
+}
+
 function daysAgo(iso: string) {
   return Math.floor((Date.now() - new Date(iso).getTime()) / 86400000);
 }
@@ -498,7 +510,7 @@ export default function BillingPage() {
       </div>
 
       {/* Content */}
-      <div className="rounded-xl bg-white text-gray-900 shadow-sm dark:bg-gray-800 dark:text-gray-100">
+      <div className="overflow-x-auto rounded-xl bg-white text-gray-900 shadow-sm dark:bg-gray-800 dark:text-gray-100">
         {loading ? (
           <div className="p-8 text-center text-gray-500 dark:text-gray-400">Loading...</div>
         ) : tab === "outstanding" ? (
@@ -507,14 +519,14 @@ export default function BillingPage() {
               No outstanding invoices.
             </div>
           ) : (
-            <table className="w-full">
+            <table className="w-full min-w-[920px]">
               <thead>
                 <tr className="border-b border-gray-200 text-left text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
                   <th className="px-4 py-3">Invoice #</th>
                   <th className="px-4 py-3">Patient</th>
-                  <th className="px-4 py-3">Total</th>
-                  <th className="px-4 py-3">Paid</th>
-                  <th className="px-4 py-3">Balance</th>
+                  <th className="min-w-36 px-4 py-3 text-right">Total</th>
+                  <th className="min-w-36 px-4 py-3 text-right">Paid</th>
+                  <th className="min-w-36 px-4 py-3 text-right">Balance</th>
                   <th className="px-4 py-3">Days Overdue</th>
                   <th className="px-4 py-3">Status</th>
                   <th className="px-4 py-3">Actions</th>
@@ -539,10 +551,14 @@ export default function BillingPage() {
                         <p className="text-xs text-gray-500 dark:text-gray-400">{r.patient.user.phone}</p>
                       )}
                     </td>
-                    <td className="px-4 py-3 text-sm">{fmtMoney(r.totalAmount)}</td>
-                    <td className="px-4 py-3 text-sm">{fmtMoney(r.paid)}</td>
-                    <td className="px-4 py-3 text-sm font-semibold text-red-600">
-                      {fmtMoney(r.balance)}
+                    <td className="px-4 py-3 text-sm">
+                      <MoneyValue amount={r.totalAmount} />
+                    </td>
+                    <td className="px-4 py-3 text-sm">
+                      <MoneyValue amount={r.paid} />
+                    </td>
+                    <td className="px-4 py-3 text-sm font-semibold">
+                      <MoneyValue amount={r.balance} tone="text-red-600" />
                     </td>
                     <td className={`px-4 py-3 text-sm ${overdueClass(r.daysOverdue)}`}>
                       {r.daysOverdue} days
@@ -580,14 +596,14 @@ export default function BillingPage() {
             description="Invoices will appear here once they are generated from visits or admissions."
           />
         ) : (
-          <table className="w-full">
+          <table className="w-full min-w-[920px]">
             <thead>
               <tr className="border-b border-gray-200 text-left text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
                 <th className="px-4 py-3">Invoice #</th>
                 <th className="px-4 py-3">Patient</th>
-                <th className="px-4 py-3">Amount</th>
-                <th className="px-4 py-3">Paid</th>
-                <th className="px-4 py-3">Balance</th>
+                <th className="min-w-36 px-4 py-3 text-right">Amount</th>
+                <th className="min-w-36 px-4 py-3 text-right">Paid</th>
+                <th className="min-w-36 px-4 py-3 text-right">Balance</th>
                 <th className="px-4 py-3">Age</th>
                 <th className="px-4 py-3">Status</th>
                 {isStaff && <th className="px-4 py-3">Actions</th>}
@@ -612,14 +628,23 @@ export default function BillingPage() {
                       <p className="text-xs text-gray-500 dark:text-gray-400">{inv.patient.user.phone}</p>
                     )}
                   </td>
-                  <td className="px-4 py-3 font-medium">{fmtMoney(inv.totalAmount)}</td>
-                  <td className="px-4 py-3 text-sm">{fmtMoney(inv.netPaid)}</td>
+                  <td className="px-4 py-3 font-medium">
+                    <MoneyValue amount={inv.totalAmount} />
+                  </td>
+                  <td className="px-4 py-3 text-sm">
+                    <MoneyValue amount={inv.netPaid} />
+                  </td>
                   <td
-                    className={`px-4 py-3 text-sm font-semibold ${
-                      inv.balance > 0 ? "text-red-600 dark:text-red-400" : "text-gray-500 dark:text-gray-400"
-                    }`}
+                    className="px-4 py-3 text-sm font-semibold"
                   >
-                    {fmtMoney(inv.balance)}
+                    <MoneyValue
+                      amount={inv.balance}
+                      tone={
+                        inv.balance > 0
+                          ? "text-red-600 dark:text-red-400"
+                          : "text-gray-500 dark:text-gray-400"
+                      }
+                    />
                   </td>
                   {/* Issue #400: Age must be computed per-row from the
                       invoice's createdAt, not a hardcoded constant. The


### PR DESCRIPTION
﻿Fixes #568.

## Summary
- wrap the billing table container in horizontal overflow so narrow screens/table pressure do not push cells into neighbors
- render billing money values through a shared `MoneyValue` span with `tabular-nums`, right alignment, truncation, and a `title` tooltip for the full formatted amount
- apply the same containment to all Amount/Paid/Balance cells in both invoice and outstanding report tables

## Tests
- `npm run test:web -- apps/web/src/app/dashboard/__tests__/billing.page.test.tsx` -> 8 passed

Note: `npm ci` currently fails before tests because the upstream `package-lock.json` is not in sync with `package.json` (`@aws-sdk/client-s3`, `openai`, React Native packages, etc. missing from the lockfile). I installed with `npm install --package-lock=false --ignore-scripts --no-audit --no-fund` to run the focused test without rewriting the lockfile.
