### PR TITLE
fix(e2e/prescription-lifecycle): re-enable DDI override test with deterministic fixtures

### DIFF
--- a/e2e/prescription-lifecycle.spec.ts
+++ b/e2e/prescription-lifecycle.spec.ts
@@ -192,24 +192,81 @@ test.describe("Prescriptions lifecycle — /dashboard/prescriptions (DDI safety 
     expect(saveAttempts).toBe(0);
   });
 
-  // TODO(2026-05-09): genuinely flaky on shard 8 chromium+webkit under
-  // parallel load. 3 release.yml runs in a row failed at different steps:
-  // savePromise (round 2 timeout), previewPromise (round 3 timeout). Both
-  // 15s and 30s timeouts have been tried. Root cause is the EntityPicker
-  // mousedown race + check-interactions stub propagation under load.
-  // Skipping until a focused refactor session can use a deterministic
-  // fixture (mock the patient/appointment selectors as fulfilled before
-  // the form mount) instead of driving real EntityPicker UI. The override
-  // contract itself is unit-tested at apps/api/src/routes/prescriptions.test.ts
-  // (overrideWarnings:true is already pinned at the API level) — the E2E
-  // adds end-to-end UI validation but isn't the load-bearing safety pin.
-  test.skip("DOCTOR — DDI override path: clicking 'Override and continue' submits the Rx with overrideWarnings=true so the API allows the save (routes/prescriptions.ts:168 contract — hasBlocking only blocks when overrideWarnings is falsy)", async ({
+  // 2026-05-10 re-enable: refactored to use deterministic-fixture stubs for
+  // the /patients and /appointments list endpoints so the EntityPicker
+  // dropdowns render synthetic-but-valid rows without any real DB seed or
+  // backend round-trips. Previous flake history (3 release.yml rounds —
+  // savePromise then previewPromise then savePromise again, even after
+  // 15s→30s timeout bumps) traced to two compounding load sources on
+  // shard-8 chromium+webkit: (a) the seedPatient + seedAppointment writes
+  // racing the form mount, (b) the EntityPicker's debounced GET against
+  // the real backend competing with other shards' API traffic. Stubbing
+  // both list endpoints removes (a) entirely (no DB writes) and reduces
+  // (b) to instant Playwright route fulfills. The contract surface
+  // (modal-open → override-click → POST with overrideWarnings:true) is
+  // unchanged. Companion API-level pin lives at
+  // apps/api/src/routes/prescriptions.test.ts.
+  test("DOCTOR — DDI override path: clicking 'Override and continue' submits the Rx with overrideWarnings=true so the API allows the save (routes/prescriptions.ts:168 contract — hasBlocking only blocks when overrideWarnings is falsy)", async ({
     doctorPage,
-    adminApi,
   }) => {
     const page = doctorPage;
-    const patient = await seedPatient(adminApi);
-    const appt = await seedAppointment(adminApi, { patientId: patient.id });
+
+    // Deterministic synthetic IDs — the form's only consumers of these
+    // values are (i) the rx-*-picker-option's data-entity-id attribute
+    // (locator key) and (ii) the save POST body. Both are validated below
+    // against the same constants — no real DB row required.
+    const PATIENT_ID = "22222222-2222-2222-2222-222222222222";
+    const APPOINTMENT_ID = "33333333-3333-3333-3333-333333333333";
+    const DOCTOR_ID = "44444444-4444-4444-4444-444444444444";
+    const PATIENT_NAME = "DDI Override Test Patient";
+
+    // Stub the patient search list so the EntityPicker dropdown deterministically
+    // shows our synthetic row when the user types into the search input.
+    // The query string includes ?search=&limit=… per EntityPicker.tsx:172-184.
+    await page.route("**/api/v1/patients?**", (route) => {
+      if (route.request().method() !== "GET") return route.continue();
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: [
+            {
+              id: PATIENT_ID,
+              mrNumber: "MR-DDI-OVERRIDE",
+              user: { name: PATIENT_NAME, phone: "+919800000001" },
+            },
+          ],
+          error: null,
+          meta: { page: 1, limit: 10, total: 1 },
+        }),
+      });
+    });
+
+    // Stub the appointment search list (scoped by patientId+date+status per
+    // page.tsx:762). We match any /appointments?... GET so the
+    // EntityPicker's onFocus fetch (minQueryLength=0) sees one BOOKED row.
+    await page.route("**/api/v1/appointments?**", (route) => {
+      if (route.request().method() !== "GET") return route.continue();
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: [
+            {
+              id: APPOINTMENT_ID,
+              slotStart: new Date().toISOString(),
+              tokenNumber: "T-001",
+              status: "BOOKED",
+              doctor: { id: DOCTOR_ID, user: { name: "Dr. DDI Test" } },
+            },
+          ],
+          error: null,
+          meta: { page: 1, limit: 10, total: 1 },
+        }),
+      });
+    });
 
     // Same blocking preview as the previous test.
     await page.route("**/api/v1/prescriptions/check-interactions", (route) =>
@@ -235,23 +292,14 @@ test.describe("Prescriptions lifecycle — /dashboard/prescriptions (DDI safety 
       })
     );
 
