### PR TITLE
ci(demo-monitor): port every-2h health-check workflow from globussoft-crm

### DIFF
--- a/.github/workflows/demo-monitor.yml
+++ b/.github/workflows/demo-monitor.yml
@@ -1,0 +1,174 @@
+name: Demo health monitor (read-only)
+
+# Read-only assertions against https://medcore.globusdemos.com. Catches
+# regression classes that the per-push test gate can't see because that
+# gate runs against an ephemeral DB on each push:
+#   - Cross-tenant patient leak (tenant-scoping middleware regression)
+#   - Sidebar role nav 404 / not-authorized bounce (#606/#615/#637 class)
+#   - Public health endpoint reachable (deploy/PM2 health proxy)
+#   - Demo-seed contamination (placeholder rows leaking into demo data)
+#   - Login form basic flow (auth pipeline + dashboard chrome boot)
+#
+# Ported 2026-05-10 from globussoft-crm/.github/workflows/demo-monitor.yml
+# as the third of four missing workflows in the cross-product workflow
+# parity audit (after secret-scan, migration-check). The fourth — coverage
+# — is being ported in parallel on a sibling branch.
+
+on:
+  workflow_dispatch:
+    inputs:
+      open_issue_on_failure:
+        description: "Open/comment on a GitHub issue if the monitor fails"
+        type: boolean
+        default: true
+      base_url:
+        description: "BASE_URL to monitor (defaults to demo)"
+        type: string
+        default: "https://medcore.globusdemos.com"
+
+  # 2-hour cadence. Demo cleanup is automated via release.yml + the
+  # per-push test gate runs against an ephemeral DB so it can't pollute.
+  # Detection latency of ~2h is acceptable given there's no live
+  # customer traffic at risk on the demo box. If MedCore moves to a
+  # live cadence, lift to */10 + add PagerDuty fan-out (see CRM's
+  # docs/LIVE_MONITOR_PATTERN.md template).
+  schedule:
+    - cron: "0 */2 * * *"
+
+# Auto-issue-on-failure uses github.rest.issues.{create,update}Comment +
+# createIssue, both of which require `issues: write`.
+permissions:
+  contents: read
+  issues: write
+
+# Cancel any in-flight monitor on the same ref so a manual rerun
+# doesn't queue behind a scheduled tick.
+concurrency:
+  group: demo-monitor-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  demo_monitor:
+    name: Probe demo
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Node 22
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: Install (root npm ci — workspace install includes Playwright)
+        run: |
+          set -euo pipefail
+          npm ci --no-audit --no-fund
+
+      - name: Install Playwright chromium
+        run: |
+          set -euo pipefail
+          npx playwright install chromium --with-deps
+
+      - name: Run demo-health spec
+        id: probe
+        env:
+          # On scheduled runs `inputs.*` are empty; fall back to demo.
+          E2E_BASE_URL: ${{ inputs.base_url || 'https://medcore.globusdemos.com' }}
+          E2E_API_URL: ${{ inputs.base_url && format('{0}/api/v1', inputs.base_url) || 'https://medcore.globusdemos.com/api/v1' }}
+          DEMO_MONITOR: "1"
+        # Don't fail the step yet; we want to upload artifacts + post
+        # the issue first, then fail at the end.
+        continue-on-error: true
+        run: |
+          set +e
+          npx playwright test \
+            --project=full \
+            --reporter=list \
+            e2e/demo-health.spec.ts \
+            > /tmp/probe.stdout.txt 2>&1
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          ls -la test-results/ 2>/dev/null || true
+          cat /tmp/probe.stdout.txt
+
+      - name: Upload probe artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: demo-monitor-${{ github.run_id }}
+          path: |
+            /tmp/probe.stdout.txt
+            test-results/
+            playwright-report/
+          retention-days: 14
+
+      - name: Build issue body from failures
+        id: report
+        # Open issue by default. workflow_dispatch can pass false to
+        # suppress (e.g. when manually re-running for verification);
+        # scheduled runs always open.
+        # Note: `inputs.x` evaluates to '' (empty string) on scheduled
+        # runs, and `'' != false` evaluates to FALSE in GHA expressions
+        # (empty string coerces to false). So the conditional must
+        # branch on event_name explicitly, not on inputs.
+        if: ${{ steps.probe.outputs.exit_code != '0' && (github.event_name == 'schedule' || inputs.open_issue_on_failure == true) }}
+        env:
+          BASE_URL: ${{ inputs.base_url || 'https://medcore.globusdemos.com' }}
+        run: |
+          set -euo pipefail
+          {
+            echo "body<<EOF_BODY"
+            echo "## Demo monitor failed"
+            echo ""
+            echo "- **Target**: \`$BASE_URL\`"
+            echo "- **Run**: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            echo "- **Triggered by**: @$GITHUB_ACTOR"
+            echo "- **Time (UTC)**: $(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+            echo ""
+            echo "### Failed assertions"
+            echo ""
+            echo "\`\`\`"
+            # Extract just the FAIL lines + their first error line. The
+            # full Playwright output is in the artifact.
+            grep -E "(✘|Error:|expected|received|Timeout)" /tmp/probe.stdout.txt | head -60 || echo "(see artifact)"
+            echo "\`\`\`"
+            echo ""
+            echo "### What this means"
+            echo ""
+            echo "Each failed assertion in the demo-health spec maps to a"
+            echo "regression class — the test name describes which one."
+            echo "A failure here means demo state has drifted from the contract"
+            echo "the spec encodes; the per-push test gate cannot see this"
+            echo "because it runs against a fresh ephemeral DB."
+            echo ""
+            echo "_This issue is auto-managed by_ \`.github/workflows/demo-monitor.yml\`."
+            echo "EOF_BODY"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Open or update the demo-monitor tracker issue
+        if: ${{ steps.probe.outputs.exit_code != '0' && (github.event_name == 'schedule' || inputs.open_issue_on_failure == true) }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BODY: ${{ steps.report.outputs.body }}
+        run: |
+          set -euo pipefail
+          # Stable title so re-runs comment on the existing issue rather
+          # than spawning a new one each time. Matches by exact title.
+          TITLE="[demo-monitor] medcore.globusdemos.com health-check failing"
+          existing=$(gh issue list --state open --search "in:title \"$TITLE\"" --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            echo "Updating existing issue #$existing"
+            gh issue comment "$existing" --body "$BODY"
+          else
+            echo "Opening new issue"
+            gh issue create --title "$TITLE" --body "$BODY" --label "demo-monitor"
+          fi
+
+      - name: Fail the job if the probe failed
+        if: ${{ steps.probe.outputs.exit_code != '0' }}
+        run: |
+          echo "::error::Demo health monitor reported failures (exit ${{ steps.probe.outputs.exit_code }})"
+          exit 1

--- a/e2e/demo-health.spec.ts
+++ b/e2e/demo-health.spec.ts
@@ -1,0 +1,356 @@
+/**
+ * Demo health monitor — read-only assertions against the live demo box.
+ *
+ * Why this exists: the per-push Test gate validates a fix works on a
+ * clean ephemeral DB. Nobody validates that the deployed demo
+ * (`https://medcore.globusdemos.com`) stays in a sane state between
+ * deploys. This spec hits the demo (or any deployed env) with GETs +
+ * a single read-only login flow only, and fails on each regression
+ * class that's hurt us before:
+ *
+ *   - Cross-tenant patient leak (tenant-scoping middleware regression)
+ *   - Sidebar role nav 404 / not-authorized bounce (PHARMACIST nav,
+ *     #606/#615/#637 class)
+ *   - Public health endpoint reachable (deploy/PM2 health proxy)
+ *   - Demo-seed contamination (placeholder rows leaking into demo data)
+ *   - Login form basic flow (auth pipeline + dashboard chrome boot)
+ *
+ * SAFETY:
+ *   - This spec NEVER writes. No POST, PUT, DELETE.
+ *   - No fixture creation; no afterAll cleanup; nothing to leak.
+ *   - Designed to be safe to run against the live demo box.
+ *
+ * Run modes:
+ *   - Workflow_dispatch via .github/workflows/demo-monitor.yml
+ *   - Scheduled every 2h via the same workflow's cron
+ *   - Manual: E2E_BASE_URL=https://medcore.globusdemos.com \
+ *             E2E_API_URL=https://medcore.globusdemos.com/api/v1 \
+ *             DEMO_MONITOR=1 \
+ *             npx playwright test e2e/demo-health.spec.ts --project=full
+ *
+ * Unlike most specs in this repo, this monitor is BUILT to run against
+ * a remote BASE_URL. It does NOT skip when BASE_URL is non-localhost —
+ * that's the whole point. Specs that rely on shared fixtures (auth.json,
+ * test-DB seed admin@test.local) are NOT used here; we authenticate
+ * directly via the prod-seed `admin@medcore.local` / `admin123`.
+ */
+import { test, expect, Page } from "@playwright/test";
+
+const BASE_URL = process.env.E2E_BASE_URL || "https://medcore.globusdemos.com";
+const API_URL =
+  process.env.E2E_API_URL || `${BASE_URL.replace(/\/$/, "")}/api/v1`;
+
+const REQUEST_TIMEOUT = 20_000;
+
+// Prod-seed credentials (NOT the test-DB `admin@test.local`). The demo
+// box is seeded via `packages/db/src/seed.ts` + `seed-realistic.ts`,
+// both of which materialize `admin@medcore.local / admin123` and
+// `pharmacist@medcore.local / pharmacist123`.
+const ADMIN_EMAIL = "admin@medcore.local";
+const ADMIN_PASSWORD = "admin123";
+const PHARMACIST_EMAIL = "pharmacist@medcore.local";
+const PHARMACIST_PASSWORD = "pharmacist123";
+
+async function loginViaApi(
+  request: import("@playwright/test").APIRequestContext,
+  email: string,
+  password: string,
+): Promise<{ token: string; refresh: string; user: any }> {
+  const res = await request.post(`${API_URL}/auth/login`, {
+    data: { email, password },
+    headers: { "Content-Type": "application/json" },
+    timeout: REQUEST_TIMEOUT,
+  });
+  expect(
+    res.ok(),
+    `login failed for ${email}: ${res.status()} ${(await res.text()).slice(0, 200)}`,
+  ).toBe(true);
+  const json = await res.json();
+  const data = json?.data;
+  expect(
+    data?.tokens?.accessToken,
+    `login response missing tokens for ${email}`,
+  ).toBeTruthy();
+  return {
+    token: data.tokens.accessToken,
+    refresh: data.tokens.refreshToken,
+    user: data.user,
+  };
+}
+
+async function injectAuthCookies(
+  page: Page,
+  token: string,
+  refresh: string,
+): Promise<void> {
+  const apiOrigin = new URL(API_URL).origin;
+  const csrfToken = "demo-monitor-csrf-" + Date.now().toString(36);
+  await page.context().addCookies([
+    {
+      name: "medcore_at",
+      value: token,
+      url: apiOrigin,
+      httpOnly: true,
+      secure: apiOrigin.startsWith("https"),
+      sameSite: "Lax",
+    },
+    {
+      name: "medcore_rt",
+      value: refresh,
+      url: apiOrigin,
+      httpOnly: true,
+      secure: apiOrigin.startsWith("https"),
+      sameSite: "Lax",
+    },
+    {
+      name: "medcore_csrf",
+      value: csrfToken,
+      url: apiOrigin,
+      httpOnly: false,
+      secure: apiOrigin.startsWith("https"),
+      sameSite: "Lax",
+    },
+  ]);
+
+  // Pre-dismiss the per-role onboarding tour so it can't intercept clicks.
+  await page.addInitScript(() => {
+    for (const role of [
+      "ADMIN",
+      "DOCTOR",
+      "NURSE",
+      "RECEPTION",
+      "PATIENT",
+      "LAB_TECH",
+      "PHARMACIST",
+    ]) {
+      localStorage.setItem(`mc_tour_${role}`, "1");
+    }
+  });
+}
+
+test.describe("Demo health monitor (read-only)", () => {
+  let adminToken: string | null = null;
+  let pharmacistToken: string | null = null;
+  let pharmacistRefresh: string | null = null;
+
+  test.beforeAll(async ({ request }) => {
+    const adminRes = await request
+      .post(`${API_URL}/auth/login`, {
+        data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+        headers: { "Content-Type": "application/json" },
+        timeout: REQUEST_TIMEOUT,
+      })
+      .catch(() => null);
+    if (adminRes && adminRes.ok()) {
+      const json = await adminRes.json();
+      adminToken = json?.data?.tokens?.accessToken ?? null;
+    }
+
+    const pharmRes = await request
+      .post(`${API_URL}/auth/login`, {
+        data: { email: PHARMACIST_EMAIL, password: PHARMACIST_PASSWORD },
+        headers: { "Content-Type": "application/json" },
+        timeout: REQUEST_TIMEOUT,
+      })
+      .catch(() => null);
+    if (pharmRes && pharmRes.ok()) {
+      const json = await pharmRes.json();
+      pharmacistToken = json?.data?.tokens?.accessToken ?? null;
+      pharmacistRefresh = json?.data?.tokens?.refreshToken ?? null;
+    }
+  });
+
+  // ── Public health endpoint reachable ────────────────────────────────
+
+  test("GET /api/health returns 200 (deploy/PM2 health proxy)", async ({
+    request,
+  }) => {
+    const res = await request.get(`${BASE_URL.replace(/\/$/, "")}/api/health`, {
+      timeout: REQUEST_TIMEOUT,
+    });
+    expect(
+      res.status(),
+      `health endpoint returned ${res.status()} — proxy/PM2 outage?`,
+    ).toBe(200);
+    const body = await res.json();
+    expect(body.status, `unexpected health body: ${JSON.stringify(body)}`).toBe(
+      "ok",
+    );
+  });
+
+  test("admin and pharmacist demo logins succeed", () => {
+    expect(adminToken, `${ADMIN_EMAIL} login failed`).toBeTruthy();
+    expect(
+      pharmacistToken,
+      `${PHARMACIST_EMAIL} login failed`,
+    ).toBeTruthy();
+  });
+
+  // ── Cross-tenant patient leak ───────────────────────────────────────
+  //
+  // The tenant-scoping wrapper (`tenantScopedPrisma`, lifted into
+  // @medcore/db on 2026-05-05) auto-filters tenant-scoped models by
+  // tenantId on read. If that wrapper regresses or a route bypasses
+  // it, an admin from one tenant could see another tenant's patients.
+  //
+  // Patient itself doesn't carry tenantId directly (User does), so the
+  // contract we pin here is: an authed list call returns 200 with the
+  // expected response envelope, every row has the expected shape, and
+  // no row name matches any of the obvious cross-tenant residue
+  // patterns from sister Globussoft products.
+  test("cross-tenant patient leak — patient list is well-formed and contains no foreign-tenant residue", async ({
+    request,
+  }) => {
+    test.skip(!adminToken, "admin login required");
+    const res = await request.get(`${API_URL}/patients?limit=5`, {
+      headers: { Authorization: `Bearer ${adminToken}` },
+      timeout: REQUEST_TIMEOUT,
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(Array.isArray(body.data)).toBe(true);
+
+    // Every row must be a Patient with the canonical shape. Cross-tenant
+    // residue from a sister product (CRM's `wellness.demo` tenant, etc.)
+    // would surface as rows missing the medcore-specific MR-number
+    // pattern or carrying obviously foreign names.
+    for (const p of body.data) {
+      expect(p.id, "patient row missing id").toBeTruthy();
+      expect(p.mrNumber, "patient row missing mrNumber").toBeTruthy();
+      // CRM's wellness demo seeded "Tenant B scoped" rows that leaked
+      // into another tenant's lists when scoping regressed. Those
+      // names should never appear in medcore patient data.
+      const name = p.user?.name || "";
+      expect(
+        /^Tenant B scoped/i.test(name),
+        `cross-tenant residue detected: ${JSON.stringify(name)}`,
+      ).toBe(false);
+    }
+  });
+
+  // ── Sidebar role nav doesn't 404 / bounce ──────────────────────────
+  //
+  // Encodes the May 8 evening fix: PHARMACIST has Pharmacy / Medicines /
+  // Prescriptions / Controlled Substances / Stock Adjustments as the
+  // nav surfaces (#606/#615/#637). Before the fix, PHARMACIST fell
+  // through to the PATIENT nav and saw "Bills" + "AI Booking" + "Med
+  // Reminders" — none of which they could open without a 4xx.
+  //
+  // Subset-only check: we visit four of the role's nav items and
+  // assert each one (a) returns a 2xx, (b) doesn't bounce to /login
+  // or /dashboard/not-authorized. The remaining items follow the same
+  // role-allowlist shape so checking four is a representative probe.
+  const PHARMACIST_NAV_PATHS = [
+    "/dashboard/pharmacy",
+    "/dashboard/medicines",
+    "/dashboard/prescriptions",
+    "/dashboard/controlled-substances",
+  ];
+
+  for (const path of PHARMACIST_NAV_PATHS) {
+    test(`PHARMACIST nav: ${path} loads without 404 / not-authorized bounce`, async ({
+      page,
+    }) => {
+      test.skip(
+        !pharmacistToken || !pharmacistRefresh,
+        "pharmacist login required",
+      );
+      await injectAuthCookies(page, pharmacistToken!, pharmacistRefresh!);
+
+      const res = await page.goto(`${BASE_URL.replace(/\/$/, "")}${path}`, {
+        waitUntil: "domcontentloaded",
+        timeout: REQUEST_TIMEOUT,
+      });
+      expect(res, `${path}: navigation aborted`).not.toBeNull();
+      expect(res!.status(), `${path}: bad status`).toBeLessThan(400);
+
+      // Give the dashboard layout's loadSession + redirect-effect a
+      // beat to settle before we read the URL. The layout's auth
+      // guard can briefly flip URL→/login on a /auth/me 429 retry.
+      await page.waitForTimeout(800);
+      const url = page.url();
+      expect(url, `${path}: bounced to login`).not.toContain("/login");
+      expect(url, `${path}: bounced to not-authorized`).not.toContain(
+        "/not-authorized",
+      );
+    });
+  }
+
+  // ── Demo-seed contamination ────────────────────────────────────────
+  //
+  // The pre-#277 seed for visitors generated rows with names like
+  // "Visitor 1", "Visitor 2", … The fix replaced them with realistic
+  // Indian names. If the demo box is reseeded from an old script (e.g.
+  // a deploy that picked up a pre-fix seed), the placeholder pattern
+  // re-appears and reception staff demoing the system see it.
+  test("no 'Visitor N' placeholder rows in visitors list (seed contamination guard)", async ({
+    request,
+  }) => {
+    test.skip(!adminToken, "admin login required");
+    const res = await request.get(`${API_URL}/visitors?limit=10`, {
+      headers: { Authorization: `Bearer ${adminToken}` },
+      timeout: REQUEST_TIMEOUT,
+    });
+    // 200 OK is the happy path. 403 is acceptable if the role mapping
+    // changes and admin loses list rights — surface it explicitly.
+    expect(
+      [200, 403].includes(res.status()),
+      `unexpected visitors status ${res.status()}`,
+    ).toBe(true);
+    if (res.status() !== 200) return;
+
+    const body = await res.json();
+    const visitors = Array.isArray(body) ? body : body.data || [];
+    const placeholders = visitors
+      .filter((v: { name?: string }) => /^Visitor \d+$/.test(v.name || ""))
+      .map((v: { id: string; name: string }) => `id=${v.id}: ${v.name}`);
+    expect(
+      placeholders,
+      `placeholder visitor rows detected (top 5): ${placeholders.slice(0, 5).join("; ")}`,
+    ).toEqual([]);
+  });
+
+  // ── Login form basic flow ──────────────────────────────────────────
+  //
+  // End-to-end through the actual SPA: visit /login, fill the admin
+  // creds, click Sign In, assert the redirect to /dashboard. This
+  // exercises the auth pipeline (cookies set, /auth/me succeeds,
+  // dashboard layout boots, MedCore chrome renders) — i.e. catches
+  // the class of regression where backend logins succeed but the
+  // SPA's auth handshake breaks.
+  test("login form happy path: admin creds → /dashboard redirect + chrome render", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE_URL.replace(/\/$/, "")}/login`, {
+      waitUntil: "domcontentloaded",
+      timeout: REQUEST_TIMEOUT,
+    });
+
+    // The login form lives at /login. Field labels match the prod-built
+    // SPA; prefer placeholder fallback in case a copy change lands.
+    const emailInput = page
+      .getByLabel(/email/i)
+      .or(page.getByPlaceholder(/email/i))
+      .first();
+    const passwordInput = page
+      .getByLabel(/password/i)
+      .or(page.getByPlaceholder(/password/i))
+      .first();
+    await emailInput.fill(ADMIN_EMAIL);
+    await passwordInput.fill(ADMIN_PASSWORD);
+
+    const signIn = page
+      .getByRole("button", { name: /sign in|log in|login/i })
+      .first();
+    await signIn.click();
+
+    // Successful login lands on /dashboard. The layout renders the
+    // "MedCore" wordmark — its presence confirms /auth/me succeeded
+    // and the auth guard didn't bounce back to /login.
+    await page.waitForURL(/\/dashboard/, { timeout: REQUEST_TIMEOUT });
+    await expect(page.locator("text=MedCore").first()).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Third of four missing workflows in the cross-product workflow-parity audit. PR #763 ported `secret-scan.yml`, PR #764 ported `migration-check.yml`. This one ports `demo-monitor.yml`. The fourth (`coverage.yml`) is being ported on a sibling branch.

- `.github/workflows/demo-monitor.yml` — runs `e2e/demo-health.spec.ts` against `https://medcore.globusdemos.com` every 2h (cron `0 */2 * * *`) + `workflow_dispatch`. On failure auto-opens / comments-on a stable-titled GitHub issue (`[demo-monitor] medcore.globusdemos.com health-check failing`) so re-runs append rather than spawn duplicates. `permissions: contents:read, issues:write`. Concurrency-cancels on the same ref.
- `e2e/demo-health.spec.ts` — 9 read-only assertions adapted to medcore's regression classes (no fixture creation, no writes, no shared-fixture deps). Self-contained: uses prod-seed creds (`admin@medcore.local` / `admin123`, `pharmacist@medcore.local` / `pharmacist123`), not the test-DB `admin@test.local`.

### Regression classes covered

1. **`GET /api/health` returns 200** — deploy / PM2 / nginx proxy outage canary.
2. **Admin + pharmacist demo logins succeed** — auth pipeline canary; gates the rest of the suite via `test.skip(!token)`.
3. **Cross-tenant patient leak** — admin lists `/patients?limit=5`, asserts well-formed envelope + no `Tenant B scoped` residue patterns. Pinned because `tenantScopedPrisma` is the auto-filter and any wrapper-bypass would surface here first.
4. **PHARMACIST sidebar nav x4** — visits `/dashboard/{pharmacy,medicines,prescriptions,controlled-substances}` with pharmacist cookies and asserts no 404 / no `/login` or `/dashboard/not-authorized` bounce. Encodes the May 8 `#606/#615/#637` fix that gave PHARMACIST its own nav array (was falling through to PATIENT before).
5. **Visitors placeholder seed contamination** — admin lists `/visitors?limit=10`, asserts no row name matches `/^Visitor \d+$/` (the pattern that #277 fixed in the seed).
6. **Login form happy path** — visits `/login`, fills admin creds, clicks Sign In, asserts redirect to `/dashboard` + MedCore chrome renders. Catches the class where backend logins succeed but the SPA's `/auth/me` handshake breaks.

### Adaptations from the CRM source

- CRM has a public booking endpoint (`/api/wellness/public/tenant/<slug>`) — medcore has no equivalent public-tenant data surface, so that assertion didn't translate.
- CRM's wellness/CRM-specific regression numbers (#401-#406) don't map to medcore — replaced with descriptive test names tied to medcore's own issue history (#277, #606, #615, #637, May 2026).
- Workflow installs at workspace root (`npm ci` in `.`) since medcore uses npm workspaces, vs CRM's separate `e2e/` install. Playwright runs with `--project=full` per `playwright.config.ts`.
- Spec does NOT skip when `BASE_URL` is remote — that's the whole point of this monitor.

## Test plan

- [ ] PR CI runs — the new `demo_monitor` job will fire (push trigger isn't wired so it'll only fire if a PR check picks up workflow_dispatch). May need a manual `gh workflow run demo-monitor.yml` to see it green against the live demo.
- [ ] Manual verification: `gh workflow run demo-monitor.yml -f base_url=https://medcore.globusdemos.com` then watch the run to terminal state.
- [ ] Confirm the 9 listed tests pass against the live demo.
- [ ] Leave PR open for human review of the auto-issue logic before merge — needs eyeballs (don't want to spam issues if a flake fires repeatedly).