### PR TITLE
bug fixes 2.0

### DIFF
--- a/apps/api/src/routes/billing.ts
+++ b/apps/api/src/routes/billing.ts
@@ -187,7 +187,18 @@ router.post(
             packageDiscount,
             advanceApplied,
             totalAmount: Math.max(0, +totalAmount.toFixed(2)),
-            dueDate: dueDate ? new Date(dueDate) : undefined,
+            // Issue #902: when the caller doesn't supply a dueDate, default
+            // to createdAt + 14 days so the dunning + late-fee scheduler has
+            // something to age against. Previously this fell through to
+            // `undefined` → null in the DB, and 50% of PENDING invoices sat
+            // at "0 days overdue" forever — receivables never aged, no
+            // dunning fired, no late-fee revenue accumulated. The 14-day
+            // window matches the most common Indian-hospital cash-billing
+            // default; TODO: lift to a SystemConfig key (invoice_due_days)
+            // when finance asks for per-tenant policy.
+            dueDate: dueDate
+              ? new Date(dueDate)
+              : new Date(Date.now() + 14 * 24 * 60 * 60 * 1000),
             notes:
               tierDiscount > 0
                 ? `${notes ? notes + "\n" : ""}[TIER ${tier}] auto-discount Rs.${tierDiscount.toFixed(
@@ -195,6 +206,13 @@ router.post(
                   )}`
                 : notes,
             paymentStatus: advanceApplied >= totalAmount && totalAmount >= 0 ? "PAID" : "PENDING",
+            // Issue #894: persist per-line GST snapshot at create time so
+            // historical invoices retain the tax presented to the patient
+            // even if rates change later (GSTR-1 audit trail). Previously
+            // the header had cgstAmount/sgstAmount/taxAmount but every
+            // line item shipped with cgst=0/sgst=0/gstRate=0, making
+            // line-sums NOT equal the header — illegal under CGST Rule
+            // 46 and a hard reject for B2B recipients claiming ITC.
             items: {
               create: items.map(
                 (item: {
@@ -202,13 +220,21 @@ router.post(
                   category: string;
                   quantity: number;
                   unitPrice: number;
-                }) => ({
-                  description: item.description,
-                  category: item.category,
-                  quantity: item.quantity,
-                  unitPrice: item.unitPrice,
-                  amount: item.quantity * item.unitPrice,
-                })
+                }) => {
+                  const lineAmount = item.quantity * item.unitPrice;
+                  const tax = computeLineItemTax(lineAmount, item.category);
+                  return {
+                    description: item.description,
+                    category: item.category,
+                    quantity: item.quantity,
+                    unitPrice: item.unitPrice,
+                    amount: lineAmount,
+                    cgst: tax.cgst,
+                    sgst: tax.sgst,
+                    gstRate: tax.gstRate,
+                    hsnSac: tax.hsnSac,
+                  };
+                }
               ),
             },
           },
@@ -2420,14 +2446,32 @@ router.post(
             totalAmount,
             notes: notes ? `[IPD ${admission.admissionNumber}] ${notes}` : `[IPD ${admission.admissionNumber}]`,
             paymentStatus: totalAmount === 0 ? "PAID" : "PENDING",
+            // Issue #902: default dueDate to +14 days (same policy as the
+            // regular invoice-create path above) so IPD discharge bills age
+            // in the dunning queue. Previously this was unset on the IPD
+            // path and rows landed with null dueDate — invisible to the
+            // late-fee scheduler.
+            dueDate: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000),
+            // Issue #894: persist per-line GST snapshot (see invoice-create
+            // path above for the full rationale). IPD discharge bills are
+            // the canonical multi-line B2B case (room charge + drugs +
+            // procedures + lab) where GSTR-1 line-level math is required.
             items: {
-              create: safeItems.map((it) => ({
-                description: it.description,
-                category: it.category,
-                quantity: it.quantity,
-                unitPrice: it.unitPrice,
-                amount: it.quantity * it.unitPrice,
-              })),
+              create: safeItems.map((it) => {
+                const lineAmount = it.quantity * it.unitPrice;
+                const tax = computeLineItemTax(lineAmount, it.category);
+                return {
+                  description: it.description,
+                  category: it.category,
+                  quantity: it.quantity,
+                  unitPrice: it.unitPrice,
+                  amount: lineAmount,
+                  cgst: tax.cgst,
+                  sgst: tax.sgst,
+                  gstRate: tax.gstRate,
+                  hsnSac: tax.hsnSac,
+                };
+              }),
             },
           },
           include: { items: true },

--- a/apps/api/src/routes/emergency.ts
+++ b/apps/api/src/routes/emergency.ts
@@ -509,6 +509,57 @@ router.patch(
         disposition: req.body.disposition,
       }).catch(console.error);
 
+      // Issue #893: when a patient triaged RESUSCITATION / EMERGENT / URGENT
+      // leaves without being seen, the case is a patient-safety event — the
+      // QA review flagged that no alert, no complaint, no audit row, no
+      // recall task was generated. The CMO / charge nurse needed to be
+      // notified so a recall call could happen within 4h. We can't ship the
+      // full multi-channel escalation in one session (recall scheduling +
+      // complaint auto-creation are bigger features), so the minimum safety
+      // net is a HIGH-severity audit row with a greppable action name. The
+      // canonical action `ER_LWBS_SAFETY_EVENT` is what dashboards + nightly
+      // reports should pick up. `severity: "HIGH"` in `details` lets the
+      // audit viewer filter for clinical-safety events specifically.
+      const HIGH_TRIAGE = ["RESUSCITATION", "EMERGENT", "URGENT"];
+      const isLwbs = req.body.status === "LEFT_WITHOUT_BEING_SEEN";
+      const isHighTriage = HIGH_TRIAGE.includes(updated.triageLevel ?? "");
+      if (isLwbs && isHighTriage) {
+        auditLog(
+          req,
+          "ER_LWBS_SAFETY_EVENT",
+          "emergencyCase",
+          updated.id,
+          {
+            severity: "HIGH",
+            triageLevel: updated.triageLevel,
+            patientId: updated.patientId,
+            patientName: updated.patient?.user?.name ?? null,
+            patientPhone: updated.patient?.user?.phone ?? null,
+            attendingDoctorId: updated.attendingDoctorId ?? null,
+            outcomeNotes: req.body.outcomeNotes ?? null,
+            closedAt: updated.closedAt?.toISOString() ?? null,
+            recallNeededWithinHours: 4,
+            reason:
+              "Patient left ER without being seen despite high-acuity triage; clinical leadership must follow up.",
+          },
+        ).catch((e) =>
+          console.warn("[emergency] LWBS safety audit failed (non-fatal):", e),
+        );
+        // Broadcast a separate socket event so the live ER board + dashboard
+        // banners can surface a safety alert immediately, rather than the
+        // generic `emergency:update` that fires for every disposition change.
+        const io2 = req.app.get("io");
+        if (io2) {
+          io2.emit("emergency:lwbs-safety-event", {
+            caseId: updated.id,
+            triageLevel: updated.triageLevel,
+            patientId: updated.patientId,
+            patientName: updated.patient?.user?.name ?? null,
+            severity: "HIGH",
+          });
+        }
+      }
+
       const io = req.app.get("io");
       if (io) {
         io.emit("emergency:update", {

--- a/apps/api/src/routes/patients-dup-checks.test.ts
+++ b/apps/api/src/routes/patients-dup-checks.test.ts
@@ -66,13 +66,31 @@ function buildApp() {
 
 function tokenFor(role: string, userId = "u-1") {
   return jwt.sign(
-    { userId, email: `${role.toLowerCase()}@test.local`, role },
+    {
+      userId,
+      email: `${role.toLowerCase()}@test.local`,
+      role,
+      // Issue #895: patient-create now requires a tenantId on the JWT to
+      // defend against legacy-token writes that produced rows with
+      // tenantId:null. All existing dup-check assertions still hold;
+      // adding the claim here just lets the request pass the new guard
+      // and reach the actual duplicate-detection path.
+      tenantId: "t-test-1",
+    },
     "test-secret",
   );
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Issue #892: patient-create now also calls findMany() for the
+  // name+DOB / name+gender soft-duplicate check. The existing tests
+  // only stubbed findFirst (phone + email pre-checks); unstubbed
+  // findMany returns undefined and 500s the request before the
+  // intended assertion. Default to [] (no duplicates by name) so the
+  // request flows past my new check and into the legacy phone/email
+  // checks each test is actually targeting.
+  prismaMock.patient.findMany.mockResolvedValue([]);
 });
 
 describe("POST /patients — Issue #595 (email duplicate pre-check)", () => {

--- a/apps/api/src/routes/patients.ts
+++ b/apps/api/src/routes/patients.ts
@@ -215,6 +215,38 @@ router.post(
     try {
       const data = req.body;
 
+      // Issue #895 (CRITICAL — multi-tenant isolation): tenantScopedPrisma
+      // injects tenantId on create only when AsyncLocalStorage has one. ALS
+      // is populated by withTenantContext middleware from req.tenantId,
+      // which in turn comes from req.user.tenantId resolved by authenticate.
+      // If the caller's JWT was minted before tenant rollout (or their User
+      // row has tenantId: null), the entire chain silently no-ops and a new
+      // Patient row gets written with tenantId: null — orphan PHI invisible
+      // to scoped reads but still leakable via raw client. Refuse the write
+      // with a clear "re-login required" message instead. Legacy-token
+      // users hit this once, log out, log back in, and their re-issued JWT
+      // carries the now-populated User.tenantId. Note: this is a defence-
+      // in-depth guard at the WRITE endpoint specifically because patient
+      // creation is the canonical example in the issue report; the same
+      // pattern should be applied to other tenant-scoped POST endpoints
+      // (admissions, prescriptions, lab orders, pharmacy inventory) in
+      // follow-up PRs.
+      if (!req.user?.tenantId) {
+        res.status(400).json({
+          success: false,
+          data: null,
+          error: "Your session is missing tenant context. Please log out and log back in.",
+          details: [
+            {
+              field: "tenant",
+              message:
+                "No tenantId on access token. This usually means a legacy token issued before tenant rollout — sign out and sign in again to refresh.",
+            },
+          ],
+        });
+        return;
+      }
+
       // Issue #103 (Apr 2026): pre-check for an existing patient with the
       // same phone before creating a duplicate MR record. We surface the
       // matching MR number so reception can pull up the existing chart
@@ -246,6 +278,80 @@ router.post(
               mrNumber: existing.mrNumber,
               name: existing.user?.name ?? null,
             },
+          });
+          return;
+        }
+      }
+
+      // Issue #892 (May 2026): the phone+email guards above protect against
+      // identical contact details, but reception was still able to create
+      // two patients with the same name and DOB but different phones —
+      // splitting one real person's medical history across two MR numbers.
+      // The fix is a soft block: when the (name, DOB) tuple already exists
+      // (or, when DOB is absent, (name, gender)), 409 with the existing
+      // record(s) so reception can pick the existing chart. Reception can
+      // override the block by sending `confirmDuplicate: true` in the body
+      // (when they're sure it's a different person who happens to share a
+      // name) — that path is audited so we can review intentional overrides.
+      const trimmedName =
+        typeof data.name === "string" ? data.name.trim() : "";
+      const confirmDuplicate = data.confirmDuplicate === true;
+      if (trimmedName.length > 0 && !confirmDuplicate) {
+        // Build the soft-match where clause. Use a tighter (name + DOB)
+        // match when DOB is supplied; fall back to (name + gender) when
+        // DOB is absent. Name match is case-insensitive but exact — we do
+        // NOT do Levenshtein-distance fuzzy matching here because that
+        // would false-positive across genuinely-distinct patients.
+        const matchClause = data.dateOfBirth
+          ? {
+              mergedIntoId: null,
+              dateOfBirth: new Date(data.dateOfBirth),
+              user: {
+                name: { equals: trimmedName, mode: "insensitive" as const },
+              },
+            }
+          : {
+              mergedIntoId: null,
+              gender: data.gender,
+              user: {
+                name: { equals: trimmedName, mode: "insensitive" as const },
+              },
+            };
+        const candidates = await prisma.patient.findMany({
+          where: matchClause,
+          select: {
+            id: true,
+            mrNumber: true,
+            dateOfBirth: true,
+            gender: true,
+            user: {
+              select: { name: true, phone: true },
+            },
+          },
+          take: 5,
+        });
+        if (candidates.length > 0) {
+          const matchedOn = data.dateOfBirth
+            ? "name + date of birth"
+            : "name + gender";
+          res.status(409).json({
+            success: false,
+            data: null,
+            error: `A patient with the same ${matchedOn} already exists. Pick the existing chart, or resubmit with confirmDuplicate=true if this is a different person.`,
+            details: [
+              {
+                field: "name",
+                message: `Possible duplicate of ${candidates[0].user?.name ?? "existing patient"} (MR: ${candidates[0].mrNumber}).`,
+              },
+            ],
+            existingPatients: candidates.map((c) => ({
+              id: c.id,
+              mrNumber: c.mrNumber,
+              name: c.user?.name ?? null,
+              phone: c.user?.phone ?? null,
+              dateOfBirth: c.dateOfBirth?.toISOString() ?? null,
+              gender: c.gender,
+            })),
           });
           return;
         }
@@ -359,6 +465,21 @@ router.post(
 
         return { ...patient, user: { id: user.id, name: user.name, email: user.email, phone: user.phone } };
       });
+
+      // Issue #892: audit the duplicate-override path so we can review
+      // intentional "different person, same name" creations later. The
+      // normal create path is not audited (would balloon the audit table
+      // with routine reception traffic); only the soft-block bypass is.
+      if (confirmDuplicate) {
+        auditLog(req, "PATIENT_DUPLICATE_OVERRIDE", "patient", result.id, {
+          mrNumber: result.mrNumber,
+          name: trimmedName,
+          dateOfBirth: data.dateOfBirth ?? null,
+          gender: data.gender,
+        }).catch((e) =>
+          console.warn("[patients] audit override failed (non-fatal):", e),
+        );
+      }
 
       res.status(201).json({ success: true, data: result, error: null });
     } catch (err) {

--- a/apps/api/src/routes/prescriptions.ts
+++ b/apps/api/src/routes/prescriptions.ts
@@ -520,6 +520,39 @@ router.post(
       // prescription; staff already cleared the authorize() gate above.
       if (!(await assertPatientOwnsResource(req, res, existing.patientId))) return;
 
+      // Issue #897 (clinical-safety CRITICAL): refuse to share a
+      // prescription that hasn't actually been signed by the doctor.
+      // Pre-fix, the share-link endpoint emitted EMAIL / WHATSAPP / SMS
+      // to patients regardless of `signatureUrl`, so a prescription
+      // written but never signed (doctor's `User.signatureUrl` is null
+      // → row's `signatureUrl` is null too) reached the patient looking
+      // identical to a signed one. A pharmacy could dispense, the
+      // patient could self-administer, and there's no doctor's name on
+      // the legal hook. We block on signatureUrl null AND on the
+      // already-terminal statuses (CANCELLED / REJECTED) so a cancelled
+      // prescription can't be retroactively shared.
+      if (
+        !existing.signatureUrl ||
+        existing.status === "CANCELLED" ||
+        existing.status === "REJECTED"
+      ) {
+        const reason = !existing.signatureUrl
+          ? "Prescription has not been signed by the doctor. Cannot share an unsigned prescription with the patient."
+          : `Prescription is ${existing.status}; cannot share.`;
+        res.status(400).json({
+          success: false,
+          data: null,
+          error: reason,
+          details: [
+            {
+              field: "status",
+              message: reason,
+            },
+          ],
+        });
+        return;
+      }
+
       // Same fallback as the QR-generation sites in pdf.ts / pdf-generator.ts
       // — keep them in lockstep so that on a live host where PUBLIC_APP_URL
       // is unset, the QR, the email link, AND the WhatsApp link all point at

--- a/apps/api/src/test/factories.ts
+++ b/apps/api/src/test/factories.ts
@@ -16,6 +16,18 @@ let bedSeq = 0;
 
 export async function createUserFixture(overrides: Partial<any> = {}) {
   const prisma = await getPrisma();
+  // Issue #895: every fixture-created User must be tenant-bound so any
+  // JWT minted from this row carries a real tenantId. Find-or-create the
+  // default test tenant — same one resetDB() and getAuthToken() use, so
+  // there's exactly one tenant scope across the whole integration suite.
+  const tenantId = overrides.tenantId ?? (await (async () => {
+    const t = await prisma.tenant.findFirst({ where: { slug: "test-tenant" } });
+    if (t) return t.id;
+    const created = await prisma.tenant.create({
+      data: { name: "Test Tenant", slug: "test-tenant", active: true },
+    });
+    return created.id;
+  })());
   return prisma.user.create({
     data: {
       email:
@@ -26,6 +38,7 @@ export async function createUserFixture(overrides: Partial<any> = {}) {
       passwordHash: await bcrypt.hash(overrides.password || "MedCoreT3st-2026", 4),
       role: overrides.role || "PATIENT",
       isActive: overrides.isActive ?? true,
+      tenantId,
     },
   });
 }
@@ -98,6 +111,14 @@ export async function createDoctorWithToken(
   const email =
     overrides.email ||
     `doctor_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@test.local`;
+  // Issue #895: every test User needs a tenant — find-or-create the default
+  // test tenant and link this doctor to it so the JWT carries a tenantId
+  // and tenant-guarded write endpoints don't 400.
+  const testTenant = await prisma.tenant.findFirst({
+    where: { slug: "test-tenant" },
+  }) ?? await prisma.tenant.create({
+    data: { name: "Test Tenant", slug: "test-tenant", active: true },
+  });
   const user = await prisma.user.create({
     data: {
       email,
@@ -105,6 +126,7 @@ export async function createDoctorWithToken(
       phone: overrides.phone || faker.string.numeric(10),
       passwordHash: await bcrypt.hash("MedCoreT3st-2026", 4),
       role: "DOCTOR",
+      tenantId: testTenant.id,
     },
   });
   const doctor = await prisma.doctor.create({
@@ -112,11 +134,26 @@ export async function createDoctorWithToken(
       userId: user.id,
       specialization: overrides.specialization || "General Medicine",
       qualification: overrides.qualification || "MBBS",
+      // Issue #897: prescriptions created by this doctor inherit the
+      // signatureUrl (see routes/prescriptions.ts line 204). Without a
+      // default here, every route-created Rx in tests lands with
+      // signatureUrl:null and can't be shared (the new clinical-safety
+      // guard 400s). Tests asserting the unsigned-refuse path can
+      // override via `overrides: { signatureUrl: null }`.
+      signatureUrl:
+        overrides && "signatureUrl" in overrides
+          ? overrides.signatureUrl
+          : "https://example.com/test-doctor-signature.png",
     },
     include: { user: true },
   });
   const token = jwt.sign(
-    { userId: user.id, email: user.email, role: "DOCTOR" },
+    {
+      userId: user.id,
+      email: user.email,
+      role: "DOCTOR",
+      tenantId: testTenant.id,
+    },
     process.env.JWT_SECRET || "test-jwt-secret-do-not-use-in-prod",
     { expiresIn: "1h" }
   );
@@ -440,6 +477,15 @@ export async function createPrescriptionFixture(args: {
   overrides?: Partial<any>;
 }) {
   const prisma = await getPrisma();
+  // Issue #897 (May 2026): the share endpoint now refuses 400 when
+  // signatureUrl IS NULL (clinical safety — unsigned Rx must not reach
+  // patients). Tests that exercise the share path need a signed
+  // prescription by default; tests that want to assert the unsigned-
+  // refuse path can pass `overrides: { signatureUrl: null }` explicitly.
+  const signatureUrl =
+    args.overrides && "signatureUrl" in args.overrides
+      ? args.overrides.signatureUrl
+      : "https://example.com/test-signature.png";
   return prisma.prescription.create({
     data: {
       patientId: args.patientId,
@@ -447,6 +493,7 @@ export async function createPrescriptionFixture(args: {
       appointmentId: args.appointmentId,
       diagnosis: args.overrides?.diagnosis || "Acute pharyngitis",
       advice: args.overrides?.advice || "Rest and fluids",
+      signatureUrl,
       items: {
         create: [
           {

--- a/apps/api/src/test/factories.ts
+++ b/apps/api/src/test/factories.ts
@@ -20,11 +20,12 @@ export async function createUserFixture(overrides: Partial<any> = {}) {
   // JWT minted from this row carries a real tenantId. Find-or-create the
   // default test tenant — same one resetDB() and getAuthToken() use, so
   // there's exactly one tenant scope across the whole integration suite.
+  // Schema column is `subdomain @unique`, not `slug`.
   const tenantId = overrides.tenantId ?? (await (async () => {
-    const t = await prisma.tenant.findFirst({ where: { slug: "test-tenant" } });
+    const t = await prisma.tenant.findFirst({ where: { subdomain: "test-tenant" } });
     if (t) return t.id;
     const created = await prisma.tenant.create({
-      data: { name: "Test Tenant", slug: "test-tenant", active: true },
+      data: { name: "Test Tenant", subdomain: "test-tenant", active: true },
     });
     return created.id;
   })());
@@ -113,11 +114,12 @@ export async function createDoctorWithToken(
     `doctor_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@test.local`;
   // Issue #895: every test User needs a tenant — find-or-create the default
   // test tenant and link this doctor to it so the JWT carries a tenantId
-  // and tenant-guarded write endpoints don't 400.
+  // and tenant-guarded write endpoints don't 400. Schema column is
+  // `subdomain @unique` (not `slug`).
   const testTenant = await prisma.tenant.findFirst({
-    where: { slug: "test-tenant" },
+    where: { subdomain: "test-tenant" },
   }) ?? await prisma.tenant.create({
-    data: { name: "Test Tenant", slug: "test-tenant", active: true },
+    data: { name: "Test Tenant", subdomain: "test-tenant", active: true },
   });
   const user = await prisma.user.create({
     data: {

--- a/apps/api/src/test/setup.ts
+++ b/apps/api/src/test/setup.ts
@@ -47,8 +47,13 @@ export async function resetDB() {
     }
   );
 
-  // Seed minimal admin user
+  // Seed minimal admin user under a default test tenant.
+  // Issue #895: integration tests need a real tenant so JWTs minted by
+  // getAuthToken() carry a non-null tenantId — the patient-create guard
+  // (and the broader pattern documented in patients.ts) refuses 400
+  // when the caller's JWT has no tenant context.
   const prisma = await getPrisma();
+  const tenant = await ensureDefaultTestTenant(prisma);
   await prisma.user.create({
     data: {
       email: "admin@test.local",
@@ -56,6 +61,25 @@ export async function resetDB() {
       phone: "9999999999",
       passwordHash: await bcrypt.hash("MedCoreT3st-2026", 4),
       role: "ADMIN",
+      tenantId: tenant.id,
+    },
+  });
+}
+
+/**
+ * Find-or-create the default test tenant. Idempotent so it's safe to call
+ * from resetDB() AND from getAuthToken() (the latter for tests that skip
+ * resetDB and just need a tenanted user).
+ */
+async function ensureDefaultTestTenant(prisma: any): Promise<{ id: string }> {
+  const slug = "test-tenant";
+  const existing = await prisma.tenant.findFirst({ where: { slug } });
+  if (existing) return existing;
+  return prisma.tenant.create({
+    data: {
+      name: "Test Tenant",
+      slug,
+      active: true,
     },
   });
 }
@@ -76,6 +100,9 @@ export type TestRole =
 export async function getAuthToken(role: TestRole = "ADMIN"): Promise<string> {
   const prisma = await getPrisma();
   const email = `${role.toLowerCase()}@test.local`;
+  // Issue #895: every test User must be tenant-bound so the JWT carries a
+  // real tenantId and the patient-create / future write-guards don't 400.
+  const tenant = await ensureDefaultTestTenant(prisma);
   let user = await prisma.user.findUnique({ where: { email } });
   if (!user) {
     user = await prisma.user.create({
@@ -85,7 +112,15 @@ export async function getAuthToken(role: TestRole = "ADMIN"): Promise<string> {
         phone: "9000000000",
         passwordHash: await bcrypt.hash("MedCoreT3st-2026", 4),
         role: role as any,
+        tenantId: tenant.id,
       },
+    });
+  } else if (!(user as { tenantId?: string | null }).tenantId) {
+    // Pre-#895 test user — backfill the tenant link so subsequent
+    // getAuthToken() calls mint tenant-bearing JWTs.
+    user = await prisma.user.update({
+      where: { id: user.id },
+      data: { tenantId: tenant.id },
     });
   }
   // For PATIENT role, ensure a linked Patient row exists. Several routes
@@ -108,8 +143,19 @@ export async function getAuthToken(role: TestRole = "ADMIN"): Promise<string> {
       });
     }
   }
+  // Issue #895 (May 2026): patient-create (and a growing set of write
+  // endpoints) now refuses 400 when the caller's JWT has no `tenantId`,
+  // as a defence-in-depth against legacy tokens producing tenantId:null
+  // rows. The find-or-create above guarantees user.tenantId is populated.
+  const tenantId =
+    (user as { tenantId?: string | null }).tenantId ?? tenant.id;
   return jwt.sign(
-    { userId: user.id, email: user.email, role: user.role },
+    {
+      userId: user.id,
+      email: user.email,
+      role: user.role,
+      tenantId,
+    },
     process.env.JWT_SECRET || "test-jwt-secret-do-not-use-in-prod",
     { expiresIn: "1h" }
   );

--- a/apps/api/src/test/setup.ts
+++ b/apps/api/src/test/setup.ts
@@ -72,13 +72,16 @@ export async function resetDB() {
  * resetDB and just need a tenanted user).
  */
 async function ensureDefaultTestTenant(prisma: any): Promise<{ id: string }> {
-  const slug = "test-tenant";
-  const existing = await prisma.tenant.findFirst({ where: { slug } });
+  // Schema uses `subdomain @unique`, not `slug` (prior commit accidentally
+  // referenced the wrong column name and crashed every integration suite
+  // at resetDB() with "Unknown argument `slug`").
+  const subdomain = "test-tenant";
+  const existing = await prisma.tenant.findFirst({ where: { subdomain } });
   if (existing) return existing;
   return prisma.tenant.create({
     data: {
       name: "Test Tenant",
-      slug,
+      subdomain,
       active: true,
     },
   });

--- a/packages/db/src/seed-pharmacy.ts
+++ b/packages/db/src/seed-pharmacy.ts
@@ -11,6 +11,22 @@ const prisma = new PrismaClient();
 // Issue #41: every row has a realistic Indian manufacturer in `brand` (the
 //   medicines.manufacturer UI column reads from `brand` via the API alias
 //   layer — see apps/api/src/services/medicines/serialize.ts).
+// Issue #899: every prescription drug should carry regulatory metadata —
+// `schedule` (H / H1 / X per India's Drugs & Cosmetics Act 1940) and
+// `isNarcotic` / `requiresRegister` (NDPS Act 1985) — so the controlled-
+// substance register, dispensing alerts, and patient-safety guards have
+// real data to fire on. Pre-#899 the master had 82 medicines with all
+// regulatory flags either false or null, so narcotic-handling code was
+// dead weight in the codebase.
+//
+// Field semantics:
+//   schedule           — "H", "H1", "X", "G", or undefined for OTC
+//   isNarcotic         — true ONLY for opioids + controlled-narcotic
+//                        substances under NDPS. Sedatives / barbiturates
+//                        are Schedule H1 but NOT narcotic.
+//   requiresRegister   — true for Schedule H1 + X; entries must be logged
+//                        in the controlled-register page.
+//   maxDailyDoseMg     — soft cap for overdose alerts (mg/day adult).
 const MEDICINES: Array<{
   name: string;
   genericName: string;
@@ -21,6 +37,10 @@ const MEDICINES: Array<{
   manufacturer: string;
   sideEffects?: string;
   contraindications?: string;
+  schedule?: "H" | "H1" | "X" | "G";
+  isNarcotic?: boolean;
+  requiresRegister?: boolean;
+  maxDailyDoseMg?: number;
 }> = [
   // ── OTC analgesics / vitamins / electrolytes ─────────
   { name: "Paracetamol 500mg", genericName: "Paracetamol", form: "Tablet", strength: "500mg", category: "Analgesic", prescriptionRequired: false, manufacturer: "GSK", sideEffects: "Rare: rash, nausea", contraindications: "Severe liver disease" },
@@ -29,13 +49,13 @@ const MEDICINES: Array<{
   // brief (#40). Higher strengths and aspirin-paracetamol combos remain RX
   // and SHOULD be flagged true if added to the catalog later.
   { name: "Aspirin 75mg", genericName: "Acetylsalicylic acid", form: "Tablet", strength: "75mg", category: "Antiplatelet", prescriptionRequired: false, manufacturer: "USV", sideEffects: "Bleeding, GI upset", contraindications: "Active bleeding, children <16" },
-  // ── Antibiotics (ALL prescription-only) ──────────────
-  { name: "Amoxicillin 500mg", genericName: "Amoxicillin", form: "Capsule", strength: "500mg", category: "Antibiotic", prescriptionRequired: true, manufacturer: "Cipla", sideEffects: "Rash, diarrhea", contraindications: "Penicillin allergy" },
-  { name: "Azithromycin 500mg", genericName: "Azithromycin", form: "Tablet", strength: "500mg", category: "Antibiotic", prescriptionRequired: true, manufacturer: "Alembic", sideEffects: "Nausea, QT prolongation", contraindications: "Macrolide allergy" },
-  { name: "Ciprofloxacin 500mg", genericName: "Ciprofloxacin", form: "Tablet", strength: "500mg", category: "Antibiotic", prescriptionRequired: true, manufacturer: "Dr. Reddy's", sideEffects: "Tendonitis, GI upset", contraindications: "Pregnancy, children" },
-  { name: "Doxycycline 100mg", genericName: "Doxycycline", form: "Capsule", strength: "100mg", category: "Antibiotic", prescriptionRequired: true, manufacturer: "Zydus", sideEffects: "Photosensitivity", contraindications: "Pregnancy, children <8" },
-  { name: "Metronidazole 400mg", genericName: "Metronidazole", form: "Tablet", strength: "400mg", category: "Antibiotic", prescriptionRequired: true, manufacturer: "Alkem", sideEffects: "Metallic taste, nausea", contraindications: "Alcohol use" },
-  { name: "Cefixime 200mg", genericName: "Cefixime", form: "Tablet", strength: "200mg", category: "Antibiotic", prescriptionRequired: true, manufacturer: "Lupin", sideEffects: "Diarrhea, rash" },
+  // ── Antibiotics (ALL prescription-only, Schedule H per D&C Act) ──
+  { name: "Amoxicillin 500mg", genericName: "Amoxicillin", form: "Capsule", strength: "500mg", category: "Antibiotic", prescriptionRequired: true, manufacturer: "Cipla", sideEffects: "Rash, diarrhea", contraindications: "Penicillin allergy", schedule: "H", maxDailyDoseMg: 4000 },
+  { name: "Azithromycin 500mg", genericName: "Azithromycin", form: "Tablet", strength: "500mg", category: "Antibiotic", prescriptionRequired: true, manufacturer: "Alembic", sideEffects: "Nausea, QT prolongation", contraindications: "Macrolide allergy", schedule: "H", maxDailyDoseMg: 500 },
+  { name: "Ciprofloxacin 500mg", genericName: "Ciprofloxacin", form: "Tablet", strength: "500mg", category: "Antibiotic", prescriptionRequired: true, manufacturer: "Dr. Reddy's", sideEffects: "Tendonitis, GI upset", contraindications: "Pregnancy, children", schedule: "H", maxDailyDoseMg: 1500 },
+  { name: "Doxycycline 100mg", genericName: "Doxycycline", form: "Capsule", strength: "100mg", category: "Antibiotic", prescriptionRequired: true, manufacturer: "Zydus", sideEffects: "Photosensitivity", contraindications: "Pregnancy, children <8", schedule: "H", maxDailyDoseMg: 200 },
+  { name: "Metronidazole 400mg", genericName: "Metronidazole", form: "Tablet", strength: "400mg", category: "Antibiotic", prescriptionRequired: true, manufacturer: "Alkem", sideEffects: "Metallic taste, nausea", contraindications: "Alcohol use", schedule: "H", maxDailyDoseMg: 2400 },
+  { name: "Cefixime 200mg", genericName: "Cefixime", form: "Tablet", strength: "200mg", category: "Antibiotic", prescriptionRequired: true, manufacturer: "Lupin", sideEffects: "Diarrhea, rash", schedule: "H", maxDailyDoseMg: 400 },
   // ── Antihistamines (OTC) ─────────────────────────────
   { name: "Cetirizine 10mg", genericName: "Cetirizine", form: "Tablet", strength: "10mg", category: "Antihistamine", prescriptionRequired: false, manufacturer: "GSK", sideEffects: "Drowsiness, dry mouth" },
   { name: "Loratadine 10mg", genericName: "Loratadine", form: "Tablet", strength: "10mg", category: "Antihistamine", prescriptionRequired: false, manufacturer: "Glenmark" },
@@ -75,6 +95,22 @@ const MEDICINES: Array<{
   { name: "Iron + Folic Acid", genericName: "Ferrous sulfate + Folic acid", form: "Tablet", strength: "100mg+0.5mg", category: "Hematinic", prescriptionRequired: false, manufacturer: "Emcure" },
   { name: "Calcium Carbonate 500mg", genericName: "Calcium carbonate", form: "Tablet", strength: "500mg", category: "Supplement", prescriptionRequired: false, manufacturer: "Abbott India" },
   { name: "ORS Sachet", genericName: "Oral Rehydration Salts", form: "Sachet", strength: "21g", category: "Electrolyte", prescriptionRequired: false, manufacturer: "FDC" },
+  // ── Controlled / Narcotic (Issue #899) ───────────────
+  // Opioids — Schedule X under D&C Act + NDPS Act 1985. requiresRegister
+  // defaults to true via the schedule=X mapping below; explicit here for
+  // readability.
+  { name: "Tramadol 50mg", genericName: "Tramadol", form: "Capsule", strength: "50mg", category: "Opioid Analgesic", prescriptionRequired: true, manufacturer: "Sun Pharma", sideEffects: "Drowsiness, nausea, dependence", contraindications: "MAOI use, epilepsy", schedule: "H1", isNarcotic: true, requiresRegister: true, maxDailyDoseMg: 400 },
+  { name: "Morphine 10mg/ml", genericName: "Morphine", form: "Injection", strength: "10mg/ml", category: "Opioid Analgesic", prescriptionRequired: true, manufacturer: "Neon Labs", sideEffects: "Respiratory depression, dependence, constipation", contraindications: "Respiratory failure, paralytic ileus", schedule: "X", isNarcotic: true, requiresRegister: true, maxDailyDoseMg: 60 },
+  { name: "Pethidine 50mg/ml", genericName: "Pethidine (Meperidine)", form: "Injection", strength: "50mg/ml", category: "Opioid Analgesic", prescriptionRequired: true, manufacturer: "Neon Labs", sideEffects: "Respiratory depression, seizures, dependence", contraindications: "MAOI use, renal failure", schedule: "X", isNarcotic: true, requiresRegister: true, maxDailyDoseMg: 600 },
+  { name: "Fentanyl 50mcg/ml", genericName: "Fentanyl", form: "Injection", strength: "50mcg/ml", category: "Opioid Analgesic", prescriptionRequired: true, manufacturer: "Themis Medicare", sideEffects: "Respiratory depression, dependence, chest-wall rigidity", contraindications: "Respiratory failure", schedule: "X", isNarcotic: true, requiresRegister: true, maxDailyDoseMg: 0.4 },
+  { name: "Codeine + Paracetamol", genericName: "Codeine phosphate + Paracetamol", form: "Tablet", strength: "30mg+500mg", category: "Opioid Analgesic", prescriptionRequired: true, manufacturer: "Wockhardt", sideEffects: "Drowsiness, constipation, dependence", contraindications: "Children <12, respiratory disease", schedule: "H1", isNarcotic: true, requiresRegister: true, maxDailyDoseMg: 240 },
+  // Benzodiazepines / sedatives — Schedule H1, NOT narcotic. Still
+  // require register entries for dispensing under D&C Act.
+  { name: "Diazepam 5mg", genericName: "Diazepam", form: "Tablet", strength: "5mg", category: "Anxiolytic", prescriptionRequired: true, manufacturer: "Cipla", sideEffects: "Sedation, dependence, amnesia", contraindications: "Severe respiratory failure, myasthenia gravis", schedule: "H1", isNarcotic: false, requiresRegister: true, maxDailyDoseMg: 40 },
+  { name: "Alprazolam 0.5mg", genericName: "Alprazolam", form: "Tablet", strength: "0.5mg", category: "Anxiolytic", prescriptionRequired: true, manufacturer: "Torrent", sideEffects: "Sedation, dependence, rebound anxiety", contraindications: "Acute narrow-angle glaucoma", schedule: "H1", isNarcotic: false, requiresRegister: true, maxDailyDoseMg: 4 },
+  { name: "Lorazepam 2mg", genericName: "Lorazepam", form: "Tablet", strength: "2mg", category: "Anxiolytic", prescriptionRequired: true, manufacturer: "Pfizer India", sideEffects: "Sedation, dependence", schedule: "H1", isNarcotic: false, requiresRegister: true, maxDailyDoseMg: 10 },
+  // Barbiturate antiepileptic — Schedule H, register-trackable
+  { name: "Phenobarbital 30mg", genericName: "Phenobarbital", form: "Tablet", strength: "30mg", category: "Antiepileptic", prescriptionRequired: true, manufacturer: "Abbott India", sideEffects: "Sedation, paradoxical excitement (children)", contraindications: "Porphyria", schedule: "H", isNarcotic: false, requiresRegister: true, maxDailyDoseMg: 300 },
 ];
 
 // ─── DRUG INTERACTIONS ─────────────────────────────────
@@ -166,6 +202,13 @@ async function main() {
   // #41 for why we don't use a dedicated `manufacturer` column.
   const medicineRecords: Record<string, string> = {};
   for (const m of MEDICINES) {
+    // Issue #899: persist regulatory metadata so the controlled-register,
+    // overdose alerts, and dispensing guards have real data. Default
+    // `requiresRegister` to true whenever `schedule` is H1/X — that's
+    // the legal floor under India's D&C Act.
+    const requiresRegister =
+      m.requiresRegister ??
+      (m.schedule === "H1" || m.schedule === "X");
     const med = await prisma.medicine.upsert({
       where: { name: m.name },
       update: {
@@ -177,6 +220,11 @@ async function main() {
         sideEffects: m.sideEffects,
         contraindications: m.contraindications,
         prescriptionRequired: m.prescriptionRequired,
+        schedule: m.schedule ?? null,
+        scheduleClass: m.schedule ?? null,
+        isNarcotic: m.isNarcotic ?? false,
+        requiresRegister,
+        maxDailyDoseMg: m.maxDailyDoseMg ?? null,
       },
       create: {
         name: m.name,
@@ -188,6 +236,11 @@ async function main() {
         sideEffects: m.sideEffects,
         contraindications: m.contraindications,
         prescriptionRequired: m.prescriptionRequired,
+        schedule: m.schedule ?? null,
+        scheduleClass: m.schedule ?? null,
+        isNarcotic: m.isNarcotic ?? false,
+        requiresRegister,
+        maxDailyDoseMg: m.maxDailyDoseMg ?? null,
       },
     });
     medicineRecords[m.name] = med.id;

--- a/packages/shared/src/validation/patient.ts
+++ b/packages/shared/src/validation/patient.ts
@@ -59,6 +59,13 @@ const patientBaseSchema = z.object({
   pricingTier: z
     .enum(["STANDARD", "EMPLOYEE", "SENIOR_CITIZEN", "BPL", "VIP"])
     .optional(),
+  // Issue #892: reception soft-block override. When the server returns a
+  // 409 with a duplicate-by-(name+DOB) or (name+gender) candidate list,
+  // the user can resubmit with this flag set to true to confirm "yes,
+  // this is a different person who happens to share a name" and bypass
+  // the soft block. Default false; passes through only when the client
+  // explicitly opts in.
+  confirmDuplicate: z.boolean().optional(),
 });
 
 export const createPatientSchema = patientBaseSchema.superRefine((data, ctx) => {
@@ -88,6 +95,28 @@ export const createPatientSchema = patientBaseSchema.superRefine((data, ctx) => 
         path: ["dateOfBirth"],
         message: "Date of birth must be in the past",
       });
+    } else if (typeof data.age === "number") {
+      // Issue #896: cross-field validation between age and dateOfBirth.
+      // Without this, requests like {age:80, dateOfBirth:'2020-01-01'}
+      // persisted both values and downstream code (pediatric dosing,
+      // vaccine schedules, lab reference ranges) read whichever field
+      // the call site happened to use — producing 80-year-old dosing
+      // for a 6-year-old patient or vice versa.
+      //
+      // Rule: reject when the absolute difference between submitted
+      // age and the age derived from DOB exceeds 1 year. The 1-year
+      // tolerance covers (a) timezone drift around birthdays and (b)
+      // reception entering "27" the day before someone turns 28.
+      const ageFromDob = Math.floor(
+        (Date.now() - dob.getTime()) / (365.25 * 24 * 60 * 60 * 1000)
+      );
+      if (Math.abs(data.age - ageFromDob) > 1) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["age"],
+          message: `Age (${data.age}) does not match date of birth (calculated age ${ageFromDob}). Adjust one of the two fields.`,
+        });
+      }
     }
   }
 });


### PR DESCRIPTION
|#892 | Medium | Patient soft-block on `(name, DOB)` / `(name, gender)` duplicates with `confirmDuplicate: true` override path + `PATIENT_DUPLICATE_OVERRIDE` audit row |
| #893 | HIGH (patient safety) | ER LWBS-at-high-triage now emits `ER_LWBS_SAFETY_EVENT` audit row + socket event |
| #894 | HIGH (GST compliance) | Invoice line items persist `cgst/sgst/gstRate/hsnSac` per line (CGST Rule 46) — both regular + IPD discharge paths |
| #895 | CRITICAL (security) | `POST /patients` refuses 400 when JWT carries no `tenantId` — closes the legacy-token write leak that produced `tenantId: null` rows |
| #896 | HIGH (patient safety) | Zod cross-field validation rejects when `\|age − age-from-DOB\| > 1` |
| #897 | CRITICAL (clinical safety) | `/prescriptions/:id/share` refuses when `signatureUrl IS NULL` or status is CANCELLED/REJECTED — patients can no longer receive unsigned prescriptions |
| #899 | CRITICAL (NDPS/D&C) | Medicine seed now populates `isNarcotic`, `schedule`, `requiresRegister`, `maxDailyDoseMg` on 9 new narcotic/Schedule H1/X entries + 6 antibiotic Schedule H annotations |
| #902 | HIGH (financial ops) | Invoice `dueDate` defaults to `now + 14 days` when omitted (regular + IPD paths) so AR aging fires for new invoices |
