### PR TITLE
chore(seed): phase4 trio idempotency (deploy.sh wave 4)

### DIFF
--- a/packages/db/src/seed-phase4-engagement.ts
+++ b/packages/db/src/seed-phase4-engagement.ts
@@ -1,3 +1,46 @@
+/**
+ * Phase 4 engagement seed — patient feedback, complaints, internal chat,
+ * and visitor passes.
+ *
+ * Idempotency contract (2026-05-11): safe to re-run on a populated demo
+ * without creating duplicates AND without wiping user-created rows. The
+ * pre-2026-05-11 version called `deleteMany({})` (unscoped) on
+ * PatientFeedback, Complaint, ChatRoom/ChatParticipant/ChatMessage, and
+ * Visitor — which would have nuked every real-tenant row of those tables
+ * on every deploy. All four `deleteMany` calls have been removed and
+ * replaced with stable-id / deterministic-anchor guards.
+ *
+ *   - PatientFeedback (no natural unique): per-iteration anchor is the
+ *     triple `(patientId, category, submittedAt)`. Each of the 20 seed
+ *     entries gets a deterministic `submittedAt` derived from its index
+ *     (no longer `daysAgo(randomInt(0, 90))`) — see DAYS_AGO_BY_IDX
+ *     below. findFirst on that triple skip-or-creates.
+ *   - Complaint: stable seed-namespaced ticketNumber `CMP-PH4-SEED-<NNNN>`
+ *     (1..5) — distinct from both the live counter (`CMP000001..`) and
+ *     from `seed-complaints-data.ts`'s `CMP-SEED-<NNNN>`. Skip-or-create
+ *     via `findUnique({ where: { ticketNumber } })`.
+ *   - ChatRoom (group): natural anchor is `(name, isGroup, createdBy)`
+ *     for the two named group rooms ("Doctors Channel", "Nursing Team").
+ *     For the 1-on-1 direct room (no name), anchor is membership-by-both-
+ *     userIds via findFirst on the participants relation.
+ *   - ChatParticipant: `upsert({ where: { roomId_userId } })` — leverages
+ *     the existing @@unique([roomId, userId]).
+ *   - ChatMessage: seed-tag prefix `[PH4-ENG-CHAT-SEED-<roomKey>-<NNNN>]`
+ *     embedded at the start of the content column. Re-runs do
+ *     findFirst({ where: { roomId, content: { startsWith } } }) and skip
+ *     if present (same pattern as seed-chat-conversations.ts wave 2).
+ *   - Visitor: stable seed-namespaced passNumber `VIS-PH4-SEED-<NNNN>`
+ *     (1..8) — distinct from both the live passNumber counter and from
+ *     `seed-visitors-history.ts`'s `VIS-HIST-SEED-<NNNN>`. Skip-or-create
+ *     via `findUnique({ where: { passNumber } })`.
+ *
+ * Math.random() is replaced by a deterministic mulberry32 PRNG so partial-
+ * run recovery stays byte-identical.
+ *
+ * Wired into `scripts/deploy.sh` by the orchestrator (separate commit).
+ * Failures are non-fatal (matches the policy of every other deploy-time
+ * fixture seed).
+ */
 import {
   PrismaClient,
   FeedbackCategory,
@@ -8,17 +51,35 @@ import {
 
 const prisma = new PrismaClient();
 
+// ─── DETERMINISTIC RNG ──────────────────────────────────
+// mulberry32 — same fixed-seed pattern as seed-realistic.ts /
+// seed-chat-conversations.ts. Re-runs against a populated DB pick the
+// same patient for each feedback slot, same comment-bucket for each
+// rating, same purpose for each visitor, etc.
+const SEED_RNG = 0xeb1a2042;
+let _rngState = SEED_RNG;
+function rng(): number {
+  _rngState |= 0;
+  _rngState = (_rngState + 0x6D2B79F5) | 0;
+  let t = Math.imul(_rngState ^ (_rngState >>> 15), 1 | _rngState);
+  t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+}
+
 function randomItem<T>(arr: T[]): T {
-  return arr[Math.floor(Math.random() * arr.length)];
+  return arr[Math.floor(rng() * arr.length)];
 }
 
 function randomInt(min: number, max: number) {
-  return Math.floor(Math.random() * (max - min + 1)) + min;
+  return Math.floor(rng() * (max - min + 1)) + min;
 }
 
 function daysAgo(n: number) {
   const d = new Date();
   d.setDate(d.getDate() - n);
+  // Normalize to UTC midnight so re-runs at different times of day still
+  // hit the same row via the (patientId, category, submittedAt) anchor.
+  d.setUTCHours(0, 0, 0, 0);
   return d;
 }
 
@@ -27,6 +88,15 @@ function hoursAgo(n: number) {
   d.setHours(d.getHours() - n);
   return d;
 }
+
+// Stable per-index "days ago" anchors for the 20 PatientFeedback rows.
+// Pre-2026-05-11 this was `daysAgo(randomInt(0, 90))` which made the
+// submittedAt non-deterministic — re-runs would not find the previous
+// row via (patientId, category, submittedAt) and would duplicate.
+const FEEDBACK_DAYS_AGO_BY_IDX = [
+  0, 3, 7, 12, 18, 22, 28, 33, 40, 46,
+  52, 58, 63, 67, 72, 77, 81, 85, 88, 90,
+];
 
 async function main() {
   console.log("=== Seeding Phase 4 Engagement data ===\n");
@@ -70,13 +140,32 @@ async function main() {
     "Billing took forever and was confusing.",
   ];
 
-  await prisma.patientFeedback.deleteMany({});
-
+  // Pre-2026-05-11: `await prisma.patientFeedback.deleteMany({})` —
+  // wiped EVERY feedback row in the DB. Removed; replaced with the
+  // per-row (patientId, category, submittedAt) skip-or-create guard
+  // below.
+  let feedbackCreated = 0;
+  let feedbackSkipped = 0;
   for (let i = 0; i < 20; i++) {
     const patient = patients[i % patients.length];
     const category = categories[i % categories.length];
-    // Mostly 4-5, some 2-3
-    const rating = Math.random() < 0.75 ? randomInt(4, 5) : randomInt(2, 3);
+    const submittedAt = daysAgo(FEEDBACK_DAYS_AGO_BY_IDX[i]);
+
+    const existing = await prisma.patientFeedback.findFirst({
+      where: { patientId: patient.id, category, submittedAt },
+    });
+    if (existing) {
+      // Burn rng rolls so downstream decisions stay aligned with the
+      // original seeded run when only some rows were inserted.
+      rng(); // rating bucket roll
+      rng(); // rating numeric roll
+      if (category === "OVERALL") rng(); // nps roll
+      rng(); // comment roll
+      feedbackSkipped++;
+      continue;
+    }
+
+    const rating = rng() < 0.75 ? randomInt(4, 5) : randomInt(2, 3);
     const nps =
       category === "OVERALL"
         ? rating >= 4
@@ -99,15 +188,18 @@ async function main() {
         rating,
         nps: nps ?? null,
         comment: comment ?? null,
-        submittedAt: daysAgo(randomInt(0, 90)),
+        submittedAt,
       },
     });
+    feedbackCreated++;
   }
-  console.log("  Created 20 feedback entries");
+  console.log(`  Feedback: ${feedbackCreated} created, ${feedbackSkipped} skipped`);
 
   // ─── COMPLAINTS ──────────────────────────────────
   console.log("\nCreating complaints...");
-  await prisma.complaint.deleteMany({});
+  // Pre-2026-05-11: `await prisma.complaint.deleteMany({})` — wiped
+  // EVERY complaint row in the DB. Removed; replaced with per-row
+  // findUnique on the seed-namespaced ticketNumber.
 
   const admins = await prisma.user.findMany({
     where: { role: "ADMIN" },
@@ -169,13 +261,26 @@ async function main() {
     },
   ];
 
+  let complaintsCreated = 0;
+  let complaintsSkipped = 0;
   for (let i = 0; i < complaintSeeds.length; i++) {
     const c = complaintSeeds[i];
-    const patient = Math.random() > 0.4 ? patients[i % patients.length] : null;
+    const ticketNumber = `CMP-PH4-SEED-${String(i + 1).padStart(4, "0")}`;
+
+    const existing = await prisma.complaint.findUnique({ where: { ticketNumber } });
+    if (existing) {
+      // Burn rng rolls so partial-run recovery stays aligned.
+      rng(); // patient-vs-anonymous roll
+      rng(); // phone digits
+      complaintsSkipped++;
+      continue;
+    }
+
+    const patient = rng() > 0.4 ? patients[i % patients.length] : null;
     const created = daysAgo(c.daysOld);
     await prisma.complaint.create({
       data: {
-        ticketNumber: `CMP${String(i + 1).padStart(6, "0")}`,
+        ticketNumber,
         patientId: patient?.id,
         name: patient ? null : `Anonymous Caller ${i + 1}`,
         phone: patient ? null : `98765${randomInt(10000, 99999)}`,
@@ -190,14 +295,15 @@ async function main() {
         updatedAt: created,
       },
     });
+    complaintsCreated++;
   }
-  console.log(`  Created ${complaintSeeds.length} complaints`);
+  console.log(`  Complaints: ${complaintsCreated} created, ${complaintsSkipped} skipped`);
 
   // ─── CHAT ──────────────────────────────────
   console.log("\nCreating chat rooms and messages...");
-  await prisma.chatMessage.deleteMany({});
-  await prisma.chatParticipant.deleteMany({});
-  await prisma.chatRoom.deleteMany({});
+  // Pre-2026-05-11: three unscoped `deleteMany({})` calls on ChatMessage,
+  // ChatParticipant, and ChatRoom. Removed; replaced with per-room
+  // findFirst-by-name guard + per-message seed-tag startsWith guard.
 
   const doctors = await prisma.user.findMany({
     where: { role: "DOCTOR" },
@@ -214,19 +320,11 @@ async function main() {
     const admin = admins[0];
 
     // 1. Doctors Channel (group)
-    const doctorsChannel = await prisma.chatRoom.create({
-      data: {
-        name: "Doctors Channel",
-        isGroup: true,
-        createdBy: admin.id,
-        participants: {
-          create: [
-            { userId: admin.id },
-            ...doctors.map((d) => ({ userId: d.id })),
-          ],
-        },
-      },
-    });
+    const doctorsChannel = await ensureGroupRoom(
+      "Doctors Channel",
+      admin.id,
+      [admin.id, ...doctors.map((d) => d.id)],
+    );
 
     const doctorMessages = [
       { senderId: admin.id, content: "Welcome to the Doctors channel!" },
@@ -235,168 +333,69 @@ async function main() {
         senderId: doctors[1]?.id ?? admin.id,
         content: "Could we align on new referral SOPs?",
       },
-      {
-        senderId: admin.id,
-        content: "Yes, let's have a meet on Friday at 10 AM.",
-      },
-      {
-        senderId: doctors[2]?.id ?? admin.id,
-        content: "Noted. Will confirm schedule.",
-      },
-      {
-        senderId: doctors[0]?.id ?? admin.id,
-        content: "Also, the OT scheduling app needs an update.",
-      },
+      { senderId: admin.id, content: "Yes, let's have a meet on Friday at 10 AM." },
+      { senderId: doctors[2]?.id ?? admin.id, content: "Noted. Will confirm schedule." },
+      { senderId: doctors[0]?.id ?? admin.id, content: "Also, the OT scheduling app needs an update." },
       { senderId: admin.id, content: "Raising with IT team." },
-      {
-        senderId: doctors[3]?.id ?? admin.id,
-        content: "Perfect, thanks.",
-      },
-      {
-        senderId: doctors[1]?.id ?? admin.id,
-        content: "New patient from ER being admitted to ward 2B.",
-      },
-      {
-        senderId: admin.id,
-        content: "Ack. Please update admission record.",
-      },
+      { senderId: doctors[3]?.id ?? admin.id, content: "Perfect, thanks." },
+      { senderId: doctors[1]?.id ?? admin.id, content: "New patient from ER being admitted to ward 2B." },
+      { senderId: admin.id, content: "Ack. Please update admission record." },
     ];
-    for (let i = 0; i < doctorMessages.length; i++) {
-      const m = doctorMessages[i];
-      await prisma.chatMessage.create({
-        data: {
-          roomId: doctorsChannel.id,
-          senderId: m.senderId,
-          content: m.content,
-          type: "TEXT" as MessageType,
-          createdAt: hoursAgo(doctorMessages.length - i),
-        },
-      });
-    }
-    await prisma.chatRoom.update({
-      where: { id: doctorsChannel.id },
-      data: { lastMessageAt: hoursAgo(1) },
-    });
+    const doctorMsgsAny = await seedTaggedMessages(doctorsChannel.id, "doctors", doctorMessages);
 
     // 2. Nursing Team (group)
-    const nursingTeam = await prisma.chatRoom.create({
-      data: {
-        name: "Nursing Team",
-        isGroup: true,
-        createdBy: admin.id,
-        participants: {
-          create: [
-            { userId: admin.id },
-            ...nurses.map((n) => ({ userId: n.id })),
-          ],
-        },
-      },
-    });
+    const nursingTeam = await ensureGroupRoom(
+      "Nursing Team",
+      admin.id,
+      [admin.id, ...nurses.map((n) => n.id)],
+    );
 
     const nurseMessages = [
       { senderId: admin.id, content: "Shift roster for next week is uploaded." },
       { senderId: nurses[0]?.id ?? admin.id, content: "Thanks, will review." },
-      {
-        senderId: nurses[1]?.id ?? admin.id,
-        content: "Medication cart restocking today at 2 PM.",
-      },
-      {
-        senderId: nurses[2]?.id ?? admin.id,
-        content: "Copy, I'll be there.",
-      },
-      {
-        senderId: nurses[0]?.id ?? admin.id,
-        content: "Bed 304 needs attention — patient has high fever.",
-      },
+      { senderId: nurses[1]?.id ?? admin.id, content: "Medication cart restocking today at 2 PM." },
+      { senderId: nurses[2]?.id ?? admin.id, content: "Copy, I'll be there." },
+      { senderId: nurses[0]?.id ?? admin.id, content: "Bed 304 needs attention — patient has high fever." },
       { senderId: admin.id, content: "Calling the on-call doctor now." },
       { senderId: nurses[3]?.id ?? admin.id, content: "Dr. Sharma is on way." },
-      {
-        senderId: nurses[1]?.id ?? admin.id,
-        content: "Good, vitals monitored every 30 min.",
-      },
+      { senderId: nurses[1]?.id ?? admin.id, content: "Good, vitals monitored every 30 min." },
       { senderId: admin.id, content: "Appreciate the quick response team." },
-      {
-        senderId: nurses[2]?.id ?? admin.id,
-        content: "Thanks team!",
-      },
+      { senderId: nurses[2]?.id ?? admin.id, content: "Thanks team!" },
     ];
-    for (let i = 0; i < nurseMessages.length; i++) {
-      const m = nurseMessages[i];
-      await prisma.chatMessage.create({
-        data: {
-          roomId: nursingTeam.id,
-          senderId: m.senderId,
-          content: m.content,
-          type: "TEXT" as MessageType,
-          createdAt: hoursAgo(nurseMessages.length - i),
-        },
-      });
-    }
-    await prisma.chatRoom.update({
-      where: { id: nursingTeam.id },
-      data: { lastMessageAt: hoursAgo(1) },
-    });
+    const nurseMsgsAny = await seedTaggedMessages(nursingTeam.id, "nursing", nurseMessages);
 
     // 3. 1-on-1 between admin and Dr. Sharma (first doctor)
     const drSharma = doctors[0];
+    let directAny = false;
     if (drSharma) {
-      const direct = await prisma.chatRoom.create({
-        data: {
-          isGroup: false,
-          createdBy: admin.id,
-          participants: {
-            create: [{ userId: admin.id }, { userId: drSharma.id }],
-          },
-        },
-      });
+      const direct = await ensureDirectRoom(admin.id, drSharma.id);
 
       const directMessages = [
         { senderId: admin.id, content: "Hi Dr. Sharma, got a minute?" },
         { senderId: drSharma.id, content: "Yes, what's up?" },
-        {
-          senderId: admin.id,
-          content: "Need your input on the surgery schedule for next week.",
-        },
+        { senderId: admin.id, content: "Need your input on the surgery schedule for next week." },
         { senderId: drSharma.id, content: "Sure, send me the draft." },
-        {
-          senderId: admin.id,
-          content: "Sending now via email. Please review by EOD.",
-        },
+        { senderId: admin.id, content: "Sending now via email. Please review by EOD." },
         { senderId: drSharma.id, content: "Will do." },
-        {
-          senderId: admin.id,
-          content: "Also, patient Rahul Sharma is asking for a follow-up.",
-        },
-        {
-          senderId: drSharma.id,
-          content: "Schedule him for Thursday 4 PM.",
-        },
+        { senderId: admin.id, content: "Also, patient Rahul Sharma is asking for a follow-up." },
+        { senderId: drSharma.id, content: "Schedule him for Thursday 4 PM." },
         { senderId: admin.id, content: "Done, thanks." },
         { senderId: drSharma.id, content: "Anytime!" },
       ];
-      for (let i = 0; i < directMessages.length; i++) {
-        const m = directMessages[i];
-        await prisma.chatMessage.create({
-          data: {
-            roomId: direct.id,
-            senderId: m.senderId,
-            content: m.content,
-            type: "TEXT" as MessageType,
-            createdAt: hoursAgo(directMessages.length - i),
-          },
-        });
-      }
-      await prisma.chatRoom.update({
-        where: { id: direct.id },
-        data: { lastMessageAt: hoursAgo(1) },
-      });
+      directAny = await seedTaggedMessages(direct.id, "admin-sharma", directMessages);
     }
-    console.log("  Created 3 chat rooms with messages");
+
+    console.log(
+      `  Chat rooms ready (new messages this run: doctors=${doctorMsgsAny ? "yes" : "no"}, ` +
+        `nursing=${nurseMsgsAny ? "yes" : "no"}, direct=${directAny ? "yes" : "no"})`,
+    );
   }
 
   // ─── VISITORS ──────────────────────────────────
   console.log("\nCreating visitors...");
-  await prisma.visitor.deleteMany({});
+  // Pre-2026-05-11: `await prisma.visitor.deleteMany({})` — wiped EVERY
+  // visitor row in the DB. Removed; replaced with per-row findUnique on
+  // the seed-namespaced passNumber.
 
   const purposes: VisitorPurpose[] = [
     "PATIENT_VISIT",
@@ -416,42 +415,160 @@ async function main() {
     "Sunita Patel",
   ];
   const idTypes = ["Aadhaar", "PAN", "Driving License", "Passport"];
-  const today = new Date();
-  const yyyymmdd = `${today.getFullYear()}${String(today.getMonth() + 1).padStart(2, "0")}${String(today.getDate()).padStart(2, "0")}`;
 
+  let visitorsCreated = 0;
+  let visitorsSkipped = 0;
   for (let i = 0; i < 8; i++) {
+    // Stable seed-namespaced passNumber. Pre-2026-05-11 used a yyyymmdd
+    // suffix that shifted on every deploy — the new namespace is stable.
+    const passNumber = `VIS-PH4-SEED-${String(i + 1).padStart(4, "0")}`;
+
+    const existing = await prisma.visitor.findUnique({ where: { passNumber } });
+    if (existing) {
+      // Burn rng rolls for deterministic partial-run recovery.
+      rng(); rng(); rng(); rng(); rng();
+      visitorsSkipped++;
+      continue;
+    }
+
     const isActive = i < 5;
-    const checkInAt = hoursAgo(isActive ? randomInt(1, 6) : randomInt(8, 20));
+    // Deterministic checkIn offset keyed off `i`.
+    const checkInHoursAgo = isActive ? 1 + (i % 6) : 8 + ((i * 3) % 13);
+    const checkInAt = hoursAgo(checkInHoursAgo);
+    const stayMinutes = 30 + ((i * 23) % 150);
     const checkOutAt = isActive
       ? null
-      : new Date(checkInAt.getTime() + randomInt(30, 180) * 60000);
+      : new Date(checkInAt.getTime() + stayMinutes * 60000);
+
+    const idTypePick = randomItem(idTypes);
+    const idProofDigits = randomInt(100000, 999999);
+    const patientForVisitor = rng() > 0.5 ? patients[i % patients.length] : null;
+    const dept = randomItem([
+      "Cardiology",
+      "Orthopedics",
+      "Pediatrics",
+      "General",
+      "ICU",
+    ]);
+    const phoneDigits = randomInt(10000, 99999);
 
     await prisma.visitor.create({
       data: {
-        passNumber: `VIS${String(i + 1).padStart(6, "0")}-${yyyymmdd}`,
+        passNumber,
         name: visitorNames[i],
-        phone: `98765${randomInt(10000, 99999)}`,
-        idProofType: randomItem(idTypes),
-        idProofNumber: `ID${randomInt(100000, 999999)}`,
-        patientId:
-          Math.random() > 0.5 ? patients[i % patients.length].id : null,
+        phone: `98765${phoneDigits}`,
+        idProofType: idTypePick,
+        idProofNumber: `ID${idProofDigits}`,
+        patientId: patientForVisitor?.id ?? null,
         purpose: purposes[i % purposes.length],
-        department: randomItem([
-          "Cardiology",
-          "Orthopedics",
-          "Pediatrics",
-          "General",
-          "ICU",
-        ]),
+        department: dept,
         checkInAt,
         checkOutAt,
         notes: isActive ? null : "Checked out normally",
       },
     });
+    visitorsCreated++;
   }
-  console.log("  Created 8 visitors (5 active, 3 checked out)");
+  console.log(`  Visitors: ${visitorsCreated} created, ${visitorsSkipped} skipped`);
 
   console.log("\n=== Phase 4 Engagement seed complete ===");
+}
+
+// ─── Chat helpers ──────────────────────────────────────
+async function ensureGroupRoom(
+  name: string,
+  createdBy: string,
+  participantUserIds: string[],
+) {
+  let room = await prisma.chatRoom.findFirst({
+    where: { name, isGroup: true, createdBy },
+  });
+  if (!room) {
+    room = await prisma.chatRoom.create({
+      data: {
+        name,
+        isGroup: true,
+        createdBy,
+      },
+    });
+  }
+  const uniqueParticipants = Array.from(new Set(participantUserIds));
+  for (const uid of uniqueParticipants) {
+    await prisma.chatParticipant.upsert({
+      where: { roomId_userId: { roomId: room.id, userId: uid } },
+      update: {},
+      create: { roomId: room.id, userId: uid },
+    });
+  }
+  return room;
+}
+
+async function ensureDirectRoom(userA: string, userB: string) {
+  const candidate = await prisma.chatRoom.findFirst({
+    where: {
+      isGroup: false,
+      AND: [
+        { participants: { some: { userId: userA } } },
+        { participants: { some: { userId: userB } } },
+      ],
+    },
+  });
+  if (candidate) {
+    return candidate;
+  }
+  const room = await prisma.chatRoom.create({
+    data: {
+      isGroup: false,
+      createdBy: userA,
+    },
+  });
+  await prisma.chatParticipant.upsert({
+    where: { roomId_userId: { roomId: room.id, userId: userA } },
+    update: {},
+    create: { roomId: room.id, userId: userA },
+  });
+  await prisma.chatParticipant.upsert({
+    where: { roomId_userId: { roomId: room.id, userId: userB } },
+    update: {},
+    create: { roomId: room.id, userId: userB },
+  });
+  return room;
+}
+
+async function seedTaggedMessages(
+  roomId: string,
+  roomKey: string,
+  messages: Array<{ senderId: string; content: string }>,
+): Promise<boolean> {
+  let created = false;
+  for (let i = 0; i < messages.length; i++) {
+    const m = messages[i];
+    const seedTag = `[PH4-ENG-CHAT-SEED-${roomKey}-${String(i + 1).padStart(4, "0")}]`;
+
+    const exists = await prisma.chatMessage.findFirst({
+      where: { roomId, content: { startsWith: seedTag } },
+      select: { id: true },
+    });
+    if (exists) continue;
+
+    await prisma.chatMessage.create({
+      data: {
+        roomId,
+        senderId: m.senderId,
+        content: `${seedTag} ${m.content}`,
+        type: "TEXT" as MessageType,
+        createdAt: hoursAgo(messages.length - i),
+      },
+    });
+    created = true;
+  }
+  if (created) {
+    await prisma.chatRoom.update({
+      where: { id: roomId },
+      data: { lastMessageAt: hoursAgo(1) },
+    });
+  }
+  return created;
 }
 
 main()

--- a/packages/db/src/seed-phase4-ops.ts
+++ b/packages/db/src/seed-phase4-ops.ts
@@ -1,3 +1,37 @@
+/**
+ * Phase 4 ops seed — blood bank (donors / donations / units), ambulance
+ * fleet + trips, and asset register (with assignments and maintenance).
+ *
+ * Idempotency contract (2026-05-11): safe to re-run on a populated demo
+ * without creating duplicate rows. Unlike its phase4 siblings, this file
+ * never used `deleteMany` — the pre-2026-05-11 version was already
+ * largely idempotent via `upsert`, `findUnique`, and coarse
+ * `count() === 0` gates. This commit tightens the last three coarse
+ * gates (AmbulanceTrip, AssetAssignment, AssetMaintenance) into
+ * per-row stable-anchor guards so partial-run recovery is precise:
+ *
+ *   - BloodDonor: `upsert({ where: { donorNumber } })` — pre-existing.
+ *   - BloodDonation: `findUnique({ where: { unitNumber } })` skip-or-
+ *     create — pre-existing.
+ *   - BloodUnit: per-row try/catch on `unitNumber @unique` — pre-existing.
+ *   - Ambulance: `upsert({ where: { vehicleNumber } })` — pre-existing.
+ *   - AmbulanceTrip (TIGHTENED 2026-05-11): per-trip `findUnique({ where:
+ *     { tripNumber } })` skip-or-create. Pre-existing coarse
+ *     `tripCount === 0` would have skipped seed trips entirely once any
+ *     human-entered trip existed.
+ *   - Asset: `upsert({ where: { assetTag } })` — pre-existing.
+ *   - AssetAssignment (TIGHTENED 2026-05-11): per-row `findFirst({ where:
+ *     { assetId, assignedTo } })` skip-or-create + a stable seed-marker
+ *     in the notes column (`[PH4-OPS-ASSIGN-SEED-NNNN]`).
+ *   - AssetMaintenance (TIGHTENED 2026-05-11): per-row `findFirst({
+ *     where: { assetId, type, performedAt } })` skip-or-create. The
+ *     three (assetId, type, performedAt) triples below are unique and
+ *     stable (performedAt quantized to UTC midnight).
+ *
+ * Wired into `scripts/deploy.sh` by the orchestrator (separate commit).
+ * Failures are non-fatal (matches the policy of every other deploy-time
+ * fixture seed).
+ */
 import {
   PrismaClient,
   BloodGroupType,
@@ -15,6 +49,15 @@ const prisma = new PrismaClient();
 
 function daysFromNow(n: number): Date {
   return new Date(Date.now() + n * 24 * 60 * 60 * 1000);
+}
+
+// Stable per-day-offset helper that quantizes to UTC midnight, so re-runs
+// at different times of day still produce the same `performedAt` and the
+// (assetId, type, performedAt) findFirst anchor lands on the same row.
+function daysFromNowAtMidnight(n: number): Date {
+  const d = daysFromNow(n);
+  d.setUTCHours(0, 0, 0, 0);
+  return d;
 }
 
 async function main() {
@@ -104,7 +147,6 @@ async function main() {
       const group = groups[i % groups.length];
       const component = components[i % components.length];
       const collectedAt = daysFromNow(-(i % 10));
-      // Some units near expiry for demo
       const expiryDays = component === "PLATELETS" ? 5 : component === "FRESH_FROZEN_PLASMA" ? 365 : 42;
       const expiresAt = new Date(
         collectedAt.getTime() + expiryDays * 24 * 60 * 60 * 1000
@@ -140,7 +182,8 @@ async function main() {
     { vehicleNumber: "AMB-004", type: "Patient Transport", driverName: "Naresh Gupta", driverPhone: "9876543213" },
   ];
 
-  const ambulances = [];
+  type AmbulanceRow = Awaited<ReturnType<typeof prisma.ambulance.upsert>>;
+  const ambulances: AmbulanceRow[] = [];
   for (let i = 0; i < ambSpecs.length; i++) {
     const spec = ambSpecs[i];
     const a = await prisma.ambulance.upsert({
@@ -161,10 +204,16 @@ async function main() {
   console.log("\nCreating ambulance trips...");
   const patient = await prisma.patient.findFirst();
 
-  const tripCount = await prisma.ambulanceTrip.count();
-  if (tripCount === 0) {
-    await prisma.ambulanceTrip.create({
-      data: {
+  // Per-trip findUnique on stable tripNumber. Pre-2026-05-11 used a
+  // coarse `tripCount === 0` gate which would have skipped seed trips
+  // entirely once any human-entered trip existed.
+  const tripSpecs: Array<{
+    tripNumber: string;
+    build: () => Parameters<typeof prisma.ambulanceTrip.create>[0]["data"];
+  }> = [
+    {
+      tripNumber: "TRP000001",
+      build: () => ({
         tripNumber: "TRP000001",
         ambulanceId: ambulances[1].id,
         patientId: patient?.id,
@@ -178,10 +227,11 @@ async function main() {
         completedAt: daysFromNow(-3),
         distanceKm: 12.5,
         cost: 1200,
-      },
-    });
-    await prisma.ambulanceTrip.create({
-      data: {
+      }),
+    },
+    {
+      tripNumber: "TRP000002",
+      build: () => ({
         tripNumber: "TRP000002",
         ambulanceId: ambulances[0].id,
         callerName: "Mohan Rao",
@@ -192,10 +242,11 @@ async function main() {
         requestedAt: new Date(Date.now() - 30 * 60 * 1000),
         dispatchedAt: new Date(Date.now() - 25 * 60 * 1000),
         arrivedAt: new Date(Date.now() - 15 * 60 * 1000),
-      },
-    });
-    await prisma.ambulanceTrip.create({
-      data: {
+      }),
+    },
+    {
+      tripNumber: "TRP000003",
+      build: () => ({
         tripNumber: "TRP000003",
         ambulanceId: ambulances[2].id,
         callerName: "Lakshmi Devi",
@@ -203,12 +254,24 @@ async function main() {
         pickupAddress: "HSR Layout",
         chiefComplaint: "Breathing difficulty",
         status: "REQUESTED" as AmbulanceTripStatus,
-      },
+      }),
+    },
+  ];
+
+  let tripsCreated = 0;
+  let tripsSkipped = 0;
+  for (const t of tripSpecs) {
+    const existing = await prisma.ambulanceTrip.findUnique({
+      where: { tripNumber: t.tripNumber },
     });
-    console.log(`  Created 3 trips`);
-  } else {
-    console.log(`  Trips already exist (${tripCount})`);
+    if (existing) {
+      tripsSkipped++;
+      continue;
+    }
+    await prisma.ambulanceTrip.create({ data: t.build() });
+    tripsCreated++;
   }
+  console.log(`  Trips: ${tripsCreated} created, ${tripsSkipped} skipped`);
 
   // ─── Assets ────────────────────────────────────────────
   console.log("\nCreating assets...");
@@ -298,80 +361,124 @@ async function main() {
   });
 
   if (assignableUsers.length > 0) {
-    const existingAssignments = await prisma.assetAssignment.count();
-    if (existingAssignments === 0) {
-      const laptopAssets = assets.filter((a) => a.category === "IT").slice(0, 3);
-      const otherAssets = [assets[12], assets[13]]; // autoclave, suction
-      const toAssign = [...laptopAssets, ...otherAssets].filter(Boolean);
+    // Pre-2026-05-11 used a coarse `existingAssignments === 0` gate which
+    // would have skipped seed assignments entirely once any human-entered
+    // assignment existed. Replaced with per-row findFirst on
+    // (assetId, assignedTo) + a stable seed-marker in the notes column
+    // so re-runs precisely land on the same rows.
+    const laptopAssets = assets.filter((a) => a.category === "IT").slice(0, 3);
+    const otherAssets = [assets[12], assets[13]]; // autoclave, suction
+    const toAssign = [...laptopAssets, ...otherAssets].filter(Boolean);
 
-      for (let i = 0; i < toAssign.length && i < assignableUsers.length; i++) {
-        const asset = toAssign[i];
-        const user = assignableUsers[i];
-        await prisma.assetAssignment.create({
-          data: {
-            assetId: asset.id,
-            assignedTo: user.id,
-            location: asset.location,
-            notes: "Initial assignment from seed",
-          },
-        });
-        await prisma.asset.update({
-          where: { id: asset.id },
-          data: { status: "IN_USE" as AssetStatus },
-        });
+    let assignsCreated = 0;
+    let assignsSkipped = 0;
+    for (let i = 0; i < toAssign.length && i < assignableUsers.length; i++) {
+      const asset = toAssign[i];
+      const user = assignableUsers[i];
+
+      const existing = await prisma.assetAssignment.findFirst({
+        where: { assetId: asset.id, assignedTo: user.id },
+      });
+      if (existing) {
+        assignsSkipped++;
+        continue;
       }
-      console.log(`  Created ${Math.min(toAssign.length, assignableUsers.length)} asset assignments`);
-    } else {
-      console.log(`  Asset assignments already exist (${existingAssignments})`);
+
+      await prisma.assetAssignment.create({
+        data: {
+          assetId: asset.id,
+          assignedTo: user.id,
+          location: asset.location,
+          notes: `[PH4-OPS-ASSIGN-SEED-${String(i + 1).padStart(4, "0")}] Initial assignment from seed`,
+        },
+      });
+      await prisma.asset.update({
+        where: { id: asset.id },
+        data: { status: "IN_USE" as AssetStatus },
+      });
+      assignsCreated++;
     }
+    console.log(`  Asset assignments: ${assignsCreated} created, ${assignsSkipped} skipped`);
   }
 
   // ─── Asset Maintenance Logs ────────────────────────────
   console.log("\nCreating maintenance logs...");
   const technician = assignableUsers[0];
   if (technician) {
-    const existingMaint = await prisma.assetMaintenance.count();
-    if (existingMaint === 0) {
-      await prisma.assetMaintenance.create({
+    // Per-row findFirst on (assetId, type, performedAt). The three
+    // triples below are unique and stable (performedAt quantized to UTC
+    // midnight so re-runs at different times of day hit the same row).
+    const maintSpecs: Array<{
+      assetId: string;
+      type: MaintenanceType;
+      performedAt: Date;
+      data: Parameters<typeof prisma.assetMaintenance.create>[0]["data"];
+    }> = [
+      {
+        assetId: assets[0].id, // X-Ray
+        type: "CALIBRATION" as MaintenanceType,
+        performedAt: daysFromNowAtMidnight(-60),
         data: {
-          assetId: assets[0].id, // X-Ray
+          assetId: assets[0].id,
           type: "CALIBRATION" as MaintenanceType,
           performedBy: technician.id,
           vendor: "Siemens Service",
           cost: 15000,
           description: "Annual calibration and tube inspection",
-          performedAt: daysFromNow(-60),
-          nextDueDate: daysFromNow(305),
+          performedAt: daysFromNowAtMidnight(-60),
+          nextDueDate: daysFromNowAtMidnight(305),
         },
-      });
-      await prisma.assetMaintenance.create({
+      },
+      {
+        assetId: assets[12].id, // Autoclave
+        type: "SCHEDULED" as MaintenanceType,
+        performedAt: daysFromNowAtMidnight(-30),
         data: {
-          assetId: assets[12].id, // Autoclave
+          assetId: assets[12].id,
           type: "SCHEDULED" as MaintenanceType,
           performedBy: technician.id,
           vendor: "Equitron Services",
           cost: 5000,
           description: "Quarterly preventive maintenance",
-          performedAt: daysFromNow(-30),
-          nextDueDate: daysFromNow(60),
+          performedAt: daysFromNowAtMidnight(-30),
+          nextDueDate: daysFromNowAtMidnight(60),
         },
-      });
-      await prisma.assetMaintenance.create({
+      },
+      {
+        assetId: assets[14].id, // Defibrillator
+        type: "INSPECTION" as MaintenanceType,
+        performedAt: daysFromNowAtMidnight(-10),
         data: {
-          assetId: assets[14].id, // Defibrillator
+          assetId: assets[14].id,
           type: "INSPECTION" as MaintenanceType,
           performedBy: technician.id,
           vendor: "Philips Healthcare",
           cost: 2500,
           description: "Battery replacement and self-test",
-          performedAt: daysFromNow(-10),
-          nextDueDate: daysFromNow(80),
+          performedAt: daysFromNowAtMidnight(-10),
+          nextDueDate: daysFromNowAtMidnight(80),
+        },
+      },
+    ];
+
+    let maintCreated = 0;
+    let maintSkipped = 0;
+    for (const m of maintSpecs) {
+      const existing = await prisma.assetMaintenance.findFirst({
+        where: {
+          assetId: m.assetId,
+          type: m.type,
+          performedAt: m.performedAt,
         },
       });
-      console.log(`  Created 3 maintenance logs`);
-    } else {
-      console.log(`  Maintenance logs already exist (${existingMaint})`);
+      if (existing) {
+        maintSkipped++;
+        continue;
+      }
+      await prisma.assetMaintenance.create({ data: m.data });
+      maintCreated++;
     }
+    console.log(`  Maintenance logs: ${maintCreated} created, ${maintSkipped} skipped`);
   }
 
   console.log("\n=== Phase 4 Ops seeding complete ===");

--- a/packages/db/src/seed-phase4-specialty.ts
+++ b/packages/db/src/seed-phase4-specialty.ts
@@ -1,3 +1,37 @@
+/**
+ * Phase 4 specialty seed — Antenatal (ANC) cases + pediatric growth records.
+ *
+ * Idempotency contract (2026-05-11): safe to re-run on a populated demo
+ * without creating duplicate ANC cases, duplicate visits, or wiping
+ * user-created growth records.
+ *
+ *   - AntenatalCase: stable seed-namespaced `caseNumber = ANC-SEED-<NNNN>`
+ *     (1..3) — distinct from the live production ANC counter (`ANC000001..`)
+ *     so the seed never reuses or collides with a real-tenant case number.
+ *     Skip-or-create via `findUnique({ where: { caseNumber } })`.
+ *     Note: AntenatalCase.patientId is `@unique` (one active case per
+ *     patient), so we also tolerate prior seed-runs where a patient
+ *     already has a non-seed case — those patients are skipped from
+ *     the eligible set (this part was already idempotent pre-2026-05-11).
+ *   - AncVisit: no natural unique key; anchored by `(ancCaseId, type,
+ *     visitDate)` triple via findFirst skip-or-create. Per-case visit
+ *     definitions are deterministic (hard-coded list below), so this
+ *     triple is stable across re-runs.
+ *   - GrowthRecord: previously did `deleteMany({ where: { patientId } })`
+ *     before re-creating, which would WIPE real growth records logged by
+ *     a clinician for that patient on every deploy. Replaced with
+ *     `findFirst({ where: { patientId, ageMonths } })` skip-or-create
+ *     keyed on (patientId, ageMonths). The seed only re-creates the
+ *     specific milestone ages (0, 2, 4, 6, 12 months); any human-entered
+ *     records at other ages or with different anchor dates are preserved.
+ *
+ * No `Math.random()` is used in this file — all decisions are already
+ * deterministic — so no PRNG is needed.
+ *
+ * Wired into `scripts/deploy.sh` by the orchestrator (separate commit).
+ * Failures are non-fatal (matches the policy of every other deploy-time
+ * fixture seed).
+ */
 import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();
@@ -6,19 +40,6 @@ function addDays(date: Date, days: number): Date {
   const d = new Date(date);
   d.setUTCDate(d.getUTCDate() + days);
   return d;
-}
-
-async function nextAncCaseNumber(): Promise<string> {
-  const last = await prisma.antenatalCase.findFirst({
-    orderBy: { caseNumber: "desc" },
-    select: { caseNumber: true },
-  });
-  let n = 1;
-  if (last?.caseNumber) {
-    const m = last.caseNumber.match(/(\d+)$/);
-    if (m) n = parseInt(m[1], 10) + 1;
-  }
-  return `ANC${String(n).padStart(6, "0")}`;
 }
 
 async function main() {
@@ -41,7 +62,10 @@ async function main() {
     return;
   }
 
-  // Pick 3 female patients who don't already have an ANC case
+  // Pick 3 female patients who don't already have an ANC case (per the
+  // patientId @unique constraint). On a re-run, the patients seeded
+  // previously will already have a case and re-enter this branch via the
+  // findUnique-on-caseNumber path below, NOT via `eligible[]`.
   const eligible: typeof femalePatients = [];
   for (const p of femalePatients) {
     const exists = await prisma.antenatalCase.findUnique({
@@ -51,40 +75,137 @@ async function main() {
     if (eligible.length === 3) break;
   }
 
-  if (eligible.length < 3) {
-    console.log(
-      `Only ${eligible.length} eligible patient(s) without existing ANC cases — continuing with what we have.`
-    );
-  }
-
   const doctor = doctors[0];
   const now = new Date();
 
-  // Case 1: Active normal — LMP 14 weeks ago
-  if (eligible[0]) {
-    const lmp = addDays(now, -14 * 7);
-    const edd = addDays(lmp, 280);
-    const caseNumber = await nextAncCaseNumber();
-    const c = await prisma.antenatalCase.create({
-      data: {
-        caseNumber,
-        patientId: eligible[0].id,
-        doctorId: doctor.id,
-        lmpDate: lmp,
-        eddDate: edd,
-        gravida: 1,
-        parity: 0,
-        bloodGroup: "O+",
-        isHighRisk: false,
+  // ─── Canonical 3-case seed definition ───────────────
+  // Each case has a stable seed-namespaced caseNumber so re-runs hit the
+  // existing row via findUnique. The patient binding is sticky: once a
+  // seed case is created for a particular patient, that case keeps living
+  // there even if a different female patient appears earlier in
+  // `femalePatients` on the next run.
+  const seedCases: Array<{
+    seedIdx: number;
+    lmpOffsetWeeks: number; // negative = LMP weeks ago
+    gravida: number;
+    parity: number;
+    bloodGroup: string;
+    isHighRisk: boolean;
+    riskFactors?: string;
+    delivered?: {
+      deliveryType: string;
+      babyGender: string;
+      babyWeight: number;
+      outcomeNotes: string;
+      preEddDays: number; // delivered preEddDays before EDD
+    };
+  }> = [
+    {
+      seedIdx: 1,
+      lmpOffsetWeeks: -14,
+      gravida: 1,
+      parity: 0,
+      bloodGroup: "O+",
+      isHighRisk: false,
+    },
+    {
+      seedIdx: 2,
+      lmpOffsetWeeks: -28,
+      gravida: 3,
+      parity: 1,
+      bloodGroup: "A+",
+      isHighRisk: true,
+      riskFactors: "Previous C-section, Hypertension, GDM",
+    },
+    {
+      seedIdx: 3,
+      lmpOffsetWeeks: -42,
+      gravida: 2,
+      parity: 1,
+      bloodGroup: "B+",
+      isHighRisk: false,
+      delivered: {
+        deliveryType: "NORMAL",
+        babyGender: "FEMALE",
+        babyWeight: 3.1,
+        outcomeNotes: "Normal vaginal delivery. Apgar 9/10. Baby healthy.",
+        preEddDays: 14,
       },
-    });
-    console.log(`  Created ANC case ${caseNumber} (active, normal) for ${eligible[0].user.name}`);
+    },
+  ];
 
-    // 3 routine visits
-    await prisma.ancVisit.createMany({
-      data: [
+  for (const sc of seedCases) {
+    const caseNumber = `ANC-SEED-${String(sc.seedIdx).padStart(4, "0")}`;
+
+    // Skip-or-create on stable caseNumber.
+    let c = await prisma.antenatalCase.findUnique({ where: { caseNumber } });
+    if (c) {
+      console.log(`  ANC case ${caseNumber} already exists — skip create, ensure visits.`);
+    } else {
+      // Need a patient slot. If we have no eligible patient for this seed
+      // index AND no existing case, skip this seed entry.
+      const patient = eligible[sc.seedIdx - 1];
+      if (!patient) {
+        console.log(`  No eligible patient for ${caseNumber} — skipping.`);
+        continue;
+      }
+
+      const lmp = addDays(now, sc.lmpOffsetWeeks * 7);
+      const edd = addDays(lmp, 280);
+      const deliveredAt = sc.delivered ? addDays(edd, -sc.delivered.preEddDays) : null;
+
+      c = await prisma.antenatalCase.create({
+        data: {
+          caseNumber,
+          patientId: patient.id,
+          doctorId: doctor.id,
+          lmpDate: lmp,
+          eddDate: edd,
+          gravida: sc.gravida,
+          parity: sc.parity,
+          bloodGroup: sc.bloodGroup,
+          isHighRisk: sc.isHighRisk,
+          riskFactors: sc.riskFactors,
+          ...(sc.delivered && deliveredAt
+            ? {
+                deliveredAt,
+                deliveryType: sc.delivered.deliveryType,
+                babyGender: sc.delivered.babyGender,
+                babyWeight: sc.delivered.babyWeight,
+                outcomeNotes: sc.delivered.outcomeNotes,
+              }
+            : {}),
+        },
+      });
+      console.log(`  Created ANC case ${caseNumber} for ${patient.user.name}`);
+    }
+
+    // Build the deterministic visit list for this case. Re-derive lmp
+    // from the row itself so re-runs always re-anchor to whatever LMP
+    // was first seeded.
+    const lmp = c.lmpDate;
+    const edd = c.eddDate;
+    type VisitInput = {
+      type: string;
+      visitDate: Date;
+      weeksOfGestation?: number;
+      weight?: number;
+      bloodPressure?: string;
+      fundalHeight?: string;
+      fetalHeartRate?: number;
+      presentation?: string;
+      hemoglobin?: number;
+      urineProtein?: string;
+      urineSugar?: string;
+      prescribedMeds?: string;
+      notes?: string;
+      nextVisitDate?: Date;
+    };
+    const visitsForCase: VisitInput[] = [];
+
+    if (sc.seedIdx === 1) {
+      visitsForCase.push(
         {
-          ancCaseId: c.id,
           type: "FIRST_VISIT",
           visitDate: addDays(lmp, 6 * 7),
           weeksOfGestation: 6,
@@ -98,7 +219,6 @@ async function main() {
           nextVisitDate: addDays(lmp, 10 * 7),
         },
         {
-          ancCaseId: c.id,
           type: "ROUTINE",
           visitDate: addDays(lmp, 10 * 7),
           weeksOfGestation: 10,
@@ -112,7 +232,6 @@ async function main() {
           nextVisitDate: addDays(lmp, 14 * 7),
         },
         {
-          ancCaseId: c.id,
           type: "ROUTINE",
           visitDate: addDays(lmp, 14 * 7),
           weeksOfGestation: 14,
@@ -125,39 +244,11 @@ async function main() {
           urineSugar: "nil",
           prescribedMeds: "Iron, Calcium",
           notes: "Fetal heart tones audible. Mother feeling well.",
-          nextVisitDate: addDays(now, 28),
         },
-      ],
-    });
-  }
-
-  // Case 2: Active high-risk — LMP 28 weeks ago
-  if (eligible[1]) {
-    const lmp = addDays(now, -28 * 7);
-    const edd = addDays(lmp, 280);
-    const caseNumber = await nextAncCaseNumber();
-    const c = await prisma.antenatalCase.create({
-      data: {
-        caseNumber,
-        patientId: eligible[1].id,
-        doctorId: doctor.id,
-        lmpDate: lmp,
-        eddDate: edd,
-        gravida: 3,
-        parity: 1,
-        bloodGroup: "A+",
-        isHighRisk: true,
-        riskFactors: "Previous C-section, Hypertension, GDM",
-      },
-    });
-    console.log(
-      `  Created ANC case ${caseNumber} (active, high risk) for ${eligible[1].user.name}`
-    );
-
-    await prisma.ancVisit.createMany({
-      data: [
+      );
+    } else if (sc.seedIdx === 2) {
+      visitsForCase.push(
         {
-          ancCaseId: c.id,
           type: "FIRST_VISIT",
           visitDate: addDays(lmp, 8 * 7),
           weeksOfGestation: 8,
@@ -171,7 +262,6 @@ async function main() {
           nextVisitDate: addDays(lmp, 12 * 7),
         },
         {
-          ancCaseId: c.id,
           type: "HIGH_RISK_FOLLOWUP",
           visitDate: addDays(lmp, 16 * 7),
           weeksOfGestation: 16,
@@ -187,7 +277,6 @@ async function main() {
           nextVisitDate: addDays(lmp, 22 * 7),
         },
         {
-          ancCaseId: c.id,
           type: "SCAN_REVIEW",
           visitDate: addDays(lmp, 22 * 7),
           weeksOfGestation: 22,
@@ -203,7 +292,6 @@ async function main() {
           nextVisitDate: addDays(lmp, 26 * 7),
         },
         {
-          ancCaseId: c.id,
           type: "HIGH_RISK_FOLLOWUP",
           visitDate: addDays(lmp, 28 * 7),
           weeksOfGestation: 28,
@@ -217,44 +305,12 @@ async function main() {
           urineSugar: "nil",
           prescribedMeds: "Labetalol, Aspirin, Iron",
           notes: "GTT ordered. Increased monitoring.",
-          nextVisitDate: addDays(now, 14),
         },
-      ],
-    });
-  }
-
-  // Case 3: Delivered — LMP 42 weeks ago (delivered 2 weeks ago)
-  if (eligible[2]) {
-    const lmp = addDays(now, -42 * 7);
-    const edd = addDays(lmp, 280);
-    const deliveredAt = addDays(edd, -2 * 7);
-    const caseNumber = await nextAncCaseNumber();
-    const c = await prisma.antenatalCase.create({
-      data: {
-        caseNumber,
-        patientId: eligible[2].id,
-        doctorId: doctor.id,
-        lmpDate: lmp,
-        eddDate: edd,
-        gravida: 2,
-        parity: 1,
-        bloodGroup: "B+",
-        isHighRisk: false,
-        deliveredAt,
-        deliveryType: "NORMAL",
-        babyGender: "FEMALE",
-        babyWeight: 3.1,
-        outcomeNotes: "Normal vaginal delivery. Apgar 9/10. Baby healthy.",
-      },
-    });
-    console.log(
-      `  Created ANC case ${caseNumber} (delivered) for ${eligible[2].user.name}`
-    );
-
-    await prisma.ancVisit.createMany({
-      data: [
+      );
+    } else if (sc.seedIdx === 3 && sc.delivered) {
+      const deliveredAt = addDays(edd, -sc.delivered.preEddDays);
+      visitsForCase.push(
         {
-          ancCaseId: c.id,
           type: "FIRST_VISIT",
           visitDate: addDays(lmp, 8 * 7),
           weeksOfGestation: 8,
@@ -264,7 +320,6 @@ async function main() {
           notes: "Booking visit for 2nd pregnancy.",
         },
         {
-          ancCaseId: c.id,
           type: "ROUTINE",
           visitDate: addDays(lmp, 20 * 7),
           weeksOfGestation: 20,
@@ -276,7 +331,6 @@ async function main() {
           notes: "Progressing well.",
         },
         {
-          ancCaseId: c.id,
           type: "ROUTINE",
           visitDate: addDays(lmp, 36 * 7),
           weeksOfGestation: 36,
@@ -289,7 +343,6 @@ async function main() {
           notes: "Term approaching.",
         },
         {
-          ancCaseId: c.id,
           type: "DELIVERY",
           visitDate: deliveredAt,
           weeksOfGestation: 38,
@@ -298,13 +351,37 @@ async function main() {
           notes: "Normal vaginal delivery. Live female baby 3.1 kg.",
         },
         {
-          ancCaseId: c.id,
           type: "POSTNATAL",
           visitDate: addDays(deliveredAt, 7),
           notes: "Mother and baby doing well. Breastfeeding established.",
         },
-      ],
-    });
+      );
+    }
+
+    // Skip-or-create each visit anchored on (ancCaseId, type, visitDate).
+    let visitsCreated = 0;
+    for (const v of visitsForCase) {
+      const existing = await prisma.ancVisit.findFirst({
+        where: {
+          ancCaseId: c.id,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          type: v.type as any,
+          visitDate: v.visitDate,
+        },
+      });
+      if (existing) continue;
+      await prisma.ancVisit.create({
+        data: {
+          ancCaseId: c.id,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ...(v as any),
+        },
+      });
+      visitsCreated++;
+    }
+    if (visitsCreated > 0) {
+      console.log(`    + ${visitsCreated} visits for ${caseNumber}`);
+    }
   }
 
   // ─── Growth Records for a young patient ───────────────
@@ -328,11 +405,12 @@ async function main() {
       (await prisma.user.findFirst({ where: { role: "NURSE" } }));
     const recordedBy = anyStaff?.id || doctor.userId;
 
-    // Remove existing growth records to prevent duplicates on re-run
-    await prisma.growthRecord.deleteMany({
-      where: { patientId: pediatricPatient.id },
-    });
-
+    // Pre-2026-05-11 this block did:
+    //   `await prisma.growthRecord.deleteMany({ where: { patientId: ... } })`
+    // — which would WIPE any clinician-entered growth records for this
+    // patient on every deploy. Replaced with per-row skip-or-create
+    // anchored on (patientId, ageMonths). The 5 milestone ages below are
+    // hard-coded so re-runs always hit the same logical row.
     const measurements = [
       { ageMonths: 0, weightKg: 3.2, heightCm: 49, headCircumference: 34 },
       { ageMonths: 2, weightKg: 5.4, heightCm: 57, headCircumference: 38, milestoneNotes: "Smiling, cooing" },
@@ -341,10 +419,18 @@ async function main() {
       { ageMonths: 12, weightKg: 9.5, heightCm: 74, headCircumference: 45, milestoneNotes: "Walking, first words", developmentalNotes: "Meeting all expected milestones." },
     ];
 
+    let growthCreated = 0;
     for (const m of measurements) {
+      const exists = await prisma.growthRecord.findFirst({
+        where: {
+          patientId: pediatricPatient.id,
+          ageMonths: m.ageMonths,
+        },
+      });
+      if (exists) continue;
+
       const hMeters = m.heightCm / 100;
       const bmi = Math.round((m.weightKg / (hMeters * hMeters)) * 10) / 10;
-      // Rough percentile computation
       const medians: Record<number, { w: number; h: number }> = {
         0: { w: 3.3, h: 49.9 },
         2: { w: 5.6, h: 58.4 },
@@ -375,10 +461,15 @@ async function main() {
           recordedBy,
         },
       });
+      growthCreated++;
     }
-    console.log(
-      `  Seeded ${measurements.length} growth records for ${pediatricPatient.user.name}`
-    );
+    if (growthCreated > 0) {
+      console.log(
+        `  Seeded ${growthCreated} new growth record(s) for ${pediatricPatient.user.name} (skipped any already present)`,
+      );
+    } else {
+      console.log(`  All milestone growth records already present for ${pediatricPatient.user.name}.`);
+    }
   }
 
   console.log("\n=== Phase 4 Specialty seed complete ===");


### PR DESCRIPTION
## Summary

Wave 4 of the deploy.sh seed-idempotency long-tail. Three phase4 seed files hardened so deploy.sh can safely re-seed them on every push without duplicating rows OR wiping user-created data.

The HARDEST lane in this batch — two of the three files contained `deleteMany({})` upfront (unscoped wipe of EVERY row in PatientFeedback / Complaint / ChatRoom / ChatParticipant / ChatMessage / Visitor / GrowthRecord before recreating from scratch). Removed all four `deleteMany` calls and replaced with stable-id / deterministic-anchor guards.

### Stable-id namespacing

- `ANC-SEED-NNNN` (AntenatalCase, 1..3) — distinct from live `ANC000001..` counter
- `CMP-PH4-SEED-NNNN` (Complaint, 1..5) — distinct from live `CMP000001..` AND from `seed-complaints-data.ts`'s `CMP-SEED-NNNN`
- `VIS-PH4-SEED-NNNN` (Visitor, 1..8) — distinct from live counter AND from `seed-visitors-history.ts`'s `VIS-HIST-SEED-NNNN`
- `[PH4-ENG-CHAT-SEED-<roomKey>-NNNN]` content prefix (ChatMessage)
- `[PH4-OPS-ASSIGN-SEED-NNNN]` notes prefix (AssetAssignment)

### deleteMany removal strategy per file

- **seed-phase4-specialty.ts** — partial removal:
  - 1× `deleteMany({where:{patientId}})` on GrowthRecord → replaced with (patientId, ageMonths) findFirst skip-or-create
  - AntenatalCase already used `findUnique({where:{patientId}})` guard — extended to `caseNumber` stable seed-id
- **seed-phase4-engagement.ts** — full removal:
  - 4× `deleteMany({})` (unscoped — PatientFeedback / Complaint / ChatMessage / ChatParticipant / ChatRoom / Visitor)
  - All replaced with per-row stable-id or deterministic-anchor guards
  - `Math.random()` swapped for fixed-seed mulberry32 PRNG (partial-run recovery stays byte-identical)
- **seed-phase4-ops.ts** — N/A (no `deleteMany`, already idempotent):
  - Tightened the last three coarse `count() === 0` gates (AmbulanceTrip / AssetAssignment / AssetMaintenance) into per-row findUnique/findFirst guards

### Constraints respected

- `scripts/deploy.sh` NOT touched (orchestrator will wire all 3 lanes after merge, per the "don't touch deploy.sh" instruction to avoid the yesterday's merge-conflict storm)
- No live production counters or sequences touched
- File-scope commit (3 seed files only)
- `tsc --noEmit -p packages/db` clean

## Test plan

- [ ] CI Test green
- [ ] `chore/seed-enhancements-idempotency` (lane A) and `chore/seed-ipd-pediatric-ops-idempotency-v2` (lane B) merge cleanly alongside
- [ ] Orchestrator's deploy.sh wave-4 wire-in commit lands without conflicts
- [ ] After deploy.sh wire-in: re-run all 3 seeds on the populated demo DB → 0 new rows on 2nd run, no `[unique constraint]` errors