### PR TITLE
chore(seed): seed-finance + seed-clinical idempotency (deploy.sh wave 2)

### DIFF
--- a/packages/db/src/seed-clinical.ts
+++ b/packages/db/src/seed-clinical.ts
@@ -60,16 +60,10 @@ async function main() {
   // ─── 3. SAMPLE REFERRALS ─────────────────────────────
   console.log("\nCreating sample referrals...");
 
-  // Compute next referral number
-  const lastRef = await prisma.referral.findFirst({
-    orderBy: { referralNumber: "desc" },
-    select: { referralNumber: true },
-  });
-  let refSeq = 1;
-  if (lastRef?.referralNumber) {
-    const m = lastRef.referralNumber.match(/(\d+)$/);
-    if (m) refSeq = parseInt(m[1], 10) + 1;
-  }
+  // Stable namespaced referralNumbers (`REF-SEED-NNNN`) so re-running the
+  // seed never collides with the runtime `REF000001..` counter consumed by
+  // the production referrals route. The `findUnique` guard below makes
+  // every entry idempotent.
 
   const refSamples = [
     {
@@ -95,13 +89,18 @@ async function main() {
     },
   ];
 
-  for (const r of refSamples) {
-    const referralNumber = `REF${String(refSeq).padStart(6, "0")}`;
-    refSeq++;
+  let createdReferrals = 0;
+  let skippedReferrals = 0;
+  for (let i = 0; i < refSamples.length; i++) {
+    const r = refSamples[i];
+    const referralNumber = `REF-SEED-${String(i + 1).padStart(4, "0")}`;
     const exists = await prisma.referral.findUnique({
       where: { referralNumber },
     });
-    if (exists) continue;
+    if (exists) {
+      skippedReferrals++;
+      continue;
+    }
     await prisma.referral.create({
       data: {
         referralNumber,
@@ -110,21 +109,19 @@ async function main() {
         respondedAt: r.status !== "PENDING" ? new Date() : null,
       },
     });
+    createdReferrals++;
     console.log(`  Created referral: ${referralNumber} (${r.status})`);
   }
+  console.log(
+    `  Referrals: ${createdReferrals} created, ${skippedReferrals} skipped (already present)`
+  );
 
   // ─── 4. SAMPLE SURGERIES ─────────────────────────────
   console.log("\nCreating sample surgeries...");
 
-  const lastSrg = await prisma.surgery.findFirst({
-    orderBy: { caseNumber: "desc" },
-    select: { caseNumber: true },
-  });
-  let srgSeq = 1;
-  if (lastSrg?.caseNumber) {
-    const m = lastSrg.caseNumber.match(/(\d+)$/);
-    if (m) srgSeq = parseInt(m[1], 10) + 1;
-  }
+  // Stable namespaced caseNumbers (`SRG-SEED-NNNN`) — same rationale as
+  // referralNumbers above. Production case numbers (`SRG000001..`) are
+  // minted by the surgery route and we must not collide with them.
 
   const now = new Date();
   const tomorrow = new Date(now);
@@ -166,16 +163,25 @@ async function main() {
     },
   ];
 
-  for (const s of surgerySamples) {
-    const caseNumber = `SRG${String(srgSeq).padStart(6, "0")}`;
-    srgSeq++;
+  let createdSurgeries = 0;
+  let skippedSurgeries = 0;
+  for (let i = 0; i < surgerySamples.length; i++) {
+    const s = surgerySamples[i];
+    const caseNumber = `SRG-SEED-${String(i + 1).padStart(4, "0")}`;
     const exists = await prisma.surgery.findUnique({ where: { caseNumber } });
-    if (exists) continue;
+    if (exists) {
+      skippedSurgeries++;
+      continue;
+    }
     await prisma.surgery.create({
       data: { caseNumber, ...s },
     });
+    createdSurgeries++;
     console.log(`  Created surgery: ${caseNumber} — ${s.procedure}`);
   }
+  console.log(
+    `  Surgeries: ${createdSurgeries} created, ${skippedSurgeries} skipped (already present)`
+  );
 
   console.log("\n=== Clinical seed complete ===");
   await prisma.$disconnect();

--- a/packages/db/src/seed-finance.ts
+++ b/packages/db/src/seed-finance.ts
@@ -126,8 +126,8 @@ function daysAgo(n: number): Date {
   return d;
 }
 
-function padSeq(n: number): string {
-  return String(n).padStart(6, "0");
+function padSeed(n: number): string {
+  return String(n).padStart(4, "0");
 }
 
 async function main() {
@@ -197,11 +197,12 @@ async function main() {
     return;
   }
 
-  // ── Seed PO number counter ────────────────────────
-  const poConfig = await prisma.systemConfig.findUnique({
-    where: { key: "next_po_number" },
-  });
-  let nextPoSeq = poConfig ? parseInt(poConfig.value) : 1;
+  // ── Seeded PO numbers use a stable, namespaced prefix (`PO-SEED-NNNN`)
+  //   so re-running the seed never collides with the live `next_po_number`
+  //   SystemConfig counter consumed by `apps/api/src/routes/purchase-orders.ts`
+  //   (which mints production POs as `PO000001..`). DO NOT read or write
+  //   `next_po_number` here — overwriting it on every deploy would corrupt
+  //   real-tenant numbering.
 
   // ── Get a few medicines to reference ──────────────
   const medicines = await prisma.medicine.findMany({ take: 6 });
@@ -276,15 +277,23 @@ async function main() {
     },
   ];
 
-  for (const spec of poSpecs) {
+  let createdPoCount = 0;
+  let skippedPoCount = 0;
+  for (let i = 0; i < poSpecs.length; i++) {
+    const spec = poSpecs[i];
     const supplierId = supplierIds[spec.supplierIdx];
-    const poNumber = `PO${padSeq(nextPoSeq)}`;
-    nextPoSeq++;
+    // Stable namespaced PO numbers (`PO-SEED-0001`, ...). Indices are
+    // deterministic, so re-runs always map back to the same row and the
+    // findUnique guard below short-circuits the create.
+    const poNumber = `PO-SEED-${padSeed(i + 1)}`;
 
     const existing = await prisma.purchaseOrder.findUnique({
       where: { poNumber },
     });
-    if (existing) continue;
+    if (existing) {
+      skippedPoCount++;
+      continue;
+    }
 
     const subtotal = spec.items.reduce(
       (sum, it) => sum + it.quantity * it.unitPrice,
@@ -322,15 +331,11 @@ async function main() {
         },
       },
     });
+    createdPoCount++;
   }
-  console.log(`  Purchase orders: ${poSpecs.length}`);
-
-  // Update sequence counter
-  await prisma.systemConfig.upsert({
-    where: { key: "next_po_number" },
-    create: { key: "next_po_number", value: String(nextPoSeq) },
-    update: { value: String(nextPoSeq) },
-  });
+  console.log(
+    `  Purchase orders: ${createdPoCount} created, ${skippedPoCount} skipped (already present)`
+  );
 
   // ── Expenses ──────────────────────────────────────
   let expenseCount = 0;

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -263,14 +263,6 @@ fi
 # relative to the API/Web smoke checks above).
 #
 # Seeds NOT wired (intentionally — see chore commit body):
-#   - seed-finance.ts         — non-idempotent: PO counter advances each run,
-#                               creating duplicate PO0001..PO0004 etc. with
-#                               new caseNumbers. Suppliers/packages ARE
-#                               upserted but the script can't be split.
-#   - seed-clinical.ts        — non-idempotent: surgery `caseNumber` and
-#                               referral `referralNumber` use max+1 counter
-#                               with no content match — every run creates a
-#                               fresh seed surgery. OTs ARE upserted.
 #   - seed-immunization-data, seed-lab-data, seed-lab-panels (orders),
 #     seed-clinical-enhancements, seed-acute-care-enhancements,
 #     seed-ancillary-enhancements, seed-chat-conversations,
@@ -354,6 +346,32 @@ if DATABASE_URL="$DB_URL" npx tsx packages/db/src/seed-realistic.ts; then
     echo "  OK — realistic OPD flow re-seeded."
 else
     echo "  WARN — seed-realistic failed (non-fatal). Investigate offline."
+fi
+
+# Step 8l (deploy.sh wave 2): seed-finance.ts is now idempotent — POs use
+# stable namespaced `PO-SEED-NNNN` numbers guarded by a `findUnique` skip,
+# and the live `next_po_number` SystemConfig counter is no longer touched
+# (that counter is consumed by the runtime PO-creation route in
+# apps/api/src/routes/purchase-orders.ts). Suppliers and HealthPackages
+# were already upserted. Failures MUST NOT block the deploy.
+echo "=== 8l. Re-applying finance seed (suppliers, packages, sample POs) ==="
+if DATABASE_URL="$DB_URL" npx tsx packages/db/src/seed-finance.ts; then
+    echo "  OK — finance fixtures re-seeded."
+else
+    echo "  WARN — seed-finance failed (non-fatal). Investigate offline."
+fi
+
+# Step 8m (deploy.sh wave 2): seed-clinical.ts is now idempotent —
+# referrals use stable `REF-SEED-NNNN` and surgeries use `SRG-SEED-NNNN`,
+# both guarded by `findUnique` skip-or-create. The previous max+1 counter
+# scan that produced fresh `caseNumber`s on every run has been removed.
+# Operating theaters (`OperatingTheater`) were already upserted. Failures
+# MUST NOT block the deploy.
+echo "=== 8m. Re-applying clinical seed (OTs, sample referrals, surgeries) ==="
+if DATABASE_URL="$DB_URL" npx tsx packages/db/src/seed-clinical.ts; then
+    echo "  OK — clinical fixtures re-seeded."
+else
+    echo "  WARN — seed-clinical failed (non-fatal). Investigate offline."
 fi
 
 echo "=== Deployment complete (previous SHA recorded at /tmp/medcore-prev-sha) ==="


### PR DESCRIPTION
## Summary

Make 2 demo-relevant seeds fully idempotent so they can be wired into the auto-reseed chain in `scripts/deploy.sh`. Mirrors the pattern from `seed-realistic.ts` (commit 4554706) and `seed-controlled-register.ts`.

### `seed-finance.ts`
- POs now use stable namespaced numbers `PO-SEED-${i.toString().padStart(4, '0')}` (`PO-SEED-0001`, `PO-SEED-0002`, ...) keyed off the deterministic `poSpecs` index.
- Each PO is gated by `prisma.purchaseOrder.findUnique({ where: { poNumber } })` before `.create`.
- The live `next_po_number` SystemConfig counter (consumed by `apps/api/src/routes/purchase-orders.ts`) is NO LONGER read or written — that's the production runtime counter and the seed must not advance it.
- Suppliers, HealthPackages, and Expenses were already idempotent (upsert / findFirst-skip).

### `seed-clinical.ts`
- Referrals now use `REF-SEED-${i.toString().padStart(4, '0')}` (`REF-SEED-0001`, ...).
- Surgeries now use `SRG-SEED-${i.toString().padStart(4, '0')}` (`SRG-SEED-0001`, ...).
- Both gated by `findUnique` skip-or-create. The previous `max(referralNumber|caseNumber)+1` scans (which produced fresh rows on every run) are removed.
- Operating theaters were already upserted on `name`.

### `scripts/deploy.sh`
- Added step 8l (finance) and step 8m (clinical) to the post-deploy seed chain (after the existing 8k seed-realistic step).
- Both wired non-fatally (`||` warn) so a seed failure can't break the deploy.
- Updated the "Seeds NOT wired" doc-block to drop the two now-immune seeds.

## Test plan

- [ ] `npx tsc --noEmit -p packages/db/tsconfig.json` passes (verified locally).
- [ ] `bash -n scripts/deploy.sh` syntax-clean (verified locally).
- [ ] On the demo server, manual run: `DATABASE_URL=... npx tsx packages/db/src/seed-finance.ts` twice — second run reports "0 created, N skipped".
- [ ] Same for `seed-clinical.ts`.
- [ ] After next push to `main`, `test.yml` deploy job runs steps 8l + 8m green.
- [ ] Grep confirms no live counter writes: `grep -E "next_po_number|next_invoice_number|next_mr_number" packages/db/src/seed-finance.ts packages/db/src/seed-clinical.ts` returns only comment lines.

## Notes
- Lane D2/D3/D4 own seed-immunization-data, seed-asset-history, seed-chat-conversations etc. in parallel — this PR does NOT touch those files.
- Branch named `chore/seed-idempotency-batch-3` (a parallel lane appears to have already taken `batch-1` and `batch-2`; the spirit of the task is preserved — the work is the same).