-    // Capture the request body so we can pin the override contract — this
+    // Capture the save POST body to pin the override contract — this
     // is the load-bearing safety detail. If a future refactor drops
     // overrideWarnings from the payload, the DDI gate is silently broken
     // (the API would block the save AND the doctor would never know).
-    //
-    // 2026-05-09: timeout bumped 15s → 30s. The promise is set up here
-    // BEFORE form-fill / check-interactions / modal-display / click-override.
-    // Under shard-8 chromium+webkit parallel load that interaction chain
-    // can take >15s in CI, leaving no margin for the actual POST to land
-    // before the timeout fires (release.yml run 25607172246 round 2 still
-    // failed at this exact spot after the round-1 previewPromise fix).
-    const savePromise = page.waitForRequest(
-      (req) =>
-        new URL(req.url()).pathname.endsWith("/api/v1/prescriptions") &&
-        req.method() === "POST",
-      { timeout: 30_000 }
-    );
+    // The savePromise is set up RIGHT BEFORE the override-click so the
+    // 15s window only needs to cover (modal close animation + POST), not
+    // (form-fill + preview + modal display + click) — the dominant tail
+    // sources from the prior flakes.
     await page.route("**/api/v1/prescriptions", (route) => {
       if (route.request().method() === "POST") {
         return route.fulfill({
@@ -259,7 +307,7 @@ test.describe("Prescriptions lifecycle — /dashboard/prescriptions (DDI safety 
           contentType: "application/json",
           body: JSON.stringify({
             success: true,
-            data: { id: "stubbed-rx-override", patientId: patient.id, items: [] },
+            data: { id: "stubbed-rx-override", patientId: PATIENT_ID, items: [] },
             error: null,
           }),
         });
@@ -271,18 +319,25 @@ test.describe("Prescriptions lifecycle — /dashboard/prescriptions (DDI safety 
     await expectNotForbidden(page);
     await expect(page.getByTestId("rx-new-form")).toBeVisible({ timeout: PAGE_TIMEOUT });
 
-    await page.getByTestId("rx-patient-picker-input").fill(patient.name.split(" ")[0]);
+    // Patient picker — fill triggers the debounced GET (now stubbed → instant
+    // fulfill), then mousedown the locked-on synthetic row. The
+    // data-entity-id selector (CLAUDE.md gotcha #11) is a stable lock-on.
+    await page.getByTestId("rx-patient-picker-input").fill("DDI");
     await page
-      .locator(`[data-testid="rx-patient-picker-option"][data-entity-id="${patient.id}"]`)
+      .locator(`[data-testid="rx-patient-picker-option"][data-entity-id="${PATIENT_ID}"]`)
       .first()
       .click({ timeout: 10_000 });
     await expect(page.getByTestId("rx-patient-picker-chosen")).toBeVisible({
       timeout: 5_000,
     });
+
+    // Appointment picker — minQueryLength=0 fetches on focus (page.tsx:779).
+    // Click the input to open, then lock onto the synthetic appointment.
     await page.getByTestId("rx-appointment-picker-input").click();
     await page
-      .locator(`[data-testid="rx-appointment-picker-option"][data-entity-id="${appt.id}"]`)
+      .locator(`[data-testid="rx-appointment-picker-option"][data-entity-id="${APPOINTMENT_ID}"]`)
       .click({ timeout: 10_000 });
+
     await page.getByPlaceholder(/Search ICD-10/i).fill("E11.9 — Type 2 diabetes");
     await page.getByPlaceholder("Medicine name").first().fill("Metformin");
     await page.getByPlaceholder("Dosage").first().fill("500mg");
@@ -292,10 +347,8 @@ test.describe("Prescriptions lifecycle — /dashboard/prescriptions (DDI safety 
       .selectOption("1-0-1 (Morning-Night)");
     await page.getByPlaceholder("Duration").first().fill("ongoing");
 
-    // 2026-05-09 hardening: under load the click can race the
-    // /check-interactions stub on chromium+webkit shard 8 (release.yml run
-    // 25603131575). Wire an explicit waitForResponse so the assertion below
-    // doesn't poll while the preview Promise is still in-flight.
+    // Wire the preview waitForResponse so the modal-visibility assertion
+    // doesn't poll while /check-interactions is still in-flight.
     const previewPromise = page.waitForResponse(
       (r) =>
         r.url().includes("/api/v1/prescriptions/check-interactions") &&
@@ -308,6 +361,15 @@ test.describe("Prescriptions lifecycle — /dashboard/prescriptions (DDI safety 
       page.getByRole("heading", { name: /drug interaction warning/i })
     ).toBeVisible({ timeout: 15_000 });
 
+    // Set up savePromise IMMEDIATELY before the override-click. The 15s
+    // window now covers only (click → POST land) — no form-fill / preview
+    // / modal-display in the budget. This is the load-tolerance fix.
+    const savePromise = page.waitForRequest(
+      (req) =>
+        new URL(req.url()).pathname.endsWith("/api/v1/prescriptions") &&
+        req.method() === "POST",
+      { timeout: 15_000 }
+    );
     await page.getByRole("button", { name: /override and continue/i }).click();
 
     const saveReq = await savePromise;
@@ -316,7 +378,7 @@ test.describe("Prescriptions lifecycle — /dashboard/prescriptions (DDI safety 
     // when the doctor clicks the modal's primary CTA (page.tsx:1254 calls
     // submitPrescription(true)).
     expect(body.overrideWarnings).toBe(true);
-    expect(body.patientId).toBe(patient.id);
+    expect(body.patientId).toBe(PATIENT_ID);
     expect(Array.isArray(body.items)).toBe(true);
     expect(body.items.length).toBeGreaterThan(0);
 


### PR DESCRIPTION
## Summary

Re-enable the `test.skip`'d *DDI override path* test in `e2e/prescription-lifecycle.spec.ts` (skipped 2026-05-09 in `aaa4e17` after 3 release.yml flake rounds). Refactored to use **deterministic-fixture stubs** for the `/patients` and `/appointments` list endpoints, removing the two compounding load sources that caused shard-8 chromium+webkit flakes.

### Refactor pattern

- **Before**: `seedPatient` + `seedAppointment` against the real DB → real backend GETs from EntityPicker debounced search → live form drive → preview stub → modal → override → save POST. Race window: form-fill + preview + modal-display + override-click all had to land within `savePromise`'s 30s window.
- **After**: synthetic IDs + `page.route('**/api/v1/patients?**', ...)` + `page.route('**/api/v1/appointments?**', ...)` fulfilling list rows instantly. Both EntityPicker dropdowns now render from stubs; no DB seed, no real GETs. Additional hardening: `savePromise` is wired **right before** the override-click so its 15s window covers only `(override-click → POST land)`, not the whole interaction chain.

### Contract surface preserved

- Modal opens on `hasBlocking=true` preview
- Override-click fires `POST /prescriptions` with `overrideWarnings: true`
- `body.patientId` matches the picker selection
- Modal closes + form unmounts on successful save

API-level safety pin (`overrideWarnings:true` contract) at `apps/api/src/routes/prescriptions.test.ts` is unchanged — that's the load-bearing pin, this E2E is the UI-end-to-end validation layer.

## Test plan

- [x] `npx playwright test --list e2e/prescription-lifecycle.spec.ts` shows 5 tests (was 4 active + 1 skipped) per project
- [ ] Full release.yml dispatch — user will validate on next dispatch (>25min CI not run locally)
- [ ] Confirm shard-8 chromium+webkit no longer flakes on this test across 2-3 release.yml runs