### PR TITLE
ci(secret-scan): port gitleaks workflow + allowlist from globussoft-crm

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,95 @@
+name: Secret scan (gitleaks)
+
+# Ports the gbs-crm secret-scan workflow into medcore (workflow-parity gap,
+# 2026-05-09). Two modes:
+#   1. push  → fast incremental scan of the diff (10-20s, gates per-push)
+#   2. cron  → weekly full-history scan (~2-5 min, catches secrets that
+#              made it past the per-push gate via squash merges, history
+#              rewrites, or pre-existing commits before this workflow
+#              landed)
+#
+# Allowlist for KNOWN-INTENTIONAL demo + test creds + dev-fallback strings
+# lives at /.gitleaks.toml. NEVER allowlist a real production secret.
+#
+# Tooling note: we use the open-source `gitleaks` binary via its
+# official Docker image rather than gitleaks/gitleaks-action@v2, which
+# requires a paid GITLEAKS_LICENSE secret for organization repos. The
+# binary is the same engine that backs the action — same `.gitleaks.toml`
+# config, same default ruleset — so swapping back later is trivial.
+#
+# Findings cause the gitleaks CLI to exit non-zero, which fails the
+# workflow. To suppress a real false positive, add it to the allowlist
+# in /.gitleaks.toml with a descriptive comment.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Mondays 06:30 UTC = 12:00 IST. Slightly after Dependabot so
+    # the dep-PR queue lands first and any new secrets they introduce
+    # get caught.
+    - cron: "30 6 * * 1"
+  workflow_dispatch:
+
+# Don't waste runners on simultaneous scans; queue them.
+concurrency:
+  group: secret-scan-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  # ── Incremental: scan only the new commits in this push/PR. Fast (10-20s) ──
+  scan_diff:
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # Fetch enough history for gitleaks to compare against the
+          # base branch on PRs. Push events on main only need depth 2
+          # (HEAD + parent).
+          fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 2 }}
+
+      - name: Run gitleaks (incremental)
+        # Scans the commits present in the shallow clone (depth=2 for
+        # push → just HEAD + parent → effectively the diff; depth=0 for
+        # PRs → full history relative to the PR base). The binary's
+        # default exit code on findings is non-zero, which fails CI.
+        uses: docker://zricethezav/gitleaks:latest
+        with:
+          args: >-
+            detect
+            --source=/github/workspace
+            --config=/github/workspace/.gitleaks.toml
+            --redact
+            --verbose
+            --no-banner
+            --exit-code=1
+
+  # ── Full history: weekly belt-and-braces ──
+  scan_full_history:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # full history
+
+      - name: Run gitleaks (full history)
+        uses: docker://zricethezav/gitleaks:latest
+        with:
+          args: >-
+            detect
+            --source=/github/workspace
+            --config=/github/workspace/.gitleaks.toml
+            --redact
+            --verbose
+            --no-banner
+            --exit-code=1

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,152 @@
+# gitleaks config — workflow-parity port from gbs-crm (2026-05-09).
+#
+# Two layers of allowlist:
+#   1. Inherit gitleaks' default rule set (`useDefault = true`). Default
+#      rules cover AWS, Slack, Stripe, GitHub PAT, generic API keys, etc.
+#   2. Allow KNOWN-INTENTIONAL strings that are demo-only seed creds,
+#      test-fixture creds, or documented dev-fallback constants. Anything
+#      not on this list is a finding.
+#
+# CRITICAL: this allowlist documents what we know is safe. NEVER add a
+# real production credential here — that's the gate's job to catch.
+
+title = "medcore gitleaks config"
+
+[extend]
+# Inherit the default rule set (AWS, Slack, Stripe, GitHub PAT, etc.).
+useDefault = true
+
+[[allowlists]]
+description = "MedCore intentional demo/test/dev-fallback credentials"
+
+# Files where the strings below legitimately appear:
+paths = [
+    # ── Realistic demo seeds (public demo box: medcore.globusdemos.com) ──
+    '''packages/db/src/seed\.ts''',
+    '''packages/db/src/seed-realistic\.ts''',
+    '''packages/db/src/seed-pediatric-patients\.ts''',
+    '''packages/db/src/seed-pharmacy\.ts''',
+    '''scripts/reseed-demo-accounts\.ts''',
+    '''scripts/sanitize-and-reseed\.ts''',
+
+    # ── Integration test scaffolding ──
+    # Test-DB seed creds (admin@test.local / MedCoreT3st-2026) live here
+    # and are referenced from every integration test under apps/api/.
+    '''apps/api/src/test/setup\.ts''',
+    '''apps/api/src/test/setup-env\.ts''',
+    '''apps/api/src/test/factories\.ts''',
+    # Every integration test mints test JWTs against the test-only
+    # JWT_SECRET fallback string `test-jwt-secret-do-not-use-in-prod`.
+    '''apps/api/src/test/integration/.+\.test\.ts''',
+    # Route-level vitest specs mint local tokens too.
+    '''apps/api/src/routes/.+\.test\.ts''',
+    '''apps/api/src/middleware/.+\.test\.ts''',
+    # Package-level unit tests use a fixed `rls-test-pw` for ephemeral users.
+    '''packages/db/src/__tests__/.+\.test\.ts''',
+    '''packages/shared/src/.+__tests__/.+\.test\.ts''',
+    '''apps/web/src/lib/__tests__/.+\.test\.ts''',
+
+    # ── E2E (Playwright) ──
+    # Demo creds + LanguageDropdown helpers + role-based login chips.
+    '''e2e/.+\.spec\.ts''',
+    '''e2e/helpers\.ts''',
+    '''apps/mobile/e2e/.+\.md''',
+
+    # ── Load-test helpers ──
+    # JWT-mint helper that uses the same test-only fallback secret.
+    '''scripts/load-tests/.+\.ts''',
+    '''scripts/capture-screenshots\.ts''',
+    '''scripts/abdm-e2e\.ts''',
+
+    # ── Documentation that references demo creds ──
+    '''CLAUDE\.md''',
+    '''README\.md''',
+    '''TODO\.md''',
+    '''CHANGELOG\.md''',
+    '''docs/.+\.md''',
+    '''docs/archive/.+\.md''',
+    '''\.claude/skills/.+/SKILL\.md''',
+    '''\.issue-details\.txt''',
+
+    # ── Env templates (placeholders, not real creds) ──
+    '''\.env\.example''',
+    '''apps/api/\.env\.example''',
+    '''apps/web/\.env\.example''',
+    '''e2e/\.env\.example''',
+]
+
+# Known-safe content patterns that may appear inside the above paths
+# (and anywhere they're referenced as documentation or default-fallback
+# strings, not as real credentials):
+regexes = [
+    # ── Realistic-seed role passwords (packages/db/src/seed*.ts) ──
+    # Public demo creds for medcore.globusdemos.com — every role has its
+    # own deterministic password so quick-login chips on the login page
+    # demonstrate role-based access. NOT real credentials.
+    '''admin123''',
+    '''doctor123''',
+    '''reception123''',
+    '''nurse123''',
+    '''pharmacist123''',
+    '''labtech123''',
+    '''patient123''',
+    '''pedpatient123''',
+
+    # ── Integration-test seed creds (apps/api/src/test/setup.ts) ──
+    # Materialised by `resetDB()` for every vitest integration suite.
+    # Documented in CLAUDE.md ("Test DB seed creds" pickup-protocol note).
+    '''MedCoreT3st-2026''',
+
+    # ── JWT secret dev-fallback strings ──
+    # Used when JWT_SECRET env var is missing — documented in
+    # apps/api/src/middleware/auth.ts and .../tenant.ts. Production MUST
+    # set JWT_SECRET; these strings exist only so dev/test environments
+    # don't crash at boot when the env var is absent.
+    '''test-jwt-secret-do-not-use-in-prod''',
+    '''dev-secret''',
+
+    # ── RLS test-user password (packages/db/src/__tests__/rls.test.ts) ──
+    # Ephemeral bcrypt source for users created/destroyed inside a single
+    # test file. Never persisted, never leaks to demos.
+    '''rls-test-pw''',
+
+    # ── Env-template placeholders (apps/api/.env.example) ──
+    # Literal placeholder strings. Real deployments override; the literal
+    # strings ARE the placeholders (lines 3, 4, 84 of apps/api/.env.example).
+    '''change-this-to-a-random-secret''',
+    '''your-super-secret-jwt-key-change-this''',
+    '''your-refresh-token-secret-change-this''',
+]
+
+# Stop matches based on the surrounding context. Useful for false
+# positives where the same string shape appears in code comments.
+stopwords = [
+    "demo",
+    "example.com",
+    "fake",
+    "dummy",
+    "TEST_",
+    "test-jwt-secret",
+    "do-not-use-in-prod",
+    "MedCoreT3st-2026",
+    "dev-secret",
+    "rls-test-pw",
+]
+
+[[allowlists]]
+description = "E2E + integration deterministic test markers"
+regexTarget = "match"
+
+# E2E specs and integration tests use deterministic-shaped tokens like
+# E2E_<NS>_<ts>, MR-TEST-<n>, INV-SEED-<n>, MRSEED<n>, TXN-SEED-<n>,
+# patient<role>@test.local etc. These can match high-entropy heuristics.
+# Allow them anywhere.
+regexes = [
+    '''E2E_[A-Z_]+_\d+''',
+    '''MR-TEST-\d+''',
+    '''MRSEED\d+''',
+    '''INV-SEED-\d+''',
+    '''TXN-SEED-\d+''',
+    '''[a-z_]+@test\.local''',
+    '''[a-z.]+@medcore\.local''',
+]


### PR DESCRIPTION
## Summary

- Ports the secret-scan workflow from globussoft-crm (one of 4 missing workflows in the parity audit documented in TODO.md).
- Two-mode scan: per-push/PR incremental (10-20s) + weekly cron full-history (Mondays 06:30 UTC).
- Uses open-source gitleaks via Docker image — no paid GITLEAKS_LICENSE needed.
- \`.gitleaks.toml\` inherits gitleaks' default rule set + a thoughtful allowlist for KNOWN-INTENTIONAL strings (demo creds, JWT dev-fallback, test-DB password, e2e deterministic markers).

## Test plan

- [ ] Workflow self-runs on this PR (incremental scan against the PR base).
- [ ] No findings on the existing tree (the allowlist covers every documented intentional string).
- [ ] Weekly cron fires Mondays at 06:30 UTC after merge.
- [ ] If a future commit introduces a real-looking secret, the gate fails CI loud.

## Notes

- CRITICAL discipline going forward: never add a real prod credential to the allowlist. That's what the gate is for.
- Trivial to swap to the paid \`gitleaks/gitleaks-action@v2\` later if we want richer PR comments — same engine, same config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)