### PR TITLE
chore(seed): 3 enhancements seeds idempotency (deploy.sh wave 4)

### DIFF
--- a/packages/db/src/seed-acute-care-enhancements.ts
+++ b/packages/db/src/seed-acute-care-enhancements.ts
@@ -1,8 +1,36 @@
 // Seed additional Acute Care module data (Apr 2026 enhancements)
 // Run: npx tsx packages/db/src/seed-acute-care-enhancements.ts
+//
+// Idempotency contract (2026-05-11): safe to re-run on a populated demo
+// without creating duplicate rows. Every top-level seeded entity gets a
+// stable namespaced key from a deterministic index:
+//   - Admission:           IPD-SEED-NNNN              (admissionNumber, @unique)
+//   - Surgery:             SRG-SEED-NNNN              (caseNumber, @unique)
+//   - EmergencyCase:       ERS-SEED-NNNN              (caseNumber, @unique)
+//   - TelemedicineSession: TEL-SEED-NNNN              (sessionNumber, @unique)
+// Child rows (NurseRound, MedicationOrder/Administration, IpdIntakeOutput,
+// UltrasoundRecord, AncVisit, GrowthRecord, Immunization) are guarded by a
+// count-vs-expected check on the parent so re-runs don't dup-write.
+// Live runtime counters (IPD###### / SRG###### / ER###### / TEL######)
+// are no longer read or written — those belong to the runtime allocator,
+// not the seed. Math.random() is replaced by a fixed-seed mulberry32 PRNG
+// so re-runs produce byte-identical decisions.
 import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();
+
+// Deterministic mulberry32 PRNG — same fixed-seed pattern as
+// seed-realistic.ts so re-runs of the partial set produce the same
+// downstream decisions.
+const SEED_RNG = 0xacc70511;
+let _rngState = SEED_RNG;
+function rng(): number {
+  _rngState |= 0;
+  _rngState = (_rngState + 0x6d2b79f5) | 0;
+  let t = Math.imul(_rngState ^ (_rngState >>> 15), 1 | _rngState);
+  t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+}
 
 function daysAgo(n: number): Date {
   return new Date(Date.now() - n * 24 * 60 * 60 * 1000);
@@ -76,15 +104,26 @@ async function main() {
   ];
 
   const createdAdmissions: { id: string; bedId: string }[] = [];
-  const countBefore = await prisma.admission.count();
-  let nextSeq = countBefore + 1;
+  let admCreated = 0;
+  let admSkipped = 0;
 
   for (let i = 0; i < admissionSpecs.length && i < availableBeds.length; i++) {
     const bed = availableBeds[i];
     const patient = patients[i % patients.length];
     const doc = doctors[i % doctors.length];
     const s = admissionSpecs[i];
-    const admissionNumber = `IPD${String(nextSeq++).padStart(6, "0")}`;
+    // Stable seed-id namespace — never touches the live IPD###### counter.
+    const admissionNumber = `IPD-SEED-${String(i + 1).padStart(4, "0")}`;
+
+    const existingAdm = await prisma.admission.findUnique({
+      where: { admissionNumber },
+      select: { id: true, bedId: true },
+    });
+    if (existingAdm) {
+      admSkipped++;
+      createdAdmissions.push({ id: existingAdm.id, bedId: existingAdm.bedId });
+      continue;
+    }
 
     const adm = await prisma.admission.create({
       data: {
@@ -105,91 +144,107 @@ async function main() {
       data: { status: "OCCUPIED" },
     });
     createdAdmissions.push({ id: adm.id, bedId: bed.id });
+    admCreated++;
 
-    // Nurse rounds (1 per day)
+    // Nurse rounds (1 per day). Child-rows are guarded by an existing-count
+    // check on the parent — if any round exists for this admission, the seed
+    // already ran successfully for it and we skip the whole block.
     if (nurses.length > 0) {
-      for (let d = s.daysAgo; d >= 0; d--) {
-        await prisma.nurseRound.create({
+      const existingRounds = await prisma.nurseRound.count({
+        where: { admissionId: adm.id },
+      });
+      if (existingRounds === 0) {
+        for (let d = s.daysAgo; d >= 0; d--) {
+          await prisma.nurseRound.create({
+            data: {
+              admissionId: adm.id,
+              nurseId: nurses[d % nurses.length].id,
+              notes:
+                d === 0
+                  ? "Patient stable, afebrile, tolerating orals."
+                  : "Morning round — vitals within normal limits, oriented.",
+              performedAt: daysAgo(d),
+            },
+          });
+        }
+      }
+    }
+
+    // Medication order + scheduled administrations — skip if any order
+    // already exists for this admission.
+    const existingOrder = await prisma.medicationOrder.findFirst({
+      where: { admissionId: adm.id },
+      select: { id: true },
+    });
+    if (!existingOrder) {
+      const order = await prisma.medicationOrder.create({
+        data: {
+          admissionId: adm.id,
+          doctorId: doc.id,
+          medicineName: i === 2 ? "Insulin (Regular)" : "Ceftriaxone 1g",
+          dosage: i === 2 ? "10 units SC" : "1g IV",
+          frequency: i === 2 ? "every 6 hours" : "BID",
+          route: i === 2 ? "SC" : "IV",
+          startDate: daysAgo(s.daysAgo),
+          isActive: true,
+        },
+      });
+
+      const interval = i === 2 ? 6 : 12;
+      const doses: Date[] = [];
+      let t = daysAgo(s.daysAgo).getTime();
+      const endMs = Date.now();
+      while (t <= endMs) {
+        doses.push(new Date(t));
+        t += interval * 60 * 60 * 1000;
+      }
+      for (let d = 0; d < doses.length; d++) {
+        const isPast = doses[d].getTime() < Date.now() - 30 * 60 * 1000;
+        await prisma.medicationAdministration.create({
           data: {
-            admissionId: adm.id,
-            nurseId: nurses[d % nurses.length].id,
-            notes:
-              d === 0
-                ? "Patient stable, afebrile, tolerating orals."
-                : "Morning round — vitals within normal limits, oriented.",
-            performedAt: daysAgo(d),
+            medicationOrderId: order.id,
+            scheduledAt: doses[d],
+            status: isPast ? "ADMINISTERED" : "SCHEDULED",
+            administeredAt: isPast ? doses[d] : null,
+            administeredBy: isPast && nurses[0] ? nurses[0].id : null,
+            notes: isPast ? "Given on time" : null,
           },
         });
       }
     }
 
-    // Medication order + scheduled administrations
-    const order = await prisma.medicationOrder.create({
-      data: {
-        admissionId: adm.id,
-        doctorId: doc.id,
-        medicineName: i === 2 ? "Insulin (Regular)" : "Ceftriaxone 1g",
-        dosage: i === 2 ? "10 units SC" : "1g IV",
-        frequency: i === 2 ? "every 6 hours" : "BID",
-        route: i === 2 ? "SC" : "IV",
-        startDate: daysAgo(s.daysAgo),
-        isActive: true,
-      },
-    });
-
-    const interval = i === 2 ? 6 : 12;
-    const doses: Date[] = [];
-    let t = daysAgo(s.daysAgo).getTime();
-    const endMs = Date.now();
-    while (t <= endMs) {
-      doses.push(new Date(t));
-      t += interval * 60 * 60 * 1000;
-    }
-    for (let d = 0; d < doses.length; d++) {
-      const isPast = doses[d].getTime() < Date.now() - 30 * 60 * 1000;
-      await prisma.medicationAdministration.create({
-        data: {
-          medicationOrderId: order.id,
-          scheduledAt: doses[d],
-          status: isPast ? "ADMINISTERED" : "SCHEDULED",
-          administeredAt: isPast ? doses[d] : null,
-          administeredBy: isPast && nurses[0] ? nurses[0].id : null,
-          notes: isPast ? "Given on time" : null,
-        },
-      });
-    }
-
-    // I/O records (last 24h)
+    // I/O records (last 24h) — skip if any record exists for this admission.
     if (nurses.length > 0) {
-      const ioSpecs: Array<{
-        type:
-          | "INTAKE_ORAL"
-          | "INTAKE_IV"
-          | "OUTPUT_URINE"
-          | "OUTPUT_STOOL";
-        amountMl: number;
-        hoursBack: number;
-        description?: string;
-      }> = [
-        { type: "INTAKE_IV", amountMl: 500, hoursBack: 20, description: "Normal saline" },
-        { type: "INTAKE_ORAL", amountMl: 150, hoursBack: 18 },
-        { type: "OUTPUT_URINE", amountMl: 300, hoursBack: 16 },
-        { type: "INTAKE_IV", amountMl: 500, hoursBack: 12, description: "RL" },
-        { type: "OUTPUT_URINE", amountMl: 400, hoursBack: 8 },
-        { type: "INTAKE_ORAL", amountMl: 200, hoursBack: 4 },
-        { type: "OUTPUT_URINE", amountMl: 250, hoursBack: 2 },
-      ];
-      for (const io of ioSpecs) {
-        await prisma.ipdIntakeOutput.create({
-          data: {
-            admissionId: adm.id,
-            type: io.type,
-            amountMl: io.amountMl,
-            description: io.description,
-            recordedAt: hoursAgo(io.hoursBack),
-            recordedBy: nurses[0].id,
-          },
-        });
+      const existingIO = await prisma.ipdIntakeOutput.count({
+        where: { admissionId: adm.id },
+      });
+      if (existingIO === 0) {
+        const ioSpecs: Array<{
+          type: "INTAKE_ORAL" | "INTAKE_IV" | "OUTPUT_URINE" | "OUTPUT_STOOL";
+          amountMl: number;
+          hoursBack: number;
+          description?: string;
+        }> = [
+          { type: "INTAKE_IV", amountMl: 500, hoursBack: 20, description: "Normal saline" },
+          { type: "INTAKE_ORAL", amountMl: 150, hoursBack: 18 },
+          { type: "OUTPUT_URINE", amountMl: 300, hoursBack: 16 },
+          { type: "INTAKE_IV", amountMl: 500, hoursBack: 12, description: "RL" },
+          { type: "OUTPUT_URINE", amountMl: 400, hoursBack: 8 },
+          { type: "INTAKE_ORAL", amountMl: 200, hoursBack: 4 },
+          { type: "OUTPUT_URINE", amountMl: 250, hoursBack: 2 },
+        ];
+        for (const io of ioSpecs) {
+          await prisma.ipdIntakeOutput.create({
+            data: {
+              admissionId: adm.id,
+              type: io.type,
+              amountMl: io.amountMl,
+              description: io.description,
+              recordedAt: hoursAgo(io.hoursBack),
+              recordedBy: nurses[0].id,
+            },
+          });
+        }
       }
     }
 
@@ -201,7 +256,9 @@ async function main() {
       data: { totalBillAmount: bill },
     });
   }
-  console.log(`  Created ${createdAdmissions.length} additional admissions`);
+  console.log(
+    `  Admissions: ${admCreated} created, ${admSkipped} skipped (already present).`,
+  );
 
   // ─── 2. Surgeries with pre-op / complications ────────
   console.log("\nSeeding surgeries with enhancements...");
@@ -243,15 +300,24 @@ async function main() {
     },
   ];
 
-  const surgeryCountBefore = await prisma.surgery.count();
-  let srgSeq = surgeryCountBefore + 1;
-
+  let srgCreated = 0;
+  let srgSkipped = 0;
   for (let i = 0; i < surgerySpecs.length; i++) {
     const s = surgerySpecs[i];
     const patient = patients[i % patients.length];
     const surgeon = doctors[i % doctors.length];
     const ot = ots[i % ots.length];
-    const caseNumber = `SRG${String(srgSeq++).padStart(6, "0")}`;
+    // Stable seed-id namespace — never touches the live SRG###### counter.
+    const caseNumber = `SRG-SEED-${String(i + 1).padStart(4, "0")}`;
+
+    const existingSurgery = await prisma.surgery.findUnique({
+      where: { caseNumber },
+      select: { id: true },
+    });
+    if (existingSurgery) {
+      srgSkipped++;
+      continue;
+    }
     const scheduledAt = daysAgo(s.daysAgo);
     const startAt = new Date(scheduledAt.getTime() + 30 * 60 * 1000);
     const endAt = new Date(startAt.getTime() + s.duration * 60 * 1000);
@@ -292,13 +358,14 @@ async function main() {
         cost: 45000 + i * 5000,
       },
     });
+    srgCreated++;
   }
-  console.log(`  Created ${surgerySpecs.length} surgery cases`);
+  console.log(
+    `  Surgeries: ${srgCreated} created, ${srgSkipped} skipped (already present).`,
+  );
 
   // ─── 3. ER Cases at various triage levels ─────────────
   console.log("\nSeeding ER cases...");
-  const erCountBefore = await prisma.emergencyCase.count();
-  let erSeq = erCountBefore + 1;
 
   const erSpecs: Array<{
     chiefComplaint: string;
@@ -382,8 +449,21 @@ async function main() {
     },
   ];
 
-  for (const e of erSpecs) {
-    const caseNumber = `ER${String(erSeq++).padStart(6, "0")}`;
+  let erCreated = 0;
+  let erSkipped = 0;
+  for (let i = 0; i < erSpecs.length; i++) {
+    const e = erSpecs[i];
+    // Stable seed-id namespace — never touches the live ER###### counter.
+    const caseNumber = `ERS-SEED-${String(i + 1).padStart(4, "0")}`;
+
+    const existingER = await prisma.emergencyCase.findUnique({
+      where: { caseNumber },
+      select: { id: true },
+    });
+    if (existingER) {
+      erSkipped++;
+      continue;
+    }
     const arrivedAt = hoursAgo(e.hoursAgo);
     const patient =
       e.patientIdx != null ? patients[e.patientIdx % patients.length] : null;
@@ -426,13 +506,14 @@ async function main() {
           : null,
       },
     });
+    erCreated++;
   }
-  console.log(`  Created ${erSpecs.length} ER cases`);
+  console.log(
+    `  ER cases: ${erCreated} created, ${erSkipped} skipped (already present).`,
+  );
 
   // ─── 4. Past Telemedicine Sessions with ratings ─────
   console.log("\nSeeding telemedicine sessions...");
-  const telCountBefore = await prisma.telemedicineSession.count();
-  let telSeq = telCountBefore + 1;
 
   const telSpecs = [
     {
@@ -477,11 +558,25 @@ async function main() {
     },
   ];
 
-  for (const t of telSpecs) {
-    const sessionNumber = `TEL${String(telSeq++).padStart(6, "0")}`;
+  let telCreated = 0;
+  let telSkipped = 0;
+  for (let i = 0; i < telSpecs.length; i++) {
+    const t = telSpecs[i];
+    // Stable seed-id namespace — never touches the live TEL###### counter.
+    const sessionNumber = `TEL-SEED-${String(i + 1).padStart(4, "0")}`;
+
+    const existingTel = await prisma.telemedicineSession.findUnique({
+      where: { sessionNumber },
+      select: { id: true },
+    });
+    if (existingTel) {
+      telSkipped++;
+      continue;
+    }
     const scheduled = daysAgo(t.daysAgo);
     const started = new Date(scheduled.getTime() + 2 * 60 * 1000);
     const ended = new Date(started.getTime() + t.duration * 60 * 1000);
+    const meetingTag = `seed-${String(i + 1).padStart(4, "0")}`;
     await prisma.telemedicineSession.create({
       data: {
         sessionNumber,
@@ -491,8 +586,8 @@ async function main() {
         startedAt: started,
         endedAt: ended,
         durationMin: t.duration,
-        meetingId: `mtg${telSeq}`,
-        meetingUrl: `https://meet.jit.si/medcore-seed-${telSeq}`,
+        meetingId: `mtg-${meetingTag}`,
+        meetingUrl: `https://meet.jit.si/medcore-${meetingTag}`,
         status: "COMPLETED",
         chiefComplaint: t.complaint,
         doctorNotes: t.notes,
@@ -503,8 +598,11 @@ async function main() {
         patientJoinedAt: new Date(scheduled.getTime() - 5 * 60 * 1000),
       },
     });
+    telCreated++;
   }
-  console.log(`  Created ${telSpecs.length} telemedicine sessions`);
+  console.log(
+    `  Telemedicine sessions: ${telCreated} created, ${telSkipped} skipped (already present).`,
+  );
 
   // ─── 5. ANC Enhancements — visits + USG ───────────────
   console.log("\nSeeding ANC enhancements...");

--- a/packages/db/src/seed-ancillary-enhancements.ts
+++ b/packages/db/src/seed-ancillary-enhancements.ts
@@ -8,11 +8,40 @@
  *  - Asset warranty/AMC + maintenance + calibration data
  *
  * Run: tsx packages/db/src/seed-ancillary-enhancements.ts
+ *
+ * Idempotency contract (2026-05-11): safe to re-run on a populated demo
+ * without creating duplicate rows.
+ *   - LabTest, LabTestReferenceRange, InventoryItem(@@unique medicineId+batchNumber),
+ *     DrugInteraction(@@unique drugA+drugB), BloodScreening(donationId @unique),
+ *     LabResult(per orderItemId) already guarded via findUnique/findFirst.
+ *   - AmbulanceTrip: now uses stable namespaced tripNumber
+ *     `TRP-SEED-NNNN` (was reading the live TRP###### counter — removed).
+ *   - AmbulanceFuelLog and BloodTemperatureLog (no natural unique key): we
+ *     skip the section entirely if any fuel log / temperature log already
+ *     exists for that ambulance / location (so re-runs are no-ops).
+ *   - AssetMaintenance (no natural unique key): skip per-asset if any
+ *     maintenance log already exists for that asset.
+ *   - Math.random() replaced by fixed-seed mulberry32 PRNG so re-runs
+ *     produce byte-identical decisions.
  */
 
 import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();
+
+// Deterministic mulberry32 PRNG — same fixed-seed pattern as
+// seed-realistic.ts so re-runs of the partial set produce the same
+// downstream decisions for which lab values are abnormal / critical,
+// which donations fail screening, ambulance fuel litres, etc.
+const SEED_RNG = 0xa5c11051;
+let _rngState = SEED_RNG;
+function rng(): number {
+  _rngState |= 0;
+  _rngState = (_rngState + 0x6d2b79f5) | 0;
+  let t = Math.imul(_rngState ^ (_rngState >>> 15), 1 | _rngState);
+  t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+}
 
 function daysFromNow(days: number): Date {
   return new Date(Date.now() + days * 24 * 3600 * 1000);
@@ -251,9 +280,9 @@ async function seedLab() {
       let flag: "NORMAL" | "LOW" | "HIGH" | "CRITICAL" = "NORMAL";
       let normalRange = item.test.normalRange || "";
 
-      // Inject a mix of normal/abnormal
-      const abnormal = Math.random() < 0.4;
-      const critical = Math.random() < 0.1;
+      // Inject a mix of normal/abnormal — deterministic via mulberry32.
+      const abnormal = rng() < 0.4;
+      const critical = rng() < 0.1;
       switch (code) {
         case "RBS":
           value = critical ? "38" : abnormal ? "210" : "98";
@@ -346,9 +375,9 @@ async function seedPharmacy() {
       data: {
         medicineId: m.id,
         batchNumber,
-        quantity: 50 + Math.floor(Math.random() * 300),
-        unitCost: parseFloat((5 + Math.random() * 95).toFixed(2)),
-        sellingPrice: parseFloat((10 + Math.random() * 140).toFixed(2)),
+        quantity: 50 + Math.floor(rng() * 300),
+        unitCost: parseFloat((5 + rng() * 95).toFixed(2)),
+        sellingPrice: parseFloat((10 + rng() * 140).toFixed(2)),
         expiryDate: daysFromNow(180 + i * 30),
         reorderLevel: 25,
         reorderQuantity: 100,
@@ -457,15 +486,16 @@ async function seedBloodBank() {
       where: { donationId: d.id },
     });
     if (exists) continue;
-    // 90% pass, 10% random positive
-    const fail = Math.random() < 0.1;
-    const positive = () => (Math.random() < 0.5 ? "POSITIVE" : "INDETERMINATE");
+    // 90% pass, 10% deterministic-positive — driven by mulberry32 so re-runs
+    // produce byte-identical screening verdicts.
+    const fail = rng() < 0.1;
+    const positive = () => (rng() < 0.5 ? "POSITIVE" : "INDETERMINATE");
     await prisma.bloodScreening.create({
       data: {
         donationId: d.id,
         hivResult: fail ? positive() : "NEGATIVE",
         hcvResult: "NEGATIVE",
-        hbsAgResult: fail && Math.random() > 0.5 ? positive() : "NEGATIVE",
+        hbsAgResult: fail && rng() > 0.5 ? positive() : "NEGATIVE",
         syphilisResult: "NEGATIVE",
         malariaResult: "NEGATIVE",
         bloodGrouping: "Confirmed",
@@ -477,13 +507,27 @@ async function seedBloodBank() {
     screens++;
   }
 
-  // Temperature log entries
+  // Temperature log entries — BloodTemperatureLog has no natural unique
+  // key. We skip the section per-location if any log already exists for
+  // that location, so re-runs are no-ops without duping rows.
   const locations = ["Fridge A (RBC)", "Fridge B (RBC)", "Freezer Plasma-1"];
   let temps = 0;
+  let tempsSkipped = 0;
   for (const loc of locations) {
+    const existingTempCount = await prisma.bloodTemperatureLog.count({
+      where: { location: loc },
+    });
+    if (existingTempCount > 0) {
+      tempsSkipped++;
+      // Burn 15 rng rolls (5 iters * 3 rolls each) to keep downstream
+      // decisions aligned with the original run when only some locations
+      // were inserted.
+      for (let k = 0; k < 5 * 3; k++) rng();
+      continue;
+    }
     for (let i = 0; i < 5; i++) {
       const base = loc.includes("Freezer") ? -30 : 4;
-      const variance = (Math.random() - 0.5) * 3;
+      const variance = (rng() - 0.5) * 3;
       const temp = base + variance;
       const inRange = loc.includes("Freezer") ? temp <= -18 : temp >= 2 && temp <= 6;
       await prisma.bloodTemperatureLog.create({
@@ -499,7 +543,9 @@ async function seedBloodBank() {
     }
   }
 
-  console.log(`  ✓ ${screens} screenings + ${temps} temperature logs`);
+  console.log(
+    `  ✓ ${screens} screenings + ${temps} temperature logs (skipped ${tempsSkipped} locations already populated)`,
+  );
 }
 
 async function seedAmbulance() {
@@ -512,17 +558,28 @@ async function seedAmbulance() {
     return;
   }
 
-  // Fuel logs
+  // Fuel logs — AmbulanceFuelLog has no natural unique key. Skip the
+  // 3-row insert per ambulance if any fuel log already exists for it.
   let fuels = 0;
+  let fuelsSkipped = 0;
   for (const amb of ambulances) {
+    const existingFuel = await prisma.ambulanceFuelLog.count({
+      where: { ambulanceId: amb.id },
+    });
+    if (existingFuel > 0) {
+      fuelsSkipped++;
+      // Burn 6 rng rolls (3 iters * 2 rolls each) to keep alignment.
+      for (let k = 0; k < 3 * 2; k++) rng();
+      continue;
+    }
     for (let i = 0; i < 3; i++) {
-      const litres = 20 + Math.random() * 30;
+      const litres = 20 + rng() * 30;
       await prisma.ambulanceFuelLog.create({
         data: {
           ambulanceId: amb.id,
           litres: Math.round(litres * 10) / 10,
           costTotal: Math.round(litres * 100 * 100) / 100,
-          odometerKm: 10000 + Math.floor(Math.random() * 20000),
+          odometerKm: 10000 + Math.floor(rng() * 20000),
           stationName: ["HP", "IOC", "Shell", "BP"][i % 4],
           filledAt: daysAgo(i * 7),
           filledBy: anyUser.id,
@@ -532,20 +589,23 @@ async function seedAmbulance() {
     }
   }
 
-  // Extra trips (completed + in-progress)
-  const last = await prisma.ambulanceTrip.findFirst({
-    orderBy: { createdAt: "desc" },
-    select: { tripNumber: true },
-  });
-  let nextN = 1;
-  if (last?.tripNumber) {
-    const m = last.tripNumber.match(/TRP(\d+)/);
-    if (m) nextN = parseInt(m[1]) + 1;
-  }
-
+  // Extra trips — stable seed-id namespace via TRP-SEED-NNNN, never
+  // touches the live TRP###### counter (used by runtime allocator).
   let trips = 0;
+  let tripsSkipped = 0;
   for (let i = 0; i < 5; i++) {
-    const tripNumber = "TRP" + String(nextN + i).padStart(6, "0");
+    const tripNumber = `TRP-SEED-${String(i + 1).padStart(4, "0")}`;
+    const existingTrip = await prisma.ambulanceTrip.findUnique({
+      where: { tripNumber },
+      select: { id: true },
+    });
+    if (existingTrip) {
+      tripsSkipped++;
+      // Burn 4 rng rolls (pickupLat, pickupLng, distanceKm, cost) to
+      // keep downstream alignment.
+      for (let k = 0; k < 4; k++) rng();
+      continue;
+    }
     const amb = ambulances[i % ambulances.length];
     const isCompleted = i < 3;
     await prisma.ambulanceTrip.create({
@@ -561,12 +621,12 @@ async function seedAmbulance() {
           "Malad West",
           "Kurla Station",
         ][i],
-        pickupLat: 19.0 + Math.random() * 0.2,
-        pickupLng: 72.8 + Math.random() * 0.2,
+        pickupLat: 19.0 + rng() * 0.2,
+        pickupLng: 72.8 + rng() * 0.2,
         dropAddress: "MedCore Hospital, Main Campus",
         dropLat: 19.12,
         dropLng: 72.86,
-        distanceKm: isCompleted ? 5 + Math.random() * 20 : null,
+        distanceKm: isCompleted ? 5 + rng() * 20 : null,
         chiefComplaint: ["Chest pain", "Trauma - RTA", "Breathing difficulty", "Pregnancy labor", "Fever + seizure"][i],
         priority: ["RED", "RED", "YELLOW", "YELLOW", "GREEN"][i],
         equipmentChecked: true,
@@ -576,13 +636,15 @@ async function seedAmbulance() {
         arrivedAt: isCompleted ? daysAgo(i) : null,
         completedAt: isCompleted ? daysAgo(i) : null,
         status: isCompleted ? "COMPLETED" : "EN_ROUTE_HOSPITAL",
-        cost: isCompleted ? 1500 + Math.random() * 1500 : null,
+        cost: isCompleted ? 1500 + rng() * 1500 : null,
       },
     });
     trips++;
   }
 
-  console.log(`  ✓ ${fuels} fuel logs + ${trips} extra trips`);
+  console.log(
+    `  ✓ ${fuels} fuel logs (skipped ${fuelsSkipped} ambulances) + ${trips} extra trips (skipped ${tripsSkipped} already present)`,
+  );
 }
 
 async function seedAssets() {
@@ -620,10 +682,20 @@ async function seedAssets() {
     updated++;
   }
 
-  // Maintenance logs with next-due-dates on first 5 assets
+  // Maintenance logs with next-due-dates on first 5 assets.
+  // AssetMaintenance has no natural unique key — skip per-asset if any
+  // maintenance log already exists for it.
   let maintLogs = 0;
+  let maintSkipped = 0;
   for (let i = 0; i < Math.min(5, assets.length); i++) {
     const a = assets[i];
+    const existingMaint = await prisma.assetMaintenance.count({
+      where: { assetId: a.id },
+    });
+    if (existingMaint > 0) {
+      maintSkipped++;
+      continue;
+    }
     const types = ["SCHEDULED", "INSPECTION", "CALIBRATION"] as const;
     await prisma.assetMaintenance.create({
       data: {
@@ -643,7 +715,9 @@ async function seedAssets() {
     maintLogs++;
   }
 
-  console.log(`  ✓ ${updated} assets enriched + ${maintLogs} maintenance logs`);
+  console.log(
+    `  ✓ ${updated} assets enriched + ${maintLogs} maintenance logs (skipped ${maintSkipped} assets already populated)`,
+  );
 }
 
 async function main() {

--- a/packages/db/src/seed-clinical-enhancements.ts
+++ b/packages/db/src/seed-clinical-enhancements.ts
@@ -9,6 +9,16 @@
  * Creates follow-up appointment reminders & immunization reminders.
  *
  * Run AFTER seed-realistic so there are patients to enrich.
+ *
+ * Idempotency contract (2026-05-11): safe to re-run on a populated demo
+ * without creating duplicate rows.
+ *   - Icd10Code, PrescriptionTemplate: already upserted on natural keys.
+ *   - Patient demographic enrichment: keyed on Patient.id with stable
+ *     per-row payload (no Math.random()), so re-runs idempotent.
+ *   - Notification rows (follow-up + immunization reminders) get a
+ *     stable dedupKey of the form `CLINENH-SEED-<kind>-<NNNN>` and we
+ *     skip-if-exists via findUnique on the @@unique dedupKey field
+ *     before .create.
  */
 import { PrismaClient } from "@prisma/client";
 
@@ -453,6 +463,8 @@ async function main() {
   console.log(`  Enriched ${enriched} patients.`);
 
   // ─── 4. Follow-up reminders (notifications) for patients with upcoming follow-up dates ──
+  // Idempotency: each row gets a stable dedupKey "CLINENH-SEED-FOLLOWUP-NNNN"
+  // gated by findUnique on the @@unique(dedupKey) field.
   console.log(`\nCreating follow-up reminders...`);
   const today = new Date();
   today.setHours(0, 0, 0, 0);
@@ -466,10 +478,22 @@ async function main() {
       patient: { include: { user: { select: { id: true, name: true } } } },
       doctor: { include: { user: { select: { name: true } } } },
     },
+    orderBy: { id: "asc" },
     take: 50,
   });
   let followUpCount = 0;
-  for (const rx of upcomingFollowUps) {
+  let followUpSkipped = 0;
+  for (let i = 0; i < upcomingFollowUps.length; i++) {
+    const rx = upcomingFollowUps[i];
+    const dedupKey = `CLINENH-SEED-FOLLOWUP-${String(i + 1).padStart(4, "0")}`;
+    const existing = await prisma.notification.findUnique({
+      where: { dedupKey },
+      select: { id: true },
+    });
+    if (existing) {
+      followUpSkipped += 1;
+      continue;
+    }
     await prisma.notification.create({
       data: {
         userId: rx.patient.user.id,
@@ -481,13 +505,17 @@ async function main() {
         } is due on ${rx.followUpDate!.toISOString().split("T")[0]}.`,
         data: { prescriptionId: rx.id } as any,
         sentAt: new Date(),
+        dedupKey,
       },
     });
     followUpCount += 1;
   }
-  console.log(`  Created ${followUpCount} follow-up reminders.`);
+  console.log(
+    `  Created ${followUpCount} follow-up reminders (skipped ${followUpSkipped} pre-existing).`,
+  );
 
   // ─── 5. Immunization reminders for pediatric patients ───
+  // Idempotency: each row gets a stable dedupKey "CLINENH-SEED-IMMUN-NNNN".
   console.log(`\nCreating pediatric immunization reminders...`);
   const children = await prisma.patient.findMany({
     where: {
@@ -496,11 +524,23 @@ async function main() {
       },
     },
     include: { user: { select: { id: true, name: true } } },
+    orderBy: { id: "asc" },
     take: 30,
   });
   let pedReminders = 0;
-  for (const child of children) {
+  let pedSkipped = 0;
+  for (let i = 0; i < children.length; i++) {
+    const child = children[i];
     if (!child.dateOfBirth) continue;
+    const dedupKey = `CLINENH-SEED-IMMUN-${String(i + 1).padStart(4, "0")}`;
+    const existing = await prisma.notification.findUnique({
+      where: { dedupKey },
+      select: { id: true },
+    });
+    if (existing) {
+      pedSkipped += 1;
+      continue;
+    }
     // Queue one reminder per child for the next DPT/MMR/etc due
     await prisma.notification.create({
       data: {
@@ -511,11 +551,14 @@ async function main() {
         message: `Hi ${child.user.name}, please check your immunization schedule. We'll share the next due vaccines at your upcoming visit.`,
         data: { kind: "immunization-reminder" } as any,
         sentAt: new Date(),
+        dedupKey,
       },
     });
     pedReminders += 1;
   }
-  console.log(`  Created ${pedReminders} pediatric immunization reminders.`);
+  console.log(
+    `  Created ${pedReminders} pediatric immunization reminders (skipped ${pedSkipped} pre-existing).`,
+  );
 
   console.log("\n=== Clinical Enhancements seed complete ===");
 }


### PR DESCRIPTION
## Summary

Make 3 enhancements seeds idempotent so they can later be wired into `scripts/deploy.sh` auto-reseed chain. Mirrors the pattern from `seed-realistic.ts` (commit `4554706`), `seed-controlled-register.ts`, and yesterday's wave-2 PRs (#768 / #769 / #770 / #771).

**This PR does NOT touch `scripts/deploy.sh`** — the orchestrator wires all 3 lanes' seeds into deploy.sh in a single commit AFTER all 3 PRs merge, to avoid the merge-conflict storm from yesterday.

### `seed-clinical-enhancements.ts`
- `Icd10Code` and `PrescriptionTemplate` were already upserted on natural keys.
- Patient demographic enrichment was already idempotent (keyed on `Patient.id`, deterministic per-row payload, no `Math.random()`).
- NEW guard: follow-up `Notification` rows now stamp `dedupKey = "CLINENH-SEED-FOLLOWUP-NNNN"` and check `findUnique({ where: { dedupKey } })` before `.create`. The dedupKey column is `@@unique` on the schema.
- NEW guard: pediatric immunization `Notification` rows now stamp `dedupKey = "CLINENH-SEED-IMMUN-NNNN"` with the same `findUnique` guard.
- Both Patient and Prescription queries gained `orderBy: { id: "asc" }` so the deterministic index to dedupKey mapping is stable across runs.

### `seed-acute-care-enhancements.ts`
Stable seed-id namespaces (all `@unique`):
- `Admission.admissionNumber` -> `IPD-SEED-NNNN`
- `Surgery.caseNumber` -> `SRG-SEED-NNNN`
- `EmergencyCase.caseNumber` -> `ERS-SEED-NNNN`
- `TelemedicineSession.sessionNumber` -> `TEL-SEED-NNNN`

Removed live counter touches: the old code did `prisma.<model>.count() + 1` to produce sequential `IPD######` / `SRG######` / `ER######` / `TEL######` numbers, which collided with the runtime allocator's counter. Replaced with per-spec deterministic index.

Each top-level row gated by `findUnique` on its `@unique` business key before `.create`. Child rows (NurseRound, MedicationOrder/Administration, IpdIntakeOutput) guarded by a count-check on the parent admission. ANC/Growth/Immunization sections were already idempotent via count-vs-expected pattern.

Mulberry32 fixed-seed PRNG added (`SEED_RNG = 0xacc70511`) — currently no `Math.random()` calls in this file, but the scaffold is in place if future enrichments add randomness.

### `seed-ancillary-enhancements.ts`
- `LabTest`, `LabTestReferenceRange`, `InventoryItem` (`@@unique([medicineId, batchNumber])`), `DrugInteraction` (`@@unique([drugAId, drugBId])`), `BloodScreening` (`donationId @unique`), `LabResult` (count-per-orderItemId) were already guarded.
- NEW guard: `AmbulanceTrip.tripNumber` now uses `TRP-SEED-NNNN` (was reading the live `TRP######` counter — removed).
- NEW guard: `AmbulanceFuelLog`, `BloodTemperatureLog`, `AssetMaintenance` have no natural unique key — skip the inner loop entirely if any row already exists for the parent (ambulance / location / asset). Re-runs are no-ops without duping rows.
- PRNG swap: all `Math.random()` calls replaced by mulberry32 (`SEED_RNG = 0xa5c11051`) — drives lab-value abnormal/critical decisions, ambulance fuel litres, screening verdicts, etc. Re-runs produce byte-identical decisions.
- When skipping a block, we burn the equivalent number of `rng()` rolls so downstream decisions stay aligned with the original run (partial-run recovery pattern from `seed-chat-conversations.ts`).

## Test plan

- [x] `npx tsc --noEmit -p packages/db/tsconfig.json` — only pre-existing `seed-phase4-ops.ts` lane-conflict errors remain; my 3 files compile clean.
- [ ] On the demo server: `DATABASE_URL=... npx tsx packages/db/src/seed-clinical-enhancements.ts` twice — second run reports `0 created, N skipped`.
- [ ] Same for `seed-acute-care-enhancements.ts` (admissions, surgeries, ER cases, telemedicine sessions).
- [ ] Same for `seed-ancillary-enhancements.ts` (inventory, blood screenings, ambulance trips, asset maintenance).
- [ ] Grep confirms no remaining `Math.random()` in the 3 files.
- [ ] Grep confirms `*-SEED-*` namespaced ids are the only IPD/SRG/ER/TEL/TRP-prefixed string literals in the 3 files.

## Notes
- Lanes B + C are working on OTHER seeds in parallel (`seed-ipd.ts`, `seed-pediatric-patients.ts`, `seed-ops-enhancements.ts`, `seed-phase4-*.ts`) — this PR does NOT touch those.
- `scripts/deploy.sh` will be updated by the orchestrator in a single follow-up commit AFTER all 3 wave-4 PRs merge, to dodge the merge-conflict storm we hit in wave 2.
- Found no structural rework needed — every section maps cleanly to either (a) findUnique-then-create on an existing `@unique` field, (b) findUnique-then-create on the existing `Notification.dedupKey @@unique` field, or (c) count-check-on-parent for child rows with no natural unique. **DO NOT MERGE — leave open for the orchestrator.**