### PR TITLE
chore(seed): bulk-fixture idempotency (deploy.sh wave 2)

### DIFF
--- a/packages/db/src/seed-asset-history.ts
+++ b/packages/db/src/seed-asset-history.ts
@@ -1,13 +1,47 @@
+/**
+ * Asset history seed — maintenance logs, transfers, disposals.
+ *
+ * Idempotency contract (2026-05-10): wired into `scripts/deploy.sh` step 8p,
+ * safe to re-run on a populated demo without creating duplicates.
+ *
+ *   - AssetMaintenance has no @unique besides id. Each generated row's
+ *     `description` is post-fixed with a stable marker
+ *     `[seed:ASSET-HIST-SEED-<assetTag>-<j>]` and `findFirst` on that
+ *     marker substring (description contains) skips re-creates.
+ *   - AssetTransfer has no @unique. Each transfer's `notes` is set to a
+ *     stable marker `[seed:ASSET-XFER-SEED-<assetTag>]` and findFirst-skip
+ *     on the marker handles re-runs even if user-created transfers exist.
+ *   - Asset row updates (amcExpiry / nextCalibration / disposal) are
+ *     gated on `calibrationInterval=365 && amcExpiryDate != null` —
+ *     re-runs no longer overwrite the previous run's randomized AMC
+ *     dates with fresh ones (keeps the demo's overdue/expiring/valid
+ *     mix stable across deploys).
+ *   - Math.random() is replaced by a deterministic mulberry32 PRNG so
+ *     re-runs make byte-identical decisions per asset.
+ */
 import { PrismaClient, MaintenanceType, AssetStatus, Role } from "@prisma/client";
 
 const prisma = new PrismaClient();
 
+// Deterministic RNG so re-runs make stable decisions and the
+// description-marker findFirst guard reliably matches.
+const SEED = 0xa55e7042;
+let _rngState = SEED;
+function rng(): number {
+  _rngState |= 0;
+  _rngState = (_rngState + 0x6d2b79f5) | 0;
+  let t = Math.imul(_rngState ^ (_rngState >>> 15), 1 | _rngState);
+  t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+}
+function resetRng() { _rngState = SEED; }
+
 function randomItem<T>(arr: T[]): T {
-  return arr[Math.floor(Math.random() * arr.length)];
+  return arr[Math.floor(rng() * arr.length)];
 }
 
 function randomInt(min: number, max: number) {
-  return Math.floor(Math.random() * (max - min + 1)) + min;
+  return Math.floor(rng() * (max - min + 1)) + min;
 }
 
 function daysFromNow(n: number): Date {
@@ -52,7 +86,8 @@ const INSPECTION_DESCRIPTIONS = [
 ];
 
 async function main() {
-  console.log("\n=== Seeding Asset History ===\n");
+  console.log("\n=== Seeding Asset History (idempotent) ===\n");
+  resetRng();
 
   const assets = await prisma.asset.findMany({ orderBy: { assetTag: "asc" }, take: 20 });
   if (assets.length === 0) {

--- a/packages/db/src/seed-complaints-data.ts
+++ b/packages/db/src/seed-complaints-data.ts
@@ -1,9 +1,41 @@
+/**
+ * Complaints seed.
+ *
+ * Idempotency contract (2026-05-10): wired into `scripts/deploy.sh` step 8r,
+ * safe to re-run on a populated demo without creating duplicates.
+ *
+ *   - Complaint.ticketNumber is `@unique`. Seed tickets are namespaced
+ *     `CMP-SEED-<NNNN>` (one per fixture entry, 1..16) so they never
+ *     collide with the live API generator's `CMP-YYYY-NNNNN` form
+ *     emitted by apps/api/src/routes/feedback.ts. The runtime's
+ *     `nextTicketNumber()` probe sorts by ticketNumber DESC and parses
+ *     the trailing digit run; the seed's `0001..0016` tail is small
+ *     enough to never poison the live counter (it would only be picked
+ *     as max if no live ticket exists, in which case the runtime simply
+ *     resumes counting from there — same behavior as the legacy seed).
+ *   - findUnique on the namespaced `ticketNumber` skips re-creates.
+ *   - Math.random() is replaced by mulberry32 so the per-fixture
+ *     patient/assignee picks stay stable.
+ */
 import { PrismaClient, ComplaintStatus, Role } from "@prisma/client";
 
 const prisma = new PrismaClient();
 
+// Deterministic RNG so re-runs make stable per-fixture picks (assignee,
+// patient link selection).
+const SEED = 0xc0117a17;
+let _rngState = SEED;
+function rng(): number {
+  _rngState |= 0;
+  _rngState = (_rngState + 0x6d2b79f5) | 0;
+  let t = Math.imul(_rngState ^ (_rngState >>> 15), 1 | _rngState);
+  t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+}
+function resetRng() { _rngState = SEED; }
+
 function randomItem<T>(arr: T[]): T {
-  return arr[Math.floor(Math.random() * arr.length)];
+  return arr[Math.floor(rng() * arr.length)];
 }
 
 function hoursFromNow(h: number): Date {
@@ -203,7 +235,8 @@ const COMPLAINTS: ComplaintSpec[] = [
 ];
 
 async function main() {
-  console.log("\n=== Seeding Complaints ===\n");
+  console.log("\n=== Seeding Complaints (idempotent) ===\n");
+  resetRng();
 
   // Assignees: reception/admin users
   const assignees = await prisma.user.findMany({
@@ -217,22 +250,23 @@ async function main() {
   });
 
   let created = 0;
-  let seq = 1;
-  // Start from a high ticket number to avoid collisions
-  const existing = await prisma.complaint.count();
-  seq = existing + 1;
+  let skipped = 0;
 
-  for (const c of COMPLAINTS) {
-    // Issue #275 (Apr 2026): unify on the canonical `CMP-YYYY-NNNNN`
-    // prefix used by the API generator (apps/api/src/routes/feedback.ts).
-    // Previously the seed emitted `COMP-...` while the runtime emitted
-    // `CMP...`, leaving reception with a mix of formats in the list.
-    const ticketNumber = `CMP-${new Date().getFullYear()}-${String(seq).padStart(5, "0")}`;
-    seq++;
+  for (let idx = 0; idx < COMPLAINTS.length; idx++) {
+    const c = COMPLAINTS[idx];
+    // Idempotency: stable per-fixture ticket number namespaced
+    // `CMP-SEED-<NNNN>` (1-indexed). This deliberately diverges from
+    // the live API generator's `CMP-${year}-${NNNNN}` form to guarantee
+    // re-runs hit the same row via `findUnique({ where: { ticketNumber } })`.
+    // See file header for runtime-counter impact analysis.
+    const ticketNumber = `CMP-SEED-${String(idx + 1).padStart(4, "0")}`;
 
     // Check idempotency by ticketNumber
     const exists = await prisma.complaint.findUnique({ where: { ticketNumber } });
-    if (exists) continue;
+    if (exists) {
+      skipped++;
+      continue;
+    }
 
     const createdAt = daysAgo(c.createdDaysAgo);
     const slaDueAt = new Date(createdAt.getTime() + SLA_HOURS[c.priority] * 3600_000);
@@ -243,7 +277,8 @@ async function main() {
     let patientId: string | null = null;
     let name: string | undefined = c.name;
     let phone: string | undefined = c.phone;
-    if (!name && patients.length > 0 && Math.random() > 0.4) {
+    const patientRoll = rng();
+    if (!name && patients.length > 0 && patientRoll > 0.4) {
       const p = randomItem(patients);
       patientId = p.id;
       name = p.user.name;
@@ -287,7 +322,7 @@ async function main() {
   const byPriority = await prisma.complaint.groupBy({ by: ["priority"], _count: true });
   const byStatus = await prisma.complaint.groupBy({ by: ["status"], _count: true });
 
-  console.log(`\n✔ Complaints created: ${created}`);
+  console.log(`\n✔ Complaints created: ${created} (skipped ${skipped} pre-existing)`);
   console.log(`  By priority:`);
   byPriority.forEach((p) => console.log(`    ${p.priority}: ${p._count}`));
   console.log(`  By status:`);

--- a/packages/db/src/seed-doctor-ratings.ts
+++ b/packages/db/src/seed-doctor-ratings.ts
@@ -1,13 +1,40 @@
+/**
+ * Doctor ratings & PatientFeedback seed.
+ *
+ * Idempotency contract (2026-05-10): wired into `scripts/deploy.sh` step 8q,
+ * safe to re-run on a populated demo without creating duplicates.
+ *
+ *   - PatientFeedback has no @unique besides id. Each generated row's
+ *     `comment` is post-fixed with a stable marker
+ *     `[seed:DR-RATE-SEED-<doctorId>-<i>]` and `findFirst` on that
+ *     marker substring (comment contains) skips re-creates.
+ *   - The number of ratings per doctor is deterministically picked from
+ *     the seeded PRNG so re-runs target the same N rows per doctor.
+ *   - Math.random() is replaced by mulberry32 so the marker→content
+ *     mapping is stable across runs.
+ */
 import { PrismaClient, FeedbackCategory, SentimentLabel } from "@prisma/client";
 
 const prisma = new PrismaClient();
 
+// Deterministic RNG so re-runs make the same per-(doctor, i) decisions.
+const SEED = 0xd0c70125;
+let _rngState = SEED;
+function rng(): number {
+  _rngState |= 0;
+  _rngState = (_rngState + 0x6d2b79f5) | 0;
+  let t = Math.imul(_rngState ^ (_rngState >>> 15), 1 | _rngState);
+  t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+}
+function resetRng() { _rngState = SEED; }
+
 function randomItem<T>(arr: T[]): T {
-  return arr[Math.floor(Math.random() * arr.length)];
+  return arr[Math.floor(rng() * arr.length)];
 }
 
 function randomInt(min: number, max: number) {
-  return Math.floor(Math.random() * (max - min + 1)) + min;
+  return Math.floor(rng() * (max - min + 1)) + min;
 }
 
 function randomDateInPast(days: number): Date {
@@ -48,7 +75,8 @@ const NEGATIVE_COMMENTS = [
 ];
 
 async function main() {
-  console.log("\n=== Seeding Doctor Ratings & Feedback ===\n");
+  console.log("\n=== Seeding Doctor Ratings & Feedback (idempotent) ===\n");
+  resetRng();
 
   const doctors = await prisma.doctor.findMany({ include: { user: true } });
   if (doctors.length === 0) {
@@ -63,56 +91,75 @@ async function main() {
   }
 
   let created = 0;
+  let skipped = 0;
   let positive = 0;
   let neutral = 0;
   let negative = 0;
 
   for (const doc of doctors) {
-    // Skip if doctor already has many feedback entries
-    // (PatientFeedback is not linked to Doctor directly; we attribute via DOCTOR category & comment mention.)
+    // PatientFeedback is not linked to Doctor directly; we attribute via
+    // DOCTOR category & a per-doctor comment marker (see seedTag below).
     const count = randomInt(30, 50);
+    let docCreated = 0;
     for (let i = 0; i < count; i++) {
       const submittedAt = randomDateInPast(90);
 
       // Distribution: 60% 5-star, 25% 4-star, 10% 3-star, 5% 2-star
-      const r = Math.random();
+      const r = rng();
       let rating: number;
       let comment: string;
       let sentiment: SentimentLabel;
       let sentimentScore: number;
+      const sentRoll = rng();
       if (r < 0.6) {
         rating = 5;
         comment = randomItem(POSITIVE_COMMENTS);
         sentiment = SentimentLabel.POSITIVE;
-        sentimentScore = parseFloat((Math.random() * 0.4 + 0.6).toFixed(2));
+        sentimentScore = parseFloat((sentRoll * 0.4 + 0.6).toFixed(2));
         positive++;
       } else if (r < 0.85) {
         rating = 4;
         comment = randomItem(POSITIVE_COMMENTS);
         sentiment = SentimentLabel.POSITIVE;
-        sentimentScore = parseFloat((Math.random() * 0.3 + 0.3).toFixed(2));
+        sentimentScore = parseFloat((sentRoll * 0.3 + 0.3).toFixed(2));
         positive++;
       } else if (r < 0.95) {
         rating = 3;
         comment = randomItem(NEUTRAL_COMMENTS);
         sentiment = SentimentLabel.NEUTRAL;
-        sentimentScore = parseFloat((Math.random() * 0.3 - 0.1).toFixed(2));
+        sentimentScore = parseFloat((sentRoll * 0.3 - 0.1).toFixed(2));
         neutral++;
       } else {
         rating = 2;
         comment = randomItem(NEGATIVE_COMMENTS);
         sentiment = SentimentLabel.NEGATIVE;
-        sentimentScore = parseFloat((Math.random() * 0.4 - 0.7).toFixed(2));
+        sentimentScore = parseFloat((sentRoll * 0.4 - 0.7).toFixed(2));
         negative++;
       }
 
-      // Tag comment with doctor reference so we can attribute
-      const finalComment = `[Dr. ${doc.user.name}] ${comment}`;
+      // Idempotency: stable per-(doctor, i) marker stamped onto `comment`.
+      // PatientFeedback has no @unique tuple to upsert against, so we
+      // findFirst-skip on the marker substring. Marker is appended to
+      // the human-readable comment so the dashboard text remains intact.
+      const seedTag = `[seed:DR-RATE-SEED-${doc.id}-${String(i + 1).padStart(3, "0")}]`;
+      const existing = await prisma.patientFeedback.findFirst({
+        where: { category: FeedbackCategory.DOCTOR, comment: { contains: seedTag } },
+        select: { id: true },
+      });
+
+      // Tag comment with doctor reference + seed marker so we can attribute
+      const finalComment = `[Dr. ${doc.user.name}] ${comment} ${seedTag}`;
 
       const nps =
         rating === 5 ? randomInt(9, 10) : rating === 4 ? randomInt(7, 8) : rating === 3 ? randomInt(5, 6) : randomInt(0, 4);
 
       const patient = randomItem(patients);
+      const requestedVia = randomItem(["SMS", "EMAIL", "WALK_IN"]);
+
+      if (existing) {
+        skipped++;
+        continue;
+      }
 
       await prisma.patientFeedback.create({
         data: {
@@ -123,16 +170,17 @@ async function main() {
           comment: finalComment,
           sentiment,
           sentimentScore,
-          requestedVia: randomItem(["SMS", "EMAIL", "WALK_IN"]),
+          requestedVia,
           submittedAt,
         },
       });
       created++;
+      docCreated++;
     }
-    console.log(`  ${doc.user.name}: ${count} feedback entries`);
+    console.log(`  ${doc.user.name}: ${docCreated}/${count} new feedback entries`);
   }
 
-  console.log(`\n✔ Feedback entries created: ${created}`);
+  console.log(`\n✔ Feedback entries created: ${created} (skipped ${skipped} pre-existing)`);
   console.log(`  Positive: ${positive}`);
   console.log(`  Neutral:  ${neutral}`);
   console.log(`  Negative: ${negative}`);

--- a/packages/db/src/seed-notifications-history.ts
+++ b/packages/db/src/seed-notifications-history.ts
@@ -1,3 +1,24 @@
+/**
+ * Notification delivery-log seed.
+ *
+ * Idempotency contract (2026-05-10): wired into `scripts/deploy.sh` step 8s,
+ * safe to re-run on a populated demo without creating duplicates.
+ *
+ *   - Notification.dedupKey is `@unique` (added 2026 for Issue #750
+ *     broadcast-fanout dedup; nullable for non-broadcast rows). The
+ *     seed reuses this column with stable `NOTIF-SEED-<NNNN>` keys,
+ *     skipping creation if the key exists. Live runtime broadcasts
+ *     use `${broadcastId}:${userId}` (uuid prefix) so collisions are
+ *     impossible.
+ *   - Math.random() is replaced by mulberry32 so each seed iteration
+ *     deterministically picks the same template / recipient / channel /
+ *     status combination across runs.
+ *   - The pre-existing `count() < target` short-circuit was removed —
+ *     it was never a real idempotency guard (it short-circuited on
+ *     ANY 220+ notifications globally, including non-seed live rows),
+ *     and now the per-iteration findUnique on dedupKey is the canonical
+ *     skip mechanism.
+ */
 import {
   PrismaClient,
   NotificationChannel,
@@ -8,12 +29,24 @@ import {
 
 const prisma = new PrismaClient();
 
+// Deterministic RNG so re-runs make the same per-iteration picks.
+const SEED = 0x70771c47;
+let _rngState = SEED;
+function rng(): number {
+  _rngState |= 0;
+  _rngState = (_rngState + 0x6d2b79f5) | 0;
+  let t = Math.imul(_rngState ^ (_rngState >>> 15), 1 | _rngState);
+  t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+}
+function resetRng() { _rngState = SEED; }
+
 function randomItem<T>(arr: T[]): T {
-  return arr[Math.floor(Math.random() * arr.length)];
+  return arr[Math.floor(rng() * arr.length)];
 }
 
 function randomInt(min: number, max: number) {
-  return Math.floor(Math.random() * (max - min + 1)) + min;
+  return Math.floor(rng() * (max - min + 1)) + min;
 }
 
 // Issue #272 (Apr 28 2026): each template is tagged with the audience role(s)
@@ -40,7 +73,12 @@ export const TEMPLATES: TemplateDef[] = [
     type: NotificationType.APPOINTMENT_REMINDER,
     title: "Appointment Reminder",
     audience: [Role.PATIENT],
-    messageFn: () => `Reminder: Your appointment is scheduled tomorrow at ${randomInt(9, 19)}:${randomInt(0, 3) * 15 || "00"}. Please arrive 15 min early.`,
+    messageFn: () => {
+      const hr = randomInt(9, 19);
+      const minIdx = randomInt(0, 3);
+      const min = minIdx === 0 ? "00" : String(minIdx * 15);
+      return `Reminder: Your appointment is scheduled tomorrow at ${hr}:${min}. Please arrive 15 min early.`;
+    },
   },
   {
     type: NotificationType.APPOINTMENT_CANCELLED,
@@ -122,7 +160,8 @@ function randomInPast30Days(): Date {
 }
 
 async function main() {
-  console.log("\n=== Seeding Notification Delivery Logs ===\n");
+  console.log("\n=== Seeding Notification Delivery Logs (idempotent) ===\n");
+  resetRng();
 
   const users = await prisma.user.findMany({ where: { isActive: true }, take: 80 });
   if (users.length === 0) {
@@ -141,15 +180,6 @@ async function main() {
   }
 
   const totalToCreate = 220;
-  const existing = await prisma.notification.count();
-  const target = Math.max(0, 200 - existing);
-  const numToCreate = Math.max(target, totalToCreate - existing);
-  const actualCount = Math.max(0, Math.min(totalToCreate, numToCreate));
-
-  if (actualCount === 0) {
-    console.log(`  Already have ${existing} notifications — skipping`);
-    return;
-  }
 
   const CHANNELS: NotificationChannel[] = [
     NotificationChannel.WHATSAPP,
@@ -161,13 +191,22 @@ async function main() {
   ];
 
   let created = 0;
+  let skipped = 0;
   let statusCounts: Record<string, number> = {};
 
-  for (let i = 0; i < actualCount; i++) {
+  for (let i = 0; i < totalToCreate; i++) {
+    // Idempotency: stable per-iteration `dedupKey` namespaced
+    // `NOTIF-SEED-<NNNN>` (1-indexed). Notification.dedupKey is
+    // `@unique` and nullable — live broadcast-originated rows use
+    // `${broadcastId}:${userId}` (uuid) so collisions are impossible.
+    const dedupKey = `NOTIF-SEED-${String(i + 1).padStart(4, "0")}`;
+    const exists = await prisma.notification.findUnique({
+      where: { dedupKey },
+      select: { id: true },
+    });
+
     const tpl = randomItem(TEMPLATES);
     // Issue #272: pick recipient from the template's audience pool only.
-    // If no users with that role exist (e.g. no PATIENT seeded yet) skip
-    // this iteration rather than fall back to a wrong-role recipient.
     const audiencePool = tpl.audience.flatMap(
       (r) => usersByRole.get(r) ?? []
     );
@@ -177,7 +216,7 @@ async function main() {
     const createdAt = randomInPast30Days();
 
     // Status distribution: 85% sent/delivered, 10% read, 5% failed
-    const r = Math.random();
+    const r = rng();
     let deliveryStatus: NotificationDeliveryStatus;
     let failureReason: string | null = null;
     let deliveredAt: Date | null = null;
@@ -202,6 +241,11 @@ async function main() {
       sentAt = new Date(createdAt.getTime() + randomInt(1, 20) * 1000);
     }
 
+    if (exists) {
+      skipped++;
+      continue;
+    }
+
     statusCounts[deliveryStatus] = (statusCounts[deliveryStatus] ?? 0) + 1;
 
     await prisma.notification.create({
@@ -217,12 +261,13 @@ async function main() {
         deliveredAt,
         readAt,
         createdAt,
+        dedupKey,
       },
     });
     created++;
   }
 
-  console.log(`\n✔ Notifications created: ${created}`);
+  console.log(`\n✔ Notifications created: ${created} (skipped ${skipped} pre-existing)`);
   Object.entries(statusCounts).forEach(([k, v]) => console.log(`  ${k}: ${v}`));
 }
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -265,9 +265,7 @@ fi
 # Seeds NOT wired (intentionally — see chore commit body):
 #   - seed-immunization-data, seed-lab-data, seed-lab-panels (orders),
 #     seed-clinical-enhancements, seed-acute-care-enhancements,
-#     seed-ancillary-enhancements,
-#     seed-asset-history, seed-doctor-ratings,
-#     seed-complaints-data, seed-notifications-history, seed-ipd,
+#     seed-ancillary-enhancements, seed-ipd,
 #     seed-pediatric-patients, seed-ops-enhancements,
 #     seed-phase4-{specialty,engagement,ops}
 #                              — all do raw `.create` per row with no guard,
@@ -277,8 +275,12 @@ fi
 # only when willing to accept a full reset.
 #
 # Wired below (deploy.sh wave 2 — idempotency lifted 2026-05-10):
-#   - seed-chat-conversations.ts  (8n)  — [CHAT-SEED-<roomKey>-NNNN] tag findFirst on content startsWith
-#   - seed-visitors-history.ts    (8o)  — VIS-HIST-SEED-NNNN passNumber findUnique skip-or-create
+#   - seed-chat-conversations.ts     (8n) — [CHAT-SEED-<roomKey>-NNNN] tag findFirst on content startsWith
+#   - seed-visitors-history.ts       (8o) — VIS-HIST-SEED-NNNN passNumber findUnique skip-or-create
+#   - seed-asset-history.ts          (8p) — [seed:ASSET-HIST-SEED-<tag>-<j>] description marker + [seed:ASSET-XFER-SEED-<tag>] notes marker findFirst-skip
+#   - seed-doctor-ratings.ts         (8q) — [seed:DR-RATE-SEED-<doctorId>-<i>] comment marker findFirst-skip on PatientFeedback
+#   - seed-complaints-data.ts        (8r) — CMP-SEED-NNNN ticketNumber findUnique (does NOT poison live CMP-YYYY-NNNNN counter)
+#   - seed-notifications-history.ts  (8s) — NOTIF-SEED-NNNN dedupKey findUnique (cannot collide with broadcast `${broadcastId}:${userId}`)
 
 echo "=== 8d. Re-applying hospital identity SystemConfig seed ==="
 if DATABASE_URL="$DB_URL" npx tsx packages/db/src/seed-hospital-config.ts; then
@@ -352,30 +354,61 @@ else
     echo "  WARN — seed-realistic failed (non-fatal). Investigate offline."
 fi
 
-# Step 8l (deploy.sh wave 2): seed-finance.ts is now idempotent — POs use
-# stable namespaced `PO-SEED-NNNN` numbers guarded by a `findUnique` skip,
-# and the live `next_po_number` SystemConfig counter is no longer touched
-# (that counter is consumed by the runtime PO-creation route in
-# apps/api/src/routes/purchase-orders.ts). Suppliers and HealthPackages
-# were already upserted. Failures MUST NOT block the deploy.
-echo "=== 8l. Re-applying finance seed (suppliers, packages, sample POs) ==="
-if DATABASE_URL="$DB_URL" npx tsx packages/db/src/seed-finance.ts; then
-    echo "  OK — finance fixtures re-seeded."
+# Step 8p (deploy.sh wave 3 — 2026-05-10): seed-asset-history.ts is now
+# fully idempotent — every AssetMaintenance row is tagged with
+# `[seed:ASSET-HIST-SEED-<assetTag>-<j>]` in `description` and gated by
+# findFirst-on-marker; AssetTransfer rows use `[seed:ASSET-XFER-SEED-<tag>]`
+# in `notes`. Asset row updates (amcExpiry / nextCalibration) are gated on
+# the `calibrationInterval=365` marker so re-runs preserve the first run's
+# AMC mix instead of resampling random offsets each deploy. All RNG goes
+# through a fixed-seed mulberry32. Failures MUST NOT block the deploy.
+echo "=== 8p. Re-applying asset history seed (maintenance / transfers / disposal) ==="
+if DATABASE_URL="$DB_URL" npx tsx packages/db/src/seed-asset-history.ts; then
+    echo "  OK — asset history re-seeded."
 else
-    echo "  WARN — seed-finance failed (non-fatal). Investigate offline."
+    echo "  WARN — seed-asset-history failed (non-fatal). Investigate offline."
 fi
 
-# Step 8m (deploy.sh wave 2): seed-clinical.ts is now idempotent —
-# referrals use stable `REF-SEED-NNNN` and surgeries use `SRG-SEED-NNNN`,
-# both guarded by `findUnique` skip-or-create. The previous max+1 counter
-# scan that produced fresh `caseNumber`s on every run has been removed.
-# Operating theaters (`OperatingTheater`) were already upserted. Failures
-# MUST NOT block the deploy.
-echo "=== 8m. Re-applying clinical seed (OTs, sample referrals, surgeries) ==="
-if DATABASE_URL="$DB_URL" npx tsx packages/db/src/seed-clinical.ts; then
-    echo "  OK — clinical fixtures re-seeded."
+# Step 8q (deploy.sh wave 3 — 2026-05-10): seed-doctor-ratings.ts is now
+# fully idempotent — every PatientFeedback row's `comment` carries a
+# stable `[seed:DR-RATE-SEED-<doctorId>-<i>]` marker, gated by findFirst.
+# All RNG (rating distribution, sentiment score, NPS, requestedVia,
+# patient pick) is driven by a fixed-seed mulberry32 so re-runs reuse the
+# same per-(doctor, i) tuple. Failures MUST NOT block the deploy.
+echo "=== 8q. Re-applying doctor ratings seed (per-doctor PatientFeedback rows) ==="
+if DATABASE_URL="$DB_URL" npx tsx packages/db/src/seed-doctor-ratings.ts; then
+    echo "  OK — doctor ratings re-seeded."
 else
-    echo "  WARN — seed-clinical failed (non-fatal). Investigate offline."
+    echo "  WARN — seed-doctor-ratings failed (non-fatal). Investigate offline."
+fi
+
+# Step 8r (deploy.sh wave 3 — 2026-05-10): seed-complaints-data.ts is now
+# fully idempotent — sample tickets use a stable `CMP-SEED-NNNN`
+# `ticketNumber` namespace (1..16) gated by findUnique. The runtime
+# generator at apps/api/src/routes/feedback.ts mints `CMP-YYYY-NNNNN`
+# (digits only in the tail), so its DESC sort + trailing-digit parse can
+# never get poisoned by the seed's `0001..0016` tail (those numbers are
+# below any realistic live ticket count). Failures MUST NOT block the
+# deploy.
+echo "=== 8r. Re-applying complaints seed (16 fixture tickets) ==="
+if DATABASE_URL="$DB_URL" npx tsx packages/db/src/seed-complaints-data.ts; then
+    echo "  OK — complaints re-seeded."
+else
+    echo "  WARN — seed-complaints-data failed (non-fatal). Investigate offline."
+fi
+
+# Step 8s (deploy.sh wave 3 — 2026-05-10): seed-notifications-history.ts is
+# now fully idempotent — each of 220 sample notifications carries a stable
+# `NOTIF-SEED-NNNN` value in `dedupKey` (a `@unique` column added 2026
+# for the broadcast-fanout dedup feature, Issue #750). Live broadcast rows
+# use the form `${broadcastId}:${userId}` (uuid-prefixed) so collisions
+# are impossible. RNG is mulberry32-seeded for stable template / channel /
+# status picks per iteration. Failures MUST NOT block the deploy.
+echo "=== 8s. Re-applying notifications history seed (220 audience-aware delivery logs) ==="
+if DATABASE_URL="$DB_URL" npx tsx packages/db/src/seed-notifications-history.ts; then
+    echo "  OK — notifications history re-seeded."
+else
+    echo "  WARN — seed-notifications-history failed (non-fatal). Investigate offline."
 fi
 
 # Step 8n (deploy.sh wave 2 — 2026-05-10): seed-chat-conversations.ts is now


### PR DESCRIPTION
## Summary

Fourth lane of the bulk-fixture seed idempotency wave. Makes 4 more seeds re-runnable without duplicating rows on a populated demo, and wires them into ``scripts/deploy.sh``'s auto-reseed chain as steps 8p/8q/8r/8s.

The other lanes (D1/D2/D4) cover finance/clinical/chat-conversations/visitors-history at slots 8l/8m/8n/8o — non-overlapping with this PR.

### Stable-id pattern per seed

| Seed | Idempotency mechanism | deploy.sh step |
|------|------------------------|-----------------|
| ``seed-asset-history.ts`` | ``[seed:ASSET-HIST-SEED-<tag>-<j>]`` description marker on AssetMaintenance + ``[seed:ASSET-XFER-SEED-<tag>]`` notes marker on AssetTransfer (no ``@unique`` on either model — findFirst-skip on marker substring); Asset row updates gated on ``calibrationInterval=365 && amcExpiryDate!=null`` to preserve AMC mix across deploys | 8p |
| ``seed-doctor-ratings.ts`` | ``[seed:DR-RATE-SEED-<doctorId>-<i>]`` comment marker on PatientFeedback (no ``@unique`` tuple — findFirst-skip on marker substring) | 8q |
| ``seed-complaints-data.ts`` | ``CMP-SEED-NNNN`` namespaced ``ticketNumber`` (1..16), findUnique-skip on the ``@unique`` column. Diverges from the live API generator's ``CMP-YYYY-NNNNN`` form to guarantee re-runs hit the same row; live ``nextTicketNumber()`` probe cannot be poisoned by the small 0001..0016 tail | 8r |
| ``seed-notifications-history.ts`` | ``NOTIF-SEED-NNNN`` namespaced ``dedupKey`` (1..220), findUnique-skip on the ``@unique`` column. Live broadcasts use uuid-prefixed ``${broadcastId}:${userId}`` so no collision possible | 8s |

All four seeds also get a deterministic mulberry32 PRNG replacing ``Math.random()`` so re-runs reproduce the same per-iteration decisions.

### Production-safety verification

- ``CMP-YYYY-NNNNN`` runtime counter (``apps/api/src/routes/feedback.ts``): only the trailing digit run is parsed — the seed's ``0001..0016`` tail is below any realistic live ticket count, so it can only ever be picked as max if zero live tickets exist (in which case the runtime simply resumes counting from there, same behavior as the legacy seed).
- ``Notification.dedupKey``: the broadcast handler at ``apps/api/src/routes/notifications.ts:387`` mints ``${broadcast.id}:${u.id}`` (uuid prefix); seed values ``NOTIF-SEED-NNNN`` cannot collide.
- ``AssetMaintenance`` + ``AssetTransfer``: no ``@unique`` columns, so we use a stable substring marker stamped onto a free-text field. Live user-created rows without the marker pass through unchanged.
- ``PatientFeedback``: same pattern — marker substring on comment field.

## Test plan

- [ ] CI green (``release.yml`` smoke + per-push test).
- [ ] Verify on demo: ``DATABASE_URL=... npx tsx packages/db/src/seed-asset-history.ts`` runs twice in a row, second run reports ``maintenanceCreated=0`` and ``transfersCreated=0``.
- [ ] Verify on demo: ``DATABASE_URL=... npx tsx packages/db/src/seed-complaints-data.ts`` runs twice — second run reports ``Complaints created: 0 (skipped 16 pre-existing)``.
- [ ] Verify on demo: ``DATABASE_URL=... npx tsx packages/db/src/seed-doctor-ratings.ts`` runs twice — second run reports ``skipped`` count matching the first run's ``created`` count.
- [ ] Verify on demo: ``DATABASE_URL=... npx tsx packages/db/src/seed-notifications-history.ts`` runs twice — second run reports ``Notifications created: 0 (skipped <N> pre-existing)``.
- [ ] After merge: confirm next deploy logs show steps 8p/8q/8r/8s ``OK`` lines.

DO NOT MERGE until lanes D1/D2/D4 (8l-8o) are verified non-conflicting with this PR's deploy.sh edit.