### PR TITLE
chore(seed): lab + immunization idempotency (deploy.sh wave 2)

### DIFF
--- a/packages/db/src/seed-immunization-data.ts
+++ b/packages/db/src/seed-immunization-data.ts
@@ -1,13 +1,51 @@
+/**
+ * Realistic immunization data seed — UIP child schedule + adult vaccines.
+ *
+ * Idempotency contract (2026-05-10): this script is safe to re-run on a
+ * populated demo without creating duplicate Immunization rows.
+ *
+ *   - All randomness is driven by a deterministic mulberry32 PRNG seeded
+ *     from a fixed constant. Re-runs produce byte-identical decisions
+ *     (which adult vaccines, which "wasGiven" outcome, which manufacturer).
+ *   - The Immunization model has no `@unique` field we can upsert on. We
+ *     gate every `.create` with a `findFirst({where:{patientId, vaccine,
+ *     doseNumber}})` guard — that tuple is the natural logical-identity
+ *     for an immunization row. With deterministic RNG the same (patient,
+ *     vaccine, doseNumber) decisions are made on each run, so the guard
+ *     keeps re-runs idempotent.
+ *   - Each row's `notes` field is stamped with a stable
+ *     `IMMUN-SEED-NNNNNN` marker so DB-side audits can identify
+ *     seed-created rows separately from real clinical data.
+ *
+ * Wired into `scripts/deploy.sh` step 8l. Failures are non-fatal (matches
+ * the policy of every other deploy-time fixture seed).
+ */
 import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();
 
+// ─── DETERMINISTIC RNG ──────────────────────────────────
+// mulberry32 — same pattern as seed-realistic.ts. Replaces every
+// Math.random() so re-runs make byte-identical decisions and the
+// (patientId, vaccine, doseNumber) idempotency guard keeps mapping back
+// to the same logical row.
+const SEED = 0xfeed_5eed >>> 0; // arbitrary fixed constant
+let _rngState = SEED;
+function rng(): number {
+  _rngState |= 0;
+  _rngState = (_rngState + 0x6D2B79F5) | 0;
+  let t = Math.imul(_rngState ^ (_rngState >>> 15), 1 | _rngState);
+  t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+}
+function resetRng(): void { _rngState = SEED; }
+
 function pick<T>(arr: T[]): T {
-  return arr[Math.floor(Math.random() * arr.length)];
+  return arr[Math.floor(rng() * arr.length)];
 }
 
 function rand(min: number, max: number): number {
-  return Math.floor(Math.random() * (max - min + 1)) + min;
+  return Math.floor(rng() * (max - min + 1)) + min;
 }
 
 function daysAgo(n: number): Date {
@@ -22,16 +60,12 @@ function daysFromNow(n: number): Date {
   return d;
 }
 
-/**
- * India National Immunization Schedule (UIP)
- * Plus common adult vaccines.
- */
 interface VaccineEntry {
   vaccine: string;
-  dueAgeDays: number;    // Age in days when due (for children)
+  dueAgeDays: number;
   doseNumber?: number;
   manufacturer?: string;
-  interval?: number;     // If follow-up dose, days after previous
+  interval?: number;
   site?: string;
 }
 
@@ -83,8 +117,58 @@ function randomBatch(vaccine: string): string {
   return `${prefix}${String(rand(2024, 2026)).slice(2)}${String(rand(1, 999)).padStart(3, "0")}${String.fromCharCode(65 + rand(0, 25))}`;
 }
 
+/**
+ * Idempotency guard: skip the create if a row matching (patientId, vaccine,
+ * doseNumber) already exists. With deterministic RNG, the same logical
+ * decisions are made on each run, so this tuple-as-natural-key approach
+ * keeps re-runs from duplicating rows.
+ */
+async function createIfMissing(data: {
+  patientId: string;
+  vaccine: string;
+  doseNumber: number;
+  dateGiven: Date;
+  administeredBy: string;
+  batchNumber: string | null;
+  manufacturer: string | null;
+  site?: string;
+  nextDueDate: Date | null;
+  notes: string | null;
+  seedSeq: number;
+}): Promise<boolean> {
+  const existing = await prisma.immunization.findFirst({
+    where: {
+      patientId: data.patientId,
+      vaccine: data.vaccine,
+      doseNumber: data.doseNumber,
+    },
+    select: { id: true },
+  });
+  if (existing) return false;
+
+  const seedTag = `IMMUN-SEED-${String(data.seedSeq).padStart(6, "0")}`;
+  const stampedNotes = data.notes ? `[${seedTag}] ${data.notes}` : `[${seedTag}]`;
+
+  await prisma.immunization.create({
+    data: {
+      patientId: data.patientId,
+      vaccine: data.vaccine,
+      doseNumber: data.doseNumber,
+      dateGiven: data.dateGiven,
+      administeredBy: data.administeredBy,
+      batchNumber: data.batchNumber,
+      manufacturer: data.manufacturer,
+      site: data.site,
+      nextDueDate: data.nextDueDate,
+      notes: stampedNotes,
+    },
+  });
+  return true;
+}
+
 async function main() {
-  console.log("=== Seeding immunization data ===\n");
+  console.log("=== Seeding immunization data (idempotent) ===\n");
+  resetRng();
 
   const patients = await prisma.patient.findMany({
     select: {
@@ -93,6 +177,7 @@ async function main() {
       dateOfBirth: true,
       user: { select: { name: true } },
     },
+    orderBy: { id: "asc" },
   });
 
   if (!patients.length) {
@@ -101,172 +186,157 @@ async function main() {
   }
   console.log(`Found ${patients.length} patients`);
 
-  // Clear existing immunizations to avoid duplicates (we want fresh realistic data)
   const existing = await prisma.immunization.count();
   if (existing > 0) {
-    console.log(`Found ${existing} existing immunization records — keeping those and adding more.`);
+    console.log(`Found ${existing} existing immunization records — keeping those and re-asserting fixtures.`);
   }
 
   const staffUsers = await prisma.user.findMany({
     where: { role: { in: ["NURSE", "DOCTOR"] } },
     take: 5,
+    orderBy: { id: "asc" },
   });
   const adminUserId = staffUsers[0]?.id ?? "system";
 
   let totalChildDoses = 0;
   let totalAdultDoses = 0;
   let totalUpcomingDue = 0;
+  let totalSkipped = 0;
   let patientsProcessed = 0;
+  let seedSeq = 1;
 
   for (const patient of patients) {
     const age = patient.age ?? 30;
-
-    // Treat patients under 10 as "pediatric" for full schedule
     const isPediatric = age < 10;
 
     if (isPediatric) {
-      // For pediatric patients, simulate partial completion of schedule
-      // Generate hypothetical birth date (age years ago)
       const birthDate = patient.dateOfBirth
         ? new Date(patient.dateOfBirth)
         : daysAgo(age * 365);
       const ageInDays = Math.floor((Date.now() - birthDate.getTime()) / (1000 * 60 * 60 * 24));
 
-      // Apply schedule entries where dueAgeDays <= ageInDays (vaccine should have been given)
       for (const entry of CHILD_SCHEDULE) {
         if (entry.dueAgeDays > ageInDays) {
-          // Future vaccine — create upcoming-due entry if within next 180 days
           if (entry.dueAgeDays - ageInDays <= 180) {
             const nextDueDate = new Date(birthDate.getTime() + entry.dueAgeDays * 86400000);
-            await prisma.immunization.create({
-              data: {
-                patientId: patient.id,
-                vaccine: entry.vaccine,
-                doseNumber: entry.doseNumber ?? 1,
-                dateGiven: daysAgo(0), // placeholder; use notes to mark as upcoming
-                administeredBy: "Scheduled",
-                batchNumber: null,
-                manufacturer: null,
-                site: entry.site,
-                nextDueDate,
-                notes: `UPCOMING — Next scheduled dose`,
-              },
-            }).catch(() => {});
-            totalUpcomingDue++;
+            const created = await createIfMissing({
+              patientId: patient.id,
+              vaccine: entry.vaccine,
+              doseNumber: entry.doseNumber ?? 1,
+              dateGiven: daysAgo(0),
+              administeredBy: "Scheduled",
+              batchNumber: null,
+              manufacturer: null,
+              site: entry.site,
+              nextDueDate,
+              notes: `UPCOMING — Next scheduled dose`,
+              seedSeq: seedSeq++,
+            });
+            if (created) totalUpcomingDue++; else totalSkipped++;
           }
           continue;
         }
 
-        // Past due — 85% chance given, 15% chance overdue (missed)
-        const wasGiven = Math.random() < 0.85;
+        const wasGiven = rng() < 0.85;
         const dateGiven = new Date(birthDate.getTime() + entry.dueAgeDays * 86400000);
 
         if (wasGiven) {
-          // Maybe slight delay
           dateGiven.setDate(dateGiven.getDate() + rand(0, 14));
           if (dateGiven > new Date()) dateGiven.setTime(Date.now() - rand(1, 30) * 86400000);
 
-          await prisma.immunization.create({
-            data: {
-              patientId: patient.id,
-              vaccine: entry.vaccine,
-              doseNumber: entry.doseNumber ?? 1,
-              dateGiven,
-              administeredBy: pick(staffUsers)?.id ?? adminUserId,
-              batchNumber: randomBatch(entry.vaccine),
-              manufacturer: pick(MANUFACTURERS),
-              site: entry.site,
-              nextDueDate: null,
-              notes: null,
-            },
-          }).catch(() => {});
-          totalChildDoses++;
+          const created = await createIfMissing({
+            patientId: patient.id,
+            vaccine: entry.vaccine,
+            doseNumber: entry.doseNumber ?? 1,
+            dateGiven,
+            administeredBy: pick(staffUsers)?.id ?? adminUserId,
+            batchNumber: randomBatch(entry.vaccine),
+            manufacturer: pick(MANUFACTURERS),
+            site: entry.site,
+            nextDueDate: null,
+            notes: null,
+            seedSeq: seedSeq++,
+          });
+          if (created) totalChildDoses++; else totalSkipped++;
         } else {
-          // Overdue — Issue #46: clamp to a realistic demo window (7-60 days)
-          // instead of showing a due date from years ago. The record is still
-          // "pending", but the dashboard won't display "3375 days overdue".
           const overdueDays = rand(7, 60);
           const clampedDueDate = daysAgo(overdueDays);
-          await prisma.immunization.create({
-            data: {
-              patientId: patient.id,
-              vaccine: entry.vaccine,
-              doseNumber: entry.doseNumber ?? 1,
-              dateGiven: daysAgo(1), // mock placeholder since date is required
-              administeredBy: "Not given",
-              batchNumber: null,
-              manufacturer: null,
-              site: entry.site,
-              nextDueDate: clampedDueDate,
-              notes: `OVERDUE — was due ${clampedDueDate.toLocaleDateString(
-                "en-IN"
-              )} (${overdueDays}d), not yet administered`,
-            },
-          }).catch(() => {});
-          totalUpcomingDue++;
+          const created = await createIfMissing({
+            patientId: patient.id,
+            vaccine: entry.vaccine,
+            doseNumber: entry.doseNumber ?? 1,
+            dateGiven: daysAgo(1),
+            administeredBy: "Not given",
+            batchNumber: null,
+            manufacturer: null,
+            site: entry.site,
+            nextDueDate: clampedDueDate,
+            notes: `OVERDUE — was due ${clampedDueDate.toLocaleDateString(
+              "en-IN"
+            )} (${overdueDays}d), not yet administered`,
+            seedSeq: seedSeq++,
+          });
+          if (created) totalUpcomingDue++; else totalSkipped++;
         }
       }
     } else {
-      // Adult patients — pick 2-5 random adult vaccines
       const count = rand(2, 5);
-      const picked = new Set<string>();
-      for (let i = 0; i < count * 2 && picked.size < count; i++) {
-        const v = pick(ADULT_VACCINES);
-        if (picked.has(v.vaccine)) continue;
-        picked.add(v.vaccine);
+      const shuffled = [...ADULT_VACCINES];
+      for (let k = shuffled.length - 1; k > 0; k--) {
+        const j = Math.floor(rng() * (k + 1));
+        [shuffled[k], shuffled[j]] = [shuffled[j], shuffled[k]];
+      }
+      const picked = shuffled.slice(0, count);
 
-        const daysAgoGiven = rand(30, 730); // 1 month to 2 years ago
+      for (const v of picked) {
+        const daysAgoGiven = rand(30, 730);
         const dateGiven = daysAgo(daysAgoGiven);
 
-        // Some vaccines have boosters due
         let nextDueDate: Date | null = null;
-        let nextNotes: string | null = null;
+        const nextNotes: string | null = null;
         if (v.vaccine.includes("Influenza") || v.vaccine === "COVID-19 (Covishield)" || v.vaccine === "COVID-19 (Covaxin)") {
-          // annual
           nextDueDate = daysFromNow(365 - daysAgoGiven);
         }
         if (v.vaccine.includes("Tdap") || v.vaccine === "Td") {
-          nextDueDate = daysFromNow(3650 - daysAgoGiven); // 10y
+          nextDueDate = daysFromNow(3650 - daysAgoGiven);
         }
 
-        await prisma.immunization.create({
-          data: {
-            patientId: patient.id,
-            vaccine: v.vaccine,
-            doseNumber: v.vaccine.includes("COVID") ? rand(1, 3) : 1,
-            dateGiven,
-            administeredBy: pick(staffUsers)?.id ?? adminUserId,
-            batchNumber: randomBatch(v.vaccine),
-            manufacturer: v.manufacturer,
-            site: v.site,
-            nextDueDate,
-            notes: nextNotes,
-          },
-        }).catch(() => {});
-        totalAdultDoses++;
+        const doseNumber = v.vaccine.includes("COVID") ? rand(1, 3) : 1;
+        const created = await createIfMissing({
+          patientId: patient.id,
+          vaccine: v.vaccine,
+          doseNumber,
+          dateGiven,
+          administeredBy: pick(staffUsers)?.id ?? adminUserId,
+          batchNumber: randomBatch(v.vaccine),
+          manufacturer: v.manufacturer,
+          site: v.site,
+          nextDueDate,
+          notes: nextNotes,
+          seedSeq: seedSeq++,
+        });
+        if (created) totalAdultDoses++; else totalSkipped++;
 
         if (nextDueDate && nextDueDate < new Date()) totalUpcomingDue++;
       }
 
-      // 30% chance of an upcoming due booster
-      if (Math.random() < 0.3) {
+      if (rng() < 0.3) {
         const v = pick(ADULT_VACCINES);
         const nextDueDate = daysFromNow(rand(1, 90));
-        await prisma.immunization.create({
-          data: {
-            patientId: patient.id,
-            vaccine: v.vaccine,
-            doseNumber: 1,
-            dateGiven: daysAgo(1),
-            administeredBy: "Scheduled",
-            batchNumber: null,
-            manufacturer: null,
-            site: v.site,
-            nextDueDate,
-            notes: "UPCOMING — Due within 90 days",
-          },
-        }).catch(() => {});
-        totalUpcomingDue++;
+        const created = await createIfMissing({
+          patientId: patient.id,
+          vaccine: v.vaccine,
+          doseNumber: 99,
+          dateGiven: daysAgo(1),
+          administeredBy: "Scheduled",
+          batchNumber: null,
+          manufacturer: null,
+          site: v.site,
+          nextDueDate,
+          notes: "UPCOMING — Due within 90 days",
+          seedSeq: seedSeq++,
+        });
+        if (created) totalUpcomingDue++; else totalSkipped++;
       }
     }
 
@@ -277,6 +347,7 @@ async function main() {
   console.log(`  Pediatric doses given: ${totalChildDoses}`);
   console.log(`  Adult doses given: ${totalAdultDoses}`);
   console.log(`  Upcoming / overdue entries: ${totalUpcomingDue}`);
+  console.log(`  Skipped (already present): ${totalSkipped}`);
 
   const totalInDB = await prisma.immunization.count();
   console.log(`  Total immunization records in DB: ${totalInDB}`);

--- a/packages/db/src/seed-lab-data.ts
+++ b/packages/db/src/seed-lab-data.ts
@@ -1,17 +1,51 @@
+/**
+ * Realistic lab orders + results seed.
+ *
+ * Idempotency contract (2026-05-10): this script is safe to re-run on a
+ * populated demo without creating duplicate LabOrder / LabResult rows.
+ *
+ *   - All randomness is driven by a deterministic mulberry32 PRNG seeded
+ *     from a fixed constant. Re-runs produce byte-identical decisions.
+ *   - LabOrder.orderNumber is `@unique`. We mint stable
+ *     `LAB-SEED-NNNNNN` numbers from a per-scenario index so re-runs
+ *     hit the existing rows. The pre-idempotency code computed the
+ *     next sequence from `existingOrders.length`, which made every re-run
+ *     mint a fresh batch on top of the prior one.
+ *   - LabResult has no @unique we can upsert on. Per-orderItem we count
+ *     existing results — if any exist for that orderItemId we skip the
+ *     whole result-generation block (the parameter set is fixed by the
+ *     test panel, so 0 vs N is the only meaningful state).
+ *   - LabQCEntry block was already idempotent pre-2026-05-10 (findFirst
+ *     skip on per-day window). Left alone.
+ *
+ * Wired into `scripts/deploy.sh` step 8m. Failures are non-fatal.
+ */
 import { PrismaClient, LabTestStatus, LabResultFlag } from "@prisma/client";
 
 const prisma = new PrismaClient();
 
+// ─── DETERMINISTIC RNG ──────────────────────────────────
+const SEED = 0x1ab5eed0 >>> 0;
+let _rngState = SEED;
+function rng(): number {
+  _rngState |= 0;
+  _rngState = (_rngState + 0x6D2B79F5) | 0;
+  let t = Math.imul(_rngState ^ (_rngState >>> 15), 1 | _rngState);
+  t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+}
+function resetRng(): void { _rngState = SEED; }
+
 function pick<T>(arr: T[]): T {
-  return arr[Math.floor(Math.random() * arr.length)];
+  return arr[Math.floor(rng() * arr.length)];
 }
 
 function rand(min: number, max: number): number {
-  return Math.floor(Math.random() * (max - min + 1)) + min;
+  return Math.floor(rng() * (max - min + 1)) + min;
 }
 
 function randFloat(min: number, max: number, decimals = 1): number {
-  return parseFloat((Math.random() * (max - min) + min).toFixed(decimals));
+  return parseFloat((rng() * (max - min) + min).toFixed(decimals));
 }
 
 function daysAgo(n: number): Date {
@@ -26,10 +60,6 @@ function hoursAgo(n: number): Date {
   return d;
 }
 
-/**
- * Reference lab result panels — each test has expected parameters with normal ranges.
- * Values generated with ~70% normal, ~25% abnormal (high/low), ~5% critical.
- */
 type Panel = Array<{
   parameter: string;
   unit: string;
@@ -145,7 +175,7 @@ function generateValue(param: { parameter: string; normalMin: number; normalMax:
   let flag: LabResultFlag;
 
   if (outcome === "critical") {
-    if (criticalLow !== undefined && Math.random() < 0.5) {
+    if (criticalLow !== undefined && rng() < 0.5) {
       value = randFloat(criticalLow * 0.5, criticalLow, decimals);
       flag = LabResultFlag.CRITICAL;
     } else if (criticalHigh !== undefined) {
@@ -156,7 +186,7 @@ function generateValue(param: { parameter: string; normalMin: number; normalMax:
       flag = LabResultFlag.HIGH;
     }
   } else if (outcome === "abnormal") {
-    if (Math.random() < 0.5) {
+    if (rng() < 0.5) {
       const low = criticalLow ?? normalMin * 0.5;
       value = randFloat(low, normalMin * 0.95, decimals);
       flag = LabResultFlag.LOW;
@@ -177,19 +207,23 @@ function generateValue(param: { parameter: string; normalMin: number; normalMax:
 }
 
 async function main() {
-  console.log("=== Seeding lab orders + results ===\n");
+  console.log("=== Seeding lab orders + results (idempotent) ===\n");
+  resetRng();
 
-  // Get all available tests
-  const tests = await prisma.labTest.findMany();
+  const tests = await prisma.labTest.findMany({ orderBy: { id: "asc" } });
   if (tests.length === 0) {
     console.log("No lab tests found. Run seed-pharmacy.ts first.");
     return;
   }
   console.log(`Found ${tests.length} lab tests`);
 
-  const patients = await prisma.patient.findMany({ take: 30 });
-  const doctors = await prisma.doctor.findMany({ take: 5 });
-  const staffUsers = await prisma.user.findMany({ where: { role: { in: ["NURSE", "DOCTOR", "ADMIN"] } }, take: 5 });
+  const patients = await prisma.patient.findMany({ take: 30, orderBy: { id: "asc" } });
+  const doctors = await prisma.doctor.findMany({ take: 5, orderBy: { id: "asc" } });
+  const staffUsers = await prisma.user.findMany({
+    where: { role: { in: ["NURSE", "DOCTOR", "ADMIN"] } },
+    take: 5,
+    orderBy: { id: "asc" },
+  });
 
   if (!patients.length || !doctors.length) {
     console.log("Need patients and doctors seeded first.");
@@ -197,41 +231,27 @@ async function main() {
   }
   console.log(`Using ${patients.length} patients, ${doctors.length} doctors`);
 
-  // Get existing orders to pick next order number
-  const existingOrders = await prisma.labOrder.findMany({ select: { orderNumber: true } });
-  let nextSeq = 1;
-  for (const o of existingOrders) {
-    const m = o.orderNumber.match(/LAB(\d+)/);
-    if (m) nextSeq = Math.max(nextSeq, parseInt(m[1]) + 1);
-  }
-
-  // Scenarios: generate a realistic mix of orders across time + statuses
   const scenarios = [
-    // Past completed orders with results (14 days ago to today)
-    ...Array.from({ length: 40 }, (_, i) => ({
+    ...Array.from({ length: 40 }, () => ({
       daysOld: rand(0, 14),
       status: LabTestStatus.COMPLETED,
       testCount: rand(1, 4),
     })),
-    // In-progress orders (last 2 days)
     ...Array.from({ length: 8 }, () => ({
       daysOld: rand(0, 1),
       status: LabTestStatus.IN_PROGRESS,
       testCount: rand(1, 3),
     })),
-    // Sample collected but not processed (today)
     ...Array.from({ length: 5 }, () => ({
       daysOld: 0,
       status: LabTestStatus.SAMPLE_COLLECTED,
       testCount: rand(1, 2),
     })),
-    // Just ordered (last few hours)
     ...Array.from({ length: 6 }, () => ({
       daysOld: 0,
       status: LabTestStatus.ORDERED,
       testCount: rand(1, 3),
     })),
-    // Cancelled
     ...Array.from({ length: 2 }, () => ({
       daysOld: rand(2, 14),
       status: LabTestStatus.CANCELLED,
@@ -240,23 +260,22 @@ async function main() {
   ];
 
   let totalCreated = 0;
+  let totalSkipped = 0;
   let totalResults = 0;
   let totalCritical = 0;
 
-  for (const scenario of scenarios) {
+  for (let scenarioIdx = 0; scenarioIdx < scenarios.length; scenarioIdx++) {
+    const scenario = scenarios[scenarioIdx];
     const patient = pick(patients);
     const doctor = pick(doctors);
     const selectedTests = Array.from({ length: scenario.testCount }).map(() => pick(tests));
     const uniqueTests = Array.from(new Map(selectedTests.map(t => [t.id, t])).values());
 
-    const orderNumber = `LAB${String(nextSeq++).padStart(6, "0")}`;
+    // Stable seed-namespaced order number — replaces non-idempotent
+    // existingOrders+1 counter which compounded each re-run.
+    const orderNumber = `LAB-SEED-${String(scenarioIdx + 1).padStart(6, "0")}`;
     const orderedAt = scenario.daysOld > 0 ? daysAgo(scenario.daysOld) : hoursAgo(rand(0, 23));
 
-    // Issue (Apr 2026 cleanup): TS strict-mode rejected `.includes(scenario.status)`
-    // because the array's element type is the narrow 3-status subset while
-    // `scenario.status` widened to all 5 possible LabTestStatus values
-    // (ORDERED + CANCELLED also flow through here). Use a type guard against
-    // a const tuple so the narrowing is explicit and TS accepts the call.
     const COLLECTED_STATUSES = [
       LabTestStatus.SAMPLE_COLLECTED,
       LabTestStatus.IN_PROGRESS,
@@ -275,43 +294,57 @@ async function main() {
         ? new Date((collectedAt ?? orderedAt).getTime() + rand(60, 360) * 60 * 1000)
         : null;
 
-    const order = await prisma.labOrder.create({
-      data: {
-        orderNumber,
-        patientId: patient.id,
-        doctorId: doctor.id,
-        status: scenario.status,
-        notes: pick([
-          null,
-          "Routine checkup",
-          "Follow-up on previous abnormal result",
-          "Pre-operative assessment",
-          "Suspected infection",
-          "Annual health screening",
-          "Diabetic follow-up",
-        ]),
-        orderedAt,
-        collectedAt,
-        completedAt,
-        items: {
-          create: uniqueTests.map((t) => ({
-            testId: t.id,
-            status: scenario.status,
-          })),
-        },
-      },
+    const existingOrder = await prisma.labOrder.findUnique({
+      where: { orderNumber },
       include: { items: true },
     });
 
-    totalCreated++;
+    let order;
+    if (existingOrder) {
+      order = existingOrder;
+      totalSkipped++;
+    } else {
+      order = await prisma.labOrder.create({
+        data: {
+          orderNumber,
+          patientId: patient.id,
+          doctorId: doctor.id,
+          status: scenario.status,
+          notes: pick([
+            null,
+            "Routine checkup",
+            "Follow-up on previous abnormal result",
+            "Pre-operative assessment",
+            "Suspected infection",
+            "Annual health screening",
+            "Diabetic follow-up",
+          ]),
+          orderedAt,
+          collectedAt,
+          completedAt,
+          items: {
+            create: uniqueTests.map((t) => ({
+              testId: t.id,
+              status: scenario.status,
+            })),
+          },
+        },
+        include: { items: true },
+      });
+      totalCreated++;
+    }
 
-    // Generate results for COMPLETED orders
     if (scenario.status === LabTestStatus.COMPLETED) {
       for (let idx = 0; idx < order.items.length; idx++) {
         const item = order.items[idx];
-        const test = uniqueTests[idx];
+        const test = uniqueTests[idx] ?? tests.find(t => t.id === item.testId);
+        if (!test) continue;
 
-        // Find panel by name match, else default to a single generic parameter
+        const existingResultCount = await prisma.labResult.count({
+          where: { orderItemId: item.id },
+        });
+        if (existingResultCount > 0) continue;
+
         const panel = PANELS[test.name] ?? [
           {
             parameter: test.name,
@@ -322,8 +355,7 @@ async function main() {
           },
         ];
 
-        // ~70% normal, 25% abnormal, 5% critical
-        const r = Math.random();
+        const r = rng();
         const outcome: "normal" | "abnormal" | "critical" =
           r < 0.7 ? "normal" : r < 0.95 ? "abnormal" : "critical";
 
@@ -350,11 +382,11 @@ async function main() {
     }
   }
 
-  console.log(`\n  Created ${totalCreated} lab orders`);
-  console.log(`  Generated ${totalResults} result entries`);
+  console.log(`\n  Created ${totalCreated} new lab orders`);
+  console.log(`  Skipped ${totalSkipped} pre-existing seeded orders`);
+  console.log(`  Generated ${totalResults} new result entries`);
   console.log(`  Critical findings flagged: ${totalCritical}`);
 
-  // Summary by status
   const statusCounts = await prisma.labOrder.groupBy({
     by: ["status"],
     _count: true,
@@ -364,31 +396,16 @@ async function main() {
     console.log(`    ${sc.status}: ${sc._count}`);
   }
 
-  // ─── Lab QC entries (Issue #172) ──────────────────────────
-  // The QC dashboard read empty even on tenants with hundreds of completed
-  // orders because nothing seeded `LabQCEntry`. This block creates ~10
-  // Levey-Jennings-style daily QC runs per common test (CBC, KFT, LFT,
-  // Lipid Profile, Thyroid Profile, FBS, HbA1c) with normal-distributed
-  // recorded values around a known mean/SD pair so the LJ chart renders
-  // realistic ±2SD / ±3SD deviations and a believable pass-rate.
   await seedLabQCEntries(staffUsers);
 
   console.log("\n=== Lab seed complete ===");
 }
 
-/**
- * Idempotent QC entries. Each (testName, instrument, runDate) combo is
- * unique, so we re-run by skipping when the rows already exist for the
- * current 10-day window.
- */
 async function seedLabQCEntries(
   staffUsers: Array<{ id: string }>
 ): Promise<void> {
   console.log("\n  Seeding Lab QC entries (Levey-Jennings)...");
 
-  // Reference QC targets — mean + SD per parameter group. Chosen to match
-  // mid-range physiologic values so the recorded points land within the
-  // ±2SD band ~95% of the time (clinically realistic pass-rate).
   const qcTargets: Array<{
     testName: string;
     instrument: string;
@@ -406,10 +423,9 @@ async function seedLabQCEntries(
     { testName: "HbA1c", instrument: "Bio-Rad D-10", qcLevel: "NORMAL", mean: 5.5, sd: 0.15 },
   ];
 
-  // Box-Muller normal-distributed sample.
   function gaussian(mean: number, sd: number): number {
-    const u1 = Math.random() || 1e-9;
-    const u2 = Math.random() || 1e-9;
+    const u1 = rng() || 1e-9;
+    const u2 = rng() || 1e-9;
     const z = Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
     return mean + z * sd;
   }
@@ -430,8 +446,6 @@ async function seedLabQCEntries(
     for (let dayBack = 9; dayBack >= 0; dayBack--) {
       const runDate = daysAgo(dayBack);
 
-      // Skip if a row for this exact (testId, instrument, qcLevel,
-      // run-day) already exists — keeps the seed idempotent.
       const dayStart = new Date(runDate);
       dayStart.setHours(0, 0, 0, 0);
       const dayEnd = new Date(runDate);
@@ -449,7 +463,7 @@ async function seedLabQCEntries(
 
       const recorded = gaussian(target.mean, target.sd);
       const z = (recorded - target.mean) / target.sd;
-      const withinRange = Math.abs(z) <= 2; // ±2SD pass band
+      const withinRange = Math.abs(z) <= 2;
       const cv = (target.sd / target.mean) * 100;
 
       await prisma.labQCEntry.create({

--- a/packages/db/src/seed-lab-panels.ts
+++ b/packages/db/src/seed-lab-panels.ts
@@ -1,17 +1,50 @@
+/**
+ * Specialty lab panels seed — VITD, B12, Iron studies, Cardiac enzymes,
+ * D-Dimer, Procalcitonin, ANA, RF, PSA, β-HCG.
+ *
+ * Idempotency contract (2026-05-10): this script is safe to re-run on a
+ * populated demo without creating duplicate rows.
+ *
+ *   - All randomness is driven by a deterministic mulberry32 PRNG seeded
+ *     from a fixed constant. Re-runs produce byte-identical decisions.
+ *   - LabTest upsert by `code` was already idempotent pre-2026-05-10.
+ *   - LabTestReferenceRange has no @unique. Per-test we count existing
+ *     ranges and skip the whole population block if any are present.
+ *   - LabOrder.orderNumber is `@unique`. Pre-idempotency this used
+ *     `LAB-${YYYY}-${existingOrders+5000+i}` which meant every re-run
+ *     minted a fresh batch. Now uses stable `LAB-SEED-PANEL-NNNNNN`
+ *     gated by `findUnique`.
+ *   - LabResult: per-orderItem we count existing results and skip if any
+ *     present (same reasoning as seed-lab-data.ts).
+ *
+ * Wired into `scripts/deploy.sh` step 8n. Failures are non-fatal.
+ */
 import { PrismaClient, LabTestStatus, LabResultFlag, Role } from "@prisma/client";
 
 const prisma = new PrismaClient();
 
+// ─── DETERMINISTIC RNG ──────────────────────────────────
+const SEED = 0x1ab9ace5 >>> 0;
+let _rngState = SEED;
+function rng(): number {
+  _rngState |= 0;
+  _rngState = (_rngState + 0x6D2B79F5) | 0;
+  let t = Math.imul(_rngState ^ (_rngState >>> 15), 1 | _rngState);
+  t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+}
+function resetRng(): void { _rngState = SEED; }
+
 function randomItem<T>(arr: T[]): T {
-  return arr[Math.floor(Math.random() * arr.length)];
+  return arr[Math.floor(rng() * arr.length)];
 }
 
 function randomInt(min: number, max: number) {
-  return Math.floor(Math.random() * (max - min + 1)) + min;
+  return Math.floor(rng() * (max - min + 1)) + min;
 }
 
 function randomFloat(min: number, max: number, decimals = 1) {
-  return parseFloat((Math.random() * (max - min) + min).toFixed(decimals));
+  return parseFloat((rng() * (max - min) + min).toFixed(decimals));
 }
 
 function daysAgo(n: number): Date {
@@ -45,190 +78,79 @@ type SpecialtyTestSpec = {
 };
 
 const SPECIALTY_TESTS: SpecialtyTestSpec[] = [
-  {
-    code: "VITD",
-    name: "Vitamin D (25-OH)",
-    category: "Biochemistry",
-    price: 1200,
-    sampleType: "Blood",
-    unit: "ng/mL",
-    normalRange: "30-100",
-    panicLow: 10,
-    panicHigh: 150,
-    tatHours: 48,
-    description: "25-Hydroxy Vitamin D — assesses vitamin D status.",
-    ranges: [{ low: 30, high: 100, unit: "ng/mL", notes: "Deficiency < 20, Insufficiency 20-30" }],
-  },
-  {
-    code: "VITB12",
-    name: "Vitamin B12",
-    category: "Biochemistry",
-    price: 900,
-    sampleType: "Blood",
-    unit: "pg/mL",
-    normalRange: "200-900",
-    panicLow: 100,
-    panicHigh: 2000,
-    tatHours: 24,
-    description: "Serum cobalamin level — screens for deficiency.",
-    ranges: [{ low: 200, high: 900, unit: "pg/mL" }],
-  },
-  {
-    code: "IRONST",
-    name: "Iron Studies",
-    category: "Biochemistry",
-    price: 1800,
-    sampleType: "Blood",
-    unit: "multi",
-    normalRange: "See parameters",
-    tatHours: 24,
-    description: "Comprehensive iron panel: Serum Iron, TIBC, Ferritin, Transferrin Saturation.",
-    ranges: [
-      { parameter: "Serum Iron", gender: "MALE", low: 65, high: 175, unit: "μg/dL" },
-      { parameter: "Serum Iron", gender: "FEMALE", low: 50, high: 170, unit: "μg/dL" },
-      { parameter: "TIBC", low: 240, high: 450, unit: "μg/dL" },
-      { parameter: "Ferritin", gender: "MALE", low: 30, high: 400, unit: "ng/mL" },
-      { parameter: "Ferritin", gender: "FEMALE", low: 13, high: 150, unit: "ng/mL" },
-      { parameter: "Transferrin Saturation", low: 20, high: 50, unit: "%" },
-    ],
-  },
-  {
-    code: "CARDENZ",
-    name: "Cardiac Enzymes",
-    category: "Biochemistry",
-    price: 2500,
-    sampleType: "Blood",
-    unit: "multi",
-    normalRange: "See parameters",
-    tatHours: 4,
-    description: "Troponin I, CK-MB, Myoglobin — acute MI evaluation.",
-    ranges: [
-      { parameter: "Troponin I", low: 0, high: 0.04, unit: "ng/mL", notes: ">0.4 suggestive of MI" },
-      { parameter: "CK-MB", low: 0, high: 6.3, unit: "ng/mL" },
-      { parameter: "Myoglobin", low: 10, high: 92, unit: "ng/mL" },
-    ],
-  },
-  {
-    code: "DDIMER",
-    name: "D-Dimer",
-    category: "Coagulation",
-    price: 1400,
-    sampleType: "Blood",
-    unit: "ng/mL",
-    normalRange: "<500",
-    panicHigh: 5000,
-    tatHours: 6,
-    description: "Fibrin degradation marker — VTE/DIC screening.",
-    ranges: [{ low: 0, high: 500, unit: "ng/mL", notes: "Age-adjusted cutoff may apply >50y" }],
-  },
-  {
-    code: "PROCAL",
-    name: "Procalcitonin",
-    category: "Immunology",
-    price: 2200,
-    sampleType: "Blood",
-    unit: "ng/mL",
-    normalRange: "<0.5",
-    panicHigh: 10,
-    tatHours: 8,
-    description: "Bacterial sepsis marker.",
-    ranges: [{ low: 0, high: 0.5, unit: "ng/mL", notes: ">2.0 suggests sepsis" }],
-  },
-  {
-    code: "ANA",
-    name: "ANA (Anti-Nuclear Antibody)",
-    category: "Immunology",
-    price: 1600,
-    sampleType: "Blood",
-    unit: "titer",
-    normalRange: "Negative",
-    tatHours: 48,
-    description: "Screening for autoimmune connective tissue disease.",
-    ranges: [{ notes: "Positive titer >1:80 is significant" }],
-  },
-  {
-    code: "RF",
-    name: "Rheumatoid Factor",
-    category: "Immunology",
-    price: 600,
-    sampleType: "Blood",
-    unit: "IU/mL",
-    normalRange: "<14",
-    tatHours: 24,
-    description: "Assists in RA diagnosis; not specific alone.",
-    ranges: [{ low: 0, high: 14, unit: "IU/mL" }],
-  },
-  {
-    code: "PSA",
-    name: "Prostate Specific Antigen (PSA)",
-    category: "Biochemistry",
-    price: 950,
-    sampleType: "Blood",
-    unit: "ng/mL",
-    normalRange: "<4.0 (age-dependent)",
-    panicHigh: 20,
-    tatHours: 24,
-    description: "Prostate health screening (male patients).",
-    ranges: [
-      { gender: "MALE", ageMin: 40, ageMax: 49, low: 0, high: 2.5, unit: "ng/mL" },
-      { gender: "MALE", ageMin: 50, ageMax: 59, low: 0, high: 3.5, unit: "ng/mL" },
-      { gender: "MALE", ageMin: 60, ageMax: 69, low: 0, high: 4.5, unit: "ng/mL" },
-      { gender: "MALE", ageMin: 70, ageMax: 120, low: 0, high: 6.5, unit: "ng/mL" },
-    ],
-  },
-  {
-    code: "BHCG",
-    name: "Beta-HCG (Quantitative)",
-    category: "Endocrinology",
-    price: 1100,
-    sampleType: "Blood",
-    unit: "mIU/mL",
-    normalRange: "<5 (non-pregnant)",
-    tatHours: 6,
-    description: "Pregnancy test (quantitative) & trophoblastic disease monitoring.",
-    ranges: [
-      { gender: "FEMALE", low: 0, high: 5, unit: "mIU/mL", notes: "Non-pregnant reference" },
-    ],
-  },
+  { code: "VITD", name: "Vitamin D (25-OH)", category: "Biochemistry", price: 1200, sampleType: "Blood", unit: "ng/mL", normalRange: "30-100", panicLow: 10, panicHigh: 150, tatHours: 48, description: "25-Hydroxy Vitamin D — assesses vitamin D status.", ranges: [{ low: 30, high: 100, unit: "ng/mL", notes: "Deficiency < 20, Insufficiency 20-30" }] },
+  { code: "VITB12", name: "Vitamin B12", category: "Biochemistry", price: 900, sampleType: "Blood", unit: "pg/mL", normalRange: "200-900", panicLow: 100, panicHigh: 2000, tatHours: 24, description: "Serum cobalamin level — screens for deficiency.", ranges: [{ low: 200, high: 900, unit: "pg/mL" }] },
+  { code: "IRONST", name: "Iron Studies", category: "Biochemistry", price: 1800, sampleType: "Blood", unit: "multi", normalRange: "See parameters", tatHours: 24, description: "Comprehensive iron panel: Serum Iron, TIBC, Ferritin, Transferrin Saturation.", ranges: [
+    { parameter: "Serum Iron", gender: "MALE", low: 65, high: 175, unit: "μg/dL" },
+    { parameter: "Serum Iron", gender: "FEMALE", low: 50, high: 170, unit: "μg/dL" },
+    { parameter: "TIBC", low: 240, high: 450, unit: "μg/dL" },
+    { parameter: "Ferritin", gender: "MALE", low: 30, high: 400, unit: "ng/mL" },
+    { parameter: "Ferritin", gender: "FEMALE", low: 13, high: 150, unit: "ng/mL" },
+    { parameter: "Transferrin Saturation", low: 20, high: 50, unit: "%" },
+  ] },
+  { code: "CARDENZ", name: "Cardiac Enzymes", category: "Biochemistry", price: 2500, sampleType: "Blood", unit: "multi", normalRange: "See parameters", tatHours: 4, description: "Troponin I, CK-MB, Myoglobin — acute MI evaluation.", ranges: [
+    { parameter: "Troponin I", low: 0, high: 0.04, unit: "ng/mL", notes: ">0.4 suggestive of MI" },
+    { parameter: "CK-MB", low: 0, high: 6.3, unit: "ng/mL" },
+    { parameter: "Myoglobin", low: 10, high: 92, unit: "ng/mL" },
+  ] },
+  { code: "DDIMER", name: "D-Dimer", category: "Coagulation", price: 1400, sampleType: "Blood", unit: "ng/mL", normalRange: "<500", panicHigh: 5000, tatHours: 6, description: "Fibrin degradation marker — VTE/DIC screening.", ranges: [{ low: 0, high: 500, unit: "ng/mL", notes: "Age-adjusted cutoff may apply >50y" }] },
+  { code: "PROCAL", name: "Procalcitonin", category: "Immunology", price: 2200, sampleType: "Blood", unit: "ng/mL", normalRange: "<0.5", panicHigh: 10, tatHours: 8, description: "Bacterial sepsis marker.", ranges: [{ low: 0, high: 0.5, unit: "ng/mL", notes: ">2.0 suggests sepsis" }] },
+  { code: "ANA", name: "ANA (Anti-Nuclear Antibody)", category: "Immunology", price: 1600, sampleType: "Blood", unit: "titer", normalRange: "Negative", tatHours: 48, description: "Screening for autoimmune connective tissue disease.", ranges: [{ notes: "Positive titer >1:80 is significant" }] },
+  { code: "RF", name: "Rheumatoid Factor", category: "Immunology", price: 600, sampleType: "Blood", unit: "IU/mL", normalRange: "<14", tatHours: 24, description: "Assists in RA diagnosis; not specific alone.", ranges: [{ low: 0, high: 14, unit: "IU/mL" }] },
+  { code: "PSA", name: "Prostate Specific Antigen (PSA)", category: "Biochemistry", price: 950, sampleType: "Blood", unit: "ng/mL", normalRange: "<4.0 (age-dependent)", panicHigh: 20, tatHours: 24, description: "Prostate health screening (male patients).", ranges: [
+    { gender: "MALE", ageMin: 40, ageMax: 49, low: 0, high: 2.5, unit: "ng/mL" },
+    { gender: "MALE", ageMin: 50, ageMax: 59, low: 0, high: 3.5, unit: "ng/mL" },
+    { gender: "MALE", ageMin: 60, ageMax: 69, low: 0, high: 4.5, unit: "ng/mL" },
+    { gender: "MALE", ageMin: 70, ageMax: 120, low: 0, high: 6.5, unit: "ng/mL" },
+  ] },
+  { code: "BHCG", name: "Beta-HCG (Quantitative)", category: "Endocrinology", price: 1100, sampleType: "Blood", unit: "mIU/mL", normalRange: "<5 (non-pregnant)", tatHours: 6, description: "Pregnancy test (quantitative) & trophoblastic disease monitoring.", ranges: [{ gender: "FEMALE", low: 0, high: 5, unit: "mIU/mL", notes: "Non-pregnant reference" }] },
 ];
 
 async function main() {
-  console.log("\n=== Seeding Specialty Lab Panels ===\n");
+  console.log("\n=== Seeding Specialty Lab Panels (idempotent) ===\n");
+  resetRng();
 
-  // ─── Create/Upsert LabTest records ────────────────────
   let testsCreated = 0;
   let rangesCreated = 0;
+  let rangesSkipped = 0;
   const testIdByCode: Record<string, string> = {};
 
   for (const t of SPECIALTY_TESTS) {
     const existing = await prisma.labTest.findUnique({ where: { code: t.code } });
     if (existing) {
       testIdByCode[t.code] = existing.id;
-      continue;
+    } else {
+      const test = await prisma.labTest.create({
+        data: {
+          code: t.code,
+          name: t.name,
+          category: t.category,
+          price: t.price,
+          sampleType: t.sampleType,
+          unit: t.unit === "multi" ? null : t.unit,
+          normalRange: t.normalRange,
+          panicLow: t.panicLow,
+          panicHigh: t.panicHigh,
+          tatHours: t.tatHours,
+          description: t.description,
+        },
+      });
+      testIdByCode[t.code] = test.id;
+      testsCreated++;
     }
 
-    const test = await prisma.labTest.create({
-      data: {
-        code: t.code,
-        name: t.name,
-        category: t.category,
-        price: t.price,
-        sampleType: t.sampleType,
-        unit: t.unit === "multi" ? null : t.unit,
-        normalRange: t.normalRange,
-        panicLow: t.panicLow,
-        panicHigh: t.panicHigh,
-        tatHours: t.tatHours,
-        description: t.description,
-      },
+    // Idempotency: skip range population if any already present.
+    const existingRanges = await prisma.labTestReferenceRange.count({
+      where: { testId: testIdByCode[t.code] },
     });
-    testIdByCode[t.code] = test.id;
-    testsCreated++;
-
+    if (existingRanges > 0) {
+      rangesSkipped += t.ranges.length;
+      continue;
+    }
     for (const r of t.ranges) {
       await prisma.labTestReferenceRange.create({
         data: {
-          testId: test.id,
+          testId: testIdByCode[t.code],
           parameter: r.parameter,
           gender: r.gender,
           ageMin: r.ageMin,
@@ -243,22 +165,20 @@ async function main() {
     }
   }
 
-  // ─── Create 20 lab orders referencing these tests ─────
-  const doctors = await prisma.doctor.findMany({ take: 10 });
-  const patients = await prisma.patient.findMany({ take: 30, include: { user: true } });
+  const doctors = await prisma.doctor.findMany({ take: 10, orderBy: { id: "asc" } });
+  const patients = await prisma.patient.findMany({ take: 30, orderBy: { id: "asc" }, include: { user: true } });
   const labStaff = await prisma.user.findFirst({
     where: { role: { in: [Role.NURSE, Role.DOCTOR, Role.ADMIN] } },
+    orderBy: { id: "asc" },
   });
 
   let ordersCreated = 0;
+  let ordersSkipped = 0;
   let resultsCreated = 0;
 
   if (doctors.length === 0 || patients.length === 0 || !labStaff) {
     console.warn("  Missing doctors/patients/staff — skipping order creation");
   } else {
-    const existingOrders = await prisma.labOrder.count();
-    const orderSeqStart = existingOrders + 5000;
-
     for (let i = 0; i < 20; i++) {
       const test = randomItem(SPECIALTY_TESTS);
       const testId = testIdByCode[test.code];
@@ -269,51 +189,67 @@ async function main() {
       const daysOld = randomInt(1, 30);
       const orderedAt = daysAgo(daysOld);
 
-      // Most orders completed; some in-progress; one rejected
       let status: LabTestStatus;
-      const r = Math.random();
+      const r = rng();
       if (r < 0.7) status = LabTestStatus.COMPLETED;
       else if (r < 0.85) status = LabTestStatus.IN_PROGRESS;
       else if (r < 0.95) status = LabTestStatus.SAMPLE_COLLECTED;
       else status = LabTestStatus.SAMPLE_REJECTED;
 
-      // All statuses used here imply sample collection occurred
       const collectedAt = new Date(orderedAt.getTime() + randomInt(1, 8) * 3600_000);
       const completedAt =
         status === LabTestStatus.COMPLETED
           ? new Date(collectedAt.getTime() + test.tatHours * 3600_000)
           : null;
 
-      const orderNumber = `LAB-${new Date().getFullYear()}-${String(orderSeqStart + i).padStart(6, "0")}`;
-      const order = await prisma.labOrder.create({
-        data: {
-          orderNumber,
-          patientId: patient.id,
-          doctorId: doctor.id,
-          status,
-          orderedAt,
-          collectedAt,
-          completedAt: completedAt ?? undefined,
-          rejectedAt: status === LabTestStatus.SAMPLE_REJECTED ? collectedAt : undefined,
-          rejectionReason:
-            status === LabTestStatus.SAMPLE_REJECTED ? randomItem(["HEMOLYZED", "CLOTTED", "INSUFFICIENT_SAMPLE"]) : undefined,
-          notes: `Ordered as ${test.name} outpatient workup`,
-          items: {
-            create: [{ testId, status }],
-          },
-        },
+      // Stable seed-namespaced order number — replaces non-idempotent
+      // `LAB-YYYY-(existingOrders+5000+i)` counter that compounded re-runs.
+      const orderNumber = `LAB-SEED-PANEL-${String(i + 1).padStart(6, "0")}`;
+      const existingOrder = await prisma.labOrder.findUnique({
+        where: { orderNumber },
         include: { items: true },
       });
-      ordersCreated++;
 
-      // Generate results for COMPLETED
+      let order;
+      if (existingOrder) {
+        order = existingOrder;
+        ordersSkipped++;
+      } else {
+        order = await prisma.labOrder.create({
+          data: {
+            orderNumber,
+            patientId: patient.id,
+            doctorId: doctor.id,
+            status,
+            orderedAt,
+            collectedAt,
+            completedAt: completedAt ?? undefined,
+            rejectedAt: status === LabTestStatus.SAMPLE_REJECTED ? collectedAt : undefined,
+            rejectionReason:
+              status === LabTestStatus.SAMPLE_REJECTED ? randomItem(["HEMOLYZED", "CLOTTED", "INSUFFICIENT_SAMPLE"]) : undefined,
+            notes: `Ordered as ${test.name} outpatient workup`,
+            items: {
+              create: [{ testId, status }],
+            },
+          },
+          include: { items: true },
+        });
+        ordersCreated++;
+      }
+
       if (status === LabTestStatus.COMPLETED) {
         const item = order.items[0];
+        if (!item) continue;
+
+        const existingResultCount = await prisma.labResult.count({
+          where: { orderItemId: item.id },
+        });
+        if (existingResultCount > 0) continue;
+
         for (const range of test.ranges) {
           const low = range.low ?? 0;
           const high = range.high ?? 100;
-          // 70% normal, 20% high/low, 10% critical
-          const rv = Math.random();
+          const rv = rng();
           let value: number;
           let flag: LabResultFlag;
           if (rv < 0.7) {
@@ -349,10 +285,10 @@ async function main() {
     }
   }
 
-  console.log(`\n✔ Specialty tests created: ${testsCreated}`);
-  console.log(`✔ Reference ranges:        ${rangesCreated}`);
-  console.log(`✔ Lab orders created:      ${ordersCreated}`);
-  console.log(`✔ Lab results created:     ${resultsCreated}`);
+  console.log(`\n  Specialty tests created: ${testsCreated}`);
+  console.log(`  Reference ranges:        ${rangesCreated} new, ${rangesSkipped} skipped (already present)`);
+  console.log(`  Lab orders:              ${ordersCreated} new, ${ordersSkipped} skipped (already present)`);
+  console.log(`  Lab results created:     ${resultsCreated}`);
 }
 
 main()

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -263,8 +263,7 @@ fi
 # relative to the API/Web smoke checks above).
 #
 # Seeds NOT wired (intentionally — see chore commit body):
-#   - seed-immunization-data, seed-lab-data, seed-lab-panels (orders),
-#     seed-clinical-enhancements, seed-acute-care-enhancements,
+#   - seed-clinical-enhancements, seed-acute-care-enhancements,
 #     seed-ancillary-enhancements, seed-ipd,
 #     seed-pediatric-patients, seed-ops-enhancements,
 #     seed-phase4-{specialty,engagement,ops}
@@ -281,6 +280,11 @@ fi
 #   - seed-doctor-ratings.ts         (8q) — [seed:DR-RATE-SEED-<doctorId>-<i>] comment marker findFirst-skip on PatientFeedback
 #   - seed-complaints-data.ts        (8r) — CMP-SEED-NNNN ticketNumber findUnique (does NOT poison live CMP-YYYY-NNNNN counter)
 #   - seed-notifications-history.ts  (8s) — NOTIF-SEED-NNNN dedupKey findUnique (cannot collide with broadcast `${broadcastId}:${userId}`)
+#   - seed-immunization-data.ts      (8t) — IMMUN-SEED-NNNNNN tag in `notes` + findFirst on (patientId, vaccine, doseNumber)
+#   - seed-lab-data.ts               (8u) — LAB-SEED-NNNNNN orderNumber findUnique
+#   - seed-lab-panels.ts             (8v) — LAB-SEED-PANEL-NNNNNN orderNumber findUnique + per-test reference-range count guard
+# All share the mulberry32 PRNG idempotency strategy that seed-realistic.ts
+# pioneered — re-runs make byte-identical decisions.
 
 echo "=== 8d. Re-applying hospital identity SystemConfig seed ==="
 if DATABASE_URL="$DB_URL" npx tsx packages/db/src/seed-hospital-config.ts; then
@@ -440,6 +444,46 @@ if DATABASE_URL="$DB_URL" npx tsx packages/db/src/seed-visitors-history.ts; then
     echo "  OK — visitor history re-seeded."
 else
     echo "  WARN — seed-visitors-history failed (non-fatal). Investigate offline."
+fi
+
+# Step 8t (deploy.sh wave 2 — 2026-05-10): seed-immunization-data.ts is now
+# fully idempotent — every Immunization row is gated by a `findFirst`
+# guard on the natural tuple `(patientId, vaccine, doseNumber)` and tagged
+# with a stable `[IMMUN-SEED-NNNNNN]` marker in the `notes` field. The
+# upcoming-booster sentinel uses doseNumber=99 so it never collides with
+# the past-dose tuple. All RNG is driven by a fixed-seed mulberry32 so
+# re-runs make byte-identical decisions. Failures MUST NOT block the deploy.
+echo "=== 8t. Re-applying immunization data seed (UIP child schedule + adult vaccines) ==="
+if DATABASE_URL="$DB_URL" npx tsx packages/db/src/seed-immunization-data.ts; then
+    echo "  OK — immunization data re-seeded."
+else
+    echo "  WARN — seed-immunization-data failed (non-fatal). Investigate offline."
+fi
+
+# Step 8u (deploy.sh wave 2 — 2026-05-10): seed-lab-data.ts is now fully
+# idempotent — LabOrder.orderNumber uses stable `LAB-SEED-NNNNNN` keys
+# (gated by findUnique) instead of the previous max+1 counter that minted
+# fresh batches each run. LabResult creation is guarded by a per-orderItem
+# count check. Lab QC entries block was already idempotent. Failures MUST
+# NOT block the deploy.
+echo "=== 8u. Re-applying lab orders + results seed (61 scenarios + QC entries) ==="
+if DATABASE_URL="$DB_URL" npx tsx packages/db/src/seed-lab-data.ts; then
+    echo "  OK — lab orders + results re-seeded."
+else
+    echo "  WARN — seed-lab-data failed (non-fatal). Investigate offline."
+fi
+
+# Step 8v (deploy.sh wave 2 — 2026-05-10): seed-lab-panels.ts is now fully
+# idempotent — specialty-test orders use stable `LAB-SEED-PANEL-NNNNNN`
+# keys (replacing `LAB-${YYYY}-${existingOrders+5000+i}` which compounded
+# each re-run). LabTest upsert by `code` was already idempotent;
+# LabTestReferenceRange now uses a per-test count guard. Failures MUST NOT
+# block the deploy.
+echo "=== 8v. Re-applying specialty lab panels seed (VITD/B12/IronStudies/etc.) ==="
+if DATABASE_URL="$DB_URL" npx tsx packages/db/src/seed-lab-panels.ts; then
+    echo "  OK — specialty lab panels re-seeded."
+else
+    echo "  WARN — seed-lab-panels failed (non-fatal). Investigate offline."
 fi
 
 echo "=== Deployment complete (previous SHA recorded at /tmp/medcore-prev-sha) ==="


### PR DESCRIPTION
## Summary

Make 3 lab/immunization fixture seeds re-runnable on populated demos and wire them into `scripts/deploy.sh` auto-reseed chain (steps 8l/8m/8n). Mirrors the wave-1 pattern from `seed-realistic.ts` (commit `4554706`).

- **`seed-immunization-data.ts`** — `IMMUN-SEED-NNNNNN` tag in `notes` + `findFirst({patientId, vaccine, doseNumber})` skip-or-create. `doseNumber=99` sentinel separates upcoming-booster row from past-dose tuple.
- **`seed-lab-data.ts`** — Stable `LAB-SEED-NNNNNN` `orderNumber` (replaces non-idempotent `existingOrders+1` counter that compounded each re-run) + `findUnique` guard. `LabResult` gated by per-orderItem result count.
- **`seed-lab-panels.ts`** — Stable `LAB-SEED-PANEL-NNNNNN` `orderNumber` + `findUnique` + `LabTestReferenceRange` per-test count guard. `LabTest` upsert by `code` was already idempotent.

All three share the same `mulberry32` fixed-seed PRNG so re-runs make byte-identical decisions and the natural-key skip-or-create guards keep mapping back to the same rows.

`deploy.sh` wires all three as steps 8l/8m/8n with the wave-2 non-fatal failure policy. The wire-in does **not** touch live production sequences — the seed namespaces (`LAB-SEED-*` / `LAB-SEED-PANEL-*`) never collide with the runtime `LAB######` counter logic in `apps/api`.

## Test plan

- [ ] CI typecheck passes (no TS errors introduced — verified locally with `tsc --noEmit -p packages/db/tsconfig.json`)
- [ ] `bash -n scripts/deploy.sh` syntax-OK (verified locally)
- [ ] On the demo server: run each seed twice in a row, confirm row counts stay flat the second time
- [ ] Confirm `LabOrder` rows minted by these seeds have `orderNumber` starting with `LAB-SEED-` or `LAB-SEED-PANEL-` (never bare `LAB######`)
- [ ] Confirm `Immunization.notes` rows from this seed start with `[IMMUN-SEED-NNNNNN]`