### PR TITLE
feat(patient): Firebase phone-OTP login + patient routing chrome + sh…

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -221,3 +221,22 @@ JITSI_DOMAIN="meet.jit.si"
 # ABDM_SKIP_VERIFY=false  # dev-only: when true, webhook callbacks with
 #                         # missing/invalid signatures are allowed through
 #                         # (audited + logged). NEVER enable in production.
+
+# ── Firebase Phone Auth (patient PWA login) ──────────────────────────────────
+# The patient PWA uses Firebase Phone Authentication for the OTP flow. The
+# browser SDK initialises with NEXT_PUBLIC_FIREBASE_* (set in apps/web/
+# .env.local — see apps/web/src/lib/firebase/config.ts for the contract).
+# This block is the server-side half: firebase-admin verifies the ID token
+# the client receives after Firebase confirms the SMS code, then mints our
+# existing medcore_at / medcore_rt session cookies.
+#
+# Provisioning:
+#   1. Firebase console → Project settings → Service accounts → Generate
+#      new private key. Download the JSON.
+#   2. Drop the JSON outside the repo (e.g. /etc/medcore/firebase-sa.json).
+#      NEVER commit it.
+#   3. Point FIREBASE_ADMIN_CREDENTIALS_PATH at the absolute path.
+#   4. Set FIREBASE_PROJECT_ID to the projectId from the JSON (it must
+#      match NEXT_PUBLIC_FIREBASE_PROJECT_ID in the web .env).
+# FIREBASE_ADMIN_CREDENTIALS_PATH=/etc/medcore/firebase-sa.json
+# FIREBASE_PROJECT_ID=medcore-12345

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
-    "start": "node dist/index.js",
+    "start": "tsx src/index.ts",
+    "start:prod": "node dist/index.js",
     "lint": "tsc --noEmit",
     "bench": "vitest bench --run --root ../.. apps/api/src/services/ai",
     "hl7v2:roundtrip": "tsx src/services/hl7v2/roundtrip.ts"
@@ -27,6 +28,7 @@
     "dicom-parser": "^1.8.21",
     "expo-server-sdk": "^6.1.0",
     "express": "^5.2.1",
+    "firebase-admin": "^13.10.0",
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.2",
     "langfuse": "^3.38.20",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -345,8 +345,17 @@ export function buildApp() {
   app.use("/api/v1/status", statusRouter);
 
   // Routes
+  //
+  // Bump 2026-05-27: namespace-wide auth limit was 30/min — too tight for a
+  // dashboard SPA where every layout mount + cross-tab broadcast listener +
+  // patient-page own /auth/me probe fans out (3-4 calls per route change).
+  // A patient tab-switching ~10 times hits 30 and gets a 429 cascade that
+  // the layout's 5-attempt retry loop misreads as "session expired" →
+  // bogus /login bounce. The strict-by-design limiter on /auth/login
+  // itself (5/min, in routes/auth.ts:88) is unchanged — this just lifts
+  // the broad cap on safe operations like /auth/me.
   const authLimiter =
-    process.env.NODE_ENV === "test" ? (_: any, __: any, n: any) => n() : rateLimit(30, 60_000);
+    process.env.NODE_ENV === "test" ? (_: any, __: any, n: any) => n() : rateLimit(300, 60_000);
   app.use("/api/v1/auth", authLimiter, authRouter);
   // Pearl §5.3 / §6.1 — patient phone-OTP login (gap #5 piece 2 of 4).
   // No global authLimiter here: the router does per-phone rate limiting

--- a/apps/api/src/middleware/csrf.ts
+++ b/apps/api/src/middleware/csrf.ts
@@ -48,6 +48,17 @@ const CSRF_BYPASS_PATHS = [
   "/api/v1/auth/2fa-validate",
   "/api/v1/auth/forgot-password",
   "/api/v1/auth/reset-password",
+  // Patient bootstrap endpoints — these MINT the medcore_csrf cookie
+  // themselves so they cannot require it. Each has its own defence:
+  //   - otp-request: per-phone rate limiter (3/10min) — see patient-auth.ts
+  //   - otp-verify: bcrypt challenge with 5-min TTL + 5-attempt limit
+  //   - firebase-verify: Firebase ID-token signature + audience verification
+  //     (firebase-admin verifyIdToken with checkRevoked) — see
+  //     services/firebase-admin.ts. The verified phone_number claim drives
+  //     the patient User lookup, never the request body.
+  "/api/v1/patient-auth/otp-request",
+  "/api/v1/patient-auth/otp-verify",
+  "/api/v1/patient-auth/firebase-verify",
   // Razorpay webhook is authenticated by signature, not CSRF — and is
   // mounted before express.json so it doesn't even pass through here,
   // but list it for documentation.

--- a/apps/api/src/routes/patient-auth.ts
+++ b/apps/api/src/routes/patient-auth.ts
@@ -50,6 +50,7 @@ import {
 import { validate } from "../middleware/validate";
 import { auditLog } from "../middleware/audit";
 import { setAuthCookies } from "../middleware/auth-cookies";
+import { rateLimit } from "../middleware/rate-limit";
 import { signAccessToken, signRefreshToken } from "../services/jwt";
 import { sendSMS } from "../services/channels/sms";
 import { verifyPhoneIdToken } from "../services/firebase-admin";
@@ -425,8 +426,29 @@ router.post(
 //     is not registered, the response is the same as for an invalid
 //     token — defence against enumeration. Onboarding goes through the
 //     existing /patient/register flow.
+// Per-IP rate limiter for /firebase-verify.
+//
+// Why IP-keyed (not per-phone like /otp-request): we can only learn the
+// phone number AFTER Firebase verifies the token, which is the expensive
+// work we're trying to guard against. An attacker can't fabricate a valid
+// token, but they CAN spam the endpoint with junk tokens and force us to
+// burn Firebase Admin SDK quota / latency on each rejection.
+//
+// 20/min/IP — generous enough for a legitimate patient who fat-fingers
+// the OTP a few times and re-mints, hostile enough to make brute-forcing
+// pointless. Mirrors the central authLimiter's NODE_ENV=test bypass
+// pattern (apps/api/src/app.ts:349) so integration tests stay
+// deterministic.
+//
+// CodeQL js/missing-rate-limiting auto-finding from PR #1019 closure.
+const firebaseVerifyLimiter =
+  process.env.NODE_ENV === "test"
+    ? (_: Request, __: Response, n: NextFunction) => n()
+    : rateLimit(20, 60_000);
+
 router.post(
   "/firebase-verify",
+  firebaseVerifyLimiter,
   validate(firebaseVerifyPatientSchema),
   async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     const { idToken } = req.body as { idToken: string };

--- a/apps/api/src/routes/patient-auth.ts
+++ b/apps/api/src/routes/patient-auth.ts
@@ -44,6 +44,7 @@ import { prisma } from "@medcore/db";
 import {
   requestPatientOtpSchema,
   verifyPatientOtpSchema,
+  firebaseVerifyPatientSchema,
   canonicalisePhone,
 } from "@medcore/shared";
 import { validate } from "../middleware/validate";
@@ -51,6 +52,7 @@ import { auditLog } from "../middleware/audit";
 import { setAuthCookies } from "../middleware/auth-cookies";
 import { signAccessToken, signRefreshToken } from "../services/jwt";
 import { sendSMS } from "../services/channels/sms";
+import { verifyPhoneIdToken } from "../services/firebase-admin";
 
 const router = Router();
 
@@ -392,6 +394,161 @@ router.post(
             role: user.role,
           },
           accessToken,
+        },
+        error: null,
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ─── POST /api/v1/patient-auth/firebase-verify ───────────────────────
+//
+// Firebase Phone Auth exchange endpoint. The patient PWA runs Firebase
+// Phone Auth in the browser (signInWithPhoneNumber → ConfirmationResult
+// .confirm), receives a Firebase ID token, and POSTs it here. We verify
+// the token with the firebase-admin SDK (signature, audience, issuer,
+// expiry, revocation), pull the verified `phone_number` out, and use it
+// — never the body — to look up the Patient User. If they exist + their
+// tenant is active, mint the existing medcore_at / medcore_rt cookies
+// and we're done; otherwise return a generic "Couldn't sign you in" so
+// we don't leak whether a phone is registered.
+//
+// Security notes:
+//   - Phone comes from the verified token claim, NOT from the body. A
+//     malicious client cannot say "I verified phone X but log me in as
+//     phone Y" — the body has only the token.
+//   - Audit logs the canonical phone suffix (last 4) same as the old
+//     otp-verify path so investigation tooling stays uniform.
+//   - The endpoint does NOT auto-create patient User rows. If the phone
+//     is not registered, the response is the same as for an invalid
+//     token — defence against enumeration. Onboarding goes through the
+//     existing /patient/register flow.
+router.post(
+  "/firebase-verify",
+  validate(firebaseVerifyPatientSchema),
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const { idToken } = req.body as { idToken: string };
+    try {
+      // 1. Verify the token with Firebase Admin. Throws on any failure.
+      let verified;
+      try {
+        verified = await verifyPhoneIdToken(idToken);
+      } catch (err) {
+        // Don't leak Firebase's verbose error messages — keep parity with
+        // the otp-verify endpoint's generic copy so callers can't tell
+        // expired-from-tampered.
+        console.warn(
+          `[patient-auth] firebase-verify rejected token: ${(err as Error).message}`,
+        );
+        res.status(401).json({
+          success: false,
+          data: null,
+          error: "Couldn't sign you in. Please try again.",
+        });
+        return;
+      }
+
+      // 2. Look up the patient by canonical phone. Firebase returns E.164
+      // (+919876543210); our User.phone column stores the bare 10-digit
+      // canonical form. Run the same canonicaliser used by the existing
+      // OTP flow so the two paths converge on the same row.
+      const phone = canonicalisePhone(verified.phoneNumber);
+      const user = await prisma.user.findFirst({
+        where: { phone, role: Role.PATIENT },
+        select: {
+          id: true,
+          email: true,
+          name: true,
+          role: true,
+          tenantId: true,
+        },
+      });
+      if (!user) {
+        // No registered patient with this phone. Generic 401 — parity
+        // with the otp-verify defence against phone-enumeration.
+        res.status(401).json({
+          success: false,
+          data: null,
+          error: "Couldn't sign you in. Please try again.",
+        });
+        return;
+      }
+
+      // 3. Honour the deactivated-tenant gate the otp-verify route uses.
+      if (user.tenantId) {
+        const tenant = await prisma.tenant.findUnique({
+          where: { id: user.tenantId },
+          select: { active: true },
+        });
+        if (tenant && !tenant.active) {
+          res.status(401).json({
+            success: false,
+            data: null,
+            error: "Couldn't sign you in. Please try again.",
+          });
+          return;
+        }
+      }
+
+      // 4. Mint the JWT pair + cookie set — identical to otp-verify's
+      // happy path so the rest of the patient surface (audit, refresh
+      // rotation, cookie posture) keeps behaving exactly the same.
+      const jti = crypto.randomUUID();
+      const accessToken = signAccessToken(
+        {
+          userId: user.id,
+          email: user.email,
+          role: user.role,
+          tenantId: user.tenantId ?? null,
+          jti,
+        },
+        { expiresIn: "24h" },
+      );
+      const refreshTtlSeconds = 7 * 24 * 60 * 60;
+      const refreshToken = signRefreshToken(
+        {
+          userId: user.id,
+          email: user.email,
+          role: user.role,
+          tenantId: user.tenantId ?? null,
+          jti: crypto.randomUUID(),
+        },
+        { expiresIn: refreshTtlSeconds },
+      );
+
+      await prisma.refreshToken.create({
+        data: {
+          token: refreshToken,
+          userId: user.id,
+          expiresAt: new Date(Date.now() + refreshTtlSeconds * 1000),
+        },
+      });
+
+      setAuthCookies(res, { accessToken, refreshToken }, refreshTtlSeconds);
+
+      await auditLog(
+        req,
+        "PATIENT_FIREBASE_VERIFY_SUCCESS",
+        "patient-auth",
+        user.id,
+        {
+          phoneSuffix: phone.slice(-4),
+          firebaseUid: verified.uid,
+        },
+      );
+
+      res.json({
+        success: true,
+        data: {
+          user: {
+            id: user.id,
+            email: user.email,
+            name: user.name,
+            role: user.role,
+            phone,
+          },
         },
         error: null,
       });

--- a/apps/api/src/services/firebase-admin.ts
+++ b/apps/api/src/services/firebase-admin.ts
@@ -1,0 +1,141 @@
+// Firebase Admin SDK — lazy, singleton init.
+//
+// Why: the patient phone-OTP flow uses Firebase to deliver SMS + verify the
+// 6-digit code. The Firebase ID token that comes back to the client is NOT
+// trusted directly by our backend — we verify it here with the Admin SDK
+// (which checks the JWT signature against Google's public keys, the
+// audience, the issuer, and the expiry), pull the verified phone number
+// out, and use that to look up the patient User row. Everything downstream
+// (cookie issuance, audit log, tenant scoping) is our existing machinery —
+// Firebase is just the OTP transport.
+//
+// Credentials: a Firebase service-account JSON file path supplied via
+//   FIREBASE_ADMIN_CREDENTIALS_PATH   (e.g. /etc/medcore/firebase-sa.json)
+// AND
+//   FIREBASE_PROJECT_ID               (must match the client-side project
+//                                      so the audience/issuer check passes)
+//
+// Both env vars are mandatory; missing them throws at first call so a
+// misconfigured deploy fails the FIRST patient sign-in cleanly rather than
+// 5xx-ing somewhere deeper in the route handler.
+
+import { existsSync, readFileSync } from "node:fs";
+import {
+  cert,
+  getApps,
+  initializeApp,
+  type App,
+  type ServiceAccount,
+} from "firebase-admin/app";
+import { getAuth, type Auth } from "firebase-admin/auth";
+
+let cachedApp: App | null = null;
+let cachedAuth: Auth | null = null;
+
+function loadServiceAccount(): ServiceAccount {
+  const path = process.env.FIREBASE_ADMIN_CREDENTIALS_PATH;
+  if (!path) {
+    throw new Error(
+      "FIREBASE_ADMIN_CREDENTIALS_PATH is not set. " +
+        "Drop the Firebase service-account JSON outside the repo and point this env var at it.",
+    );
+  }
+  if (!existsSync(path)) {
+    throw new Error(
+      `FIREBASE_ADMIN_CREDENTIALS_PATH points at "${path}" but that file does not exist.`,
+    );
+  }
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch (err) {
+    throw new Error(
+      `Could not read FIREBASE_ADMIN_CREDENTIALS_PATH at "${path}": ${(err as Error).message}`,
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `FIREBASE_ADMIN_CREDENTIALS_PATH file is not valid JSON: ${(err as Error).message}`,
+    );
+  }
+  const sa = parsed as ServiceAccount & { project_id?: string };
+  if (!sa.projectId && sa.project_id) {
+    // Service-account JSONs use snake_case; firebase-admin's ServiceAccount
+    // type wants camelCase. Bridge for older JSON exports.
+    sa.projectId = sa.project_id;
+  }
+  return sa;
+}
+
+function getFirebaseAdminApp(): App {
+  if (cachedApp) return cachedApp;
+  // firebase-admin keeps its own app registry — if hot-reload or another
+  // module has already initialised the default app, reuse it.
+  const existing = getApps();
+  if (existing.length > 0) {
+    cachedApp = existing[0];
+    return cachedApp;
+  }
+  const serviceAccount = loadServiceAccount();
+  const projectId = process.env.FIREBASE_PROJECT_ID;
+  if (!projectId) {
+    throw new Error(
+      "FIREBASE_PROJECT_ID is not set. It must match the NEXT_PUBLIC_FIREBASE_PROJECT_ID used by the web client so ID-token audience/issuer checks pass.",
+    );
+  }
+  cachedApp = initializeApp({
+    credential: cert(serviceAccount),
+    projectId,
+  });
+  return cachedApp;
+}
+
+/** Lazy-initialised Firebase Admin Auth client. Safe to call repeatedly. */
+export function getFirebaseAdminAuth(): Auth {
+  if (cachedAuth) return cachedAuth;
+  cachedAuth = getAuth(getFirebaseAdminApp());
+  return cachedAuth;
+}
+
+export interface VerifiedFirebasePhoneToken {
+  uid: string;
+  phoneNumber: string; // E.164, e.g. "+919876543210"
+  emailVerified: boolean;
+}
+
+/**
+ * Verify a Firebase ID token and assert that it came from a phone-auth
+ * sign-in (so an attacker can't take any old anonymous-auth token from the
+ * same project and use it as a patient login). Returns the verified phone
+ * number on success, throws on any failure.
+ */
+export async function verifyPhoneIdToken(
+  idToken: string,
+): Promise<VerifiedFirebasePhoneToken> {
+  if (typeof idToken !== "string" || idToken.length === 0) {
+    throw new Error("ID token is required.");
+  }
+  const auth = getFirebaseAdminAuth();
+  // `checkRevoked=true` makes the call also reject tokens whose underlying
+  // Firebase user has been disabled or whose refresh tokens have been
+  // revoked since the token was minted — cheap defence vs. a stolen token
+  // replay after the patient signs out.
+  const decoded = await auth.verifyIdToken(idToken, /* checkRevoked */ true);
+  // Firebase phone-auth populates `phone_number` on the decoded token; if
+  // it's missing, the token came from a different sign-in method (e.g.
+  // anonymous or email) and we refuse to honour it as a patient login.
+  const phoneNumber = decoded.phone_number;
+  if (!phoneNumber || typeof phoneNumber !== "string") {
+    throw new Error(
+      "Firebase token has no phone_number claim — only phone sign-in tokens are accepted here.",
+    );
+  }
+  return {
+    uid: decoded.uid,
+    phoneNumber,
+    emailVerified: Boolean(decoded.email_verified),
+  };
+}

--- a/apps/web/.env.local.example
+++ b/apps/web/.env.local.example
@@ -1,1 +1,20 @@
 NEXT_PUBLIC_API_URL=http://localhost:4000/api/v1
+
+# ── Firebase Phone Auth (patient PWA login) ─────────────────────────────────
+# The /patient/login flow uses Firebase Phone Authentication to send + verify
+# the SMS OTP. NEXT_PUBLIC_* values ship in the browser bundle (safe — the
+# Firebase API key is not a secret, access is gated by Firebase Security
+# Rules + the invisible reCAPTCHA verifier). The server-side service-account
+# credentials live in apps/api/.env (FIREBASE_ADMIN_CREDENTIALS_PATH).
+#
+# Get these six values from Firebase Console → Project settings → General →
+# Your apps → Web app SDK setup → "Config".
+NEXT_PUBLIC_FIREBASE_API_KEY=
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=
+NEXT_PUBLIC_FIREBASE_APP_ID=
+# Optional — only needed if you enable Firebase Analytics. Phone auth works
+# without it; leave blank if you're not using Analytics yet.
+NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
     "@sentry/nextjs": "^10.53.1",
     "@tailwindcss/postcss": "^4.3.0",
     "clsx": "^2.1.0",
+    "firebase": "^12.13.0",
     "lucide-react": "^1.16.0",
     "next": "^16.2.6",
     "react": "^19.2.6",

--- a/apps/web/src/app/dashboard/billing/page.tsx
+++ b/apps/web/src/app/dashboard/billing/page.tsx
@@ -653,7 +653,7 @@ export default function BillingPage() {
                 <th className="min-w-36 px-4 py-3 text-right">Balance</th>
                 <th className="px-4 py-3">Age</th>
                 <th className="px-4 py-3">Status</th>
-                {isStaff && <th className="px-4 py-3">Actions</th>}
+                {(isStaff || isPatient) && <th className="px-4 py-3">Actions</th>}
               </tr>
             </thead>
             <tbody>
@@ -871,6 +871,33 @@ export default function BillingPage() {
                           })(),
                           document.body,
                         )}
+                    </td>
+                  )}
+                  {isPatient && (
+                    <td className="px-4 py-3">
+                      {inv.displayStatus !== "PAID" && razorpay.enabled ? (
+                        <Link
+                          href={`/patient/bills/${inv.id}/pay`}
+                          data-testid={`bills-pay-online-${inv.id}`}
+                          className="inline-flex h-9 min-w-[44px] items-center justify-center gap-1.5 rounded-md bg-emerald-700 px-3 text-xs font-medium text-white hover:bg-emerald-800"
+                        >
+                          <Globe size={14} aria-hidden="true" />
+                          <span>Pay Online</span>
+                          {razorpay.isTestMode && (
+                            <span className="rounded bg-yellow-300 px-1 py-0.5 text-[10px] font-bold text-yellow-900">
+                              TEST
+                            </span>
+                          )}
+                        </Link>
+                      ) : (
+                        <Link
+                          href={`/patient/bills/${inv.id}`}
+                          data-testid={`bills-view-${inv.id}`}
+                          className="inline-flex h-9 min-w-[44px] items-center justify-center rounded-md border border-slate-300 px-3 text-xs font-medium text-slate-700 hover:bg-slate-50"
+                        >
+                          View
+                        </Link>
+                      )}
                     </td>
                   )}
                 </tr>

--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -137,11 +137,13 @@ const bottomNavByRole: Record<
     { href: "/dashboard/visitors", label: "Visitors", icon: UserCheck },
   ],
   PATIENT: [
-    { href: "/dashboard", label: "Home", icon: LayoutDashboard },
-    { href: "/dashboard/appointments", label: "Appts", icon: Calendar },
-    { href: "/dashboard/prescriptions", label: "Rx", icon: FileText },
-    { href: "/dashboard/billing", label: "Bills", icon: CreditCard },
-    { href: "/dashboard/settings", label: "Profile", icon: SettingsIcon },
+    { href: "/patient/dashboard", label: "Home", icon: LayoutDashboard },
+    { href: "/patient/appointments", label: "Appts", icon: Calendar },
+    { href: "/patient/prescriptions", label: "Rx", icon: FileText },
+    { href: "/patient/bills", label: "Bills", icon: CreditCard },
+    // Pearl §6.1 SOW row 254 — bottom-nav points at the patient profile form
+    // (/patient/profile), not the staff settings page.
+    { href: "/patient/profile", label: "Profile", icon: SettingsIcon },
   ],
 };
 
@@ -320,12 +322,16 @@ const navByRole: Record<
     { href: "/dashboard/notifications", label: "Notifications", icon: Bell },
   ],
   PATIENT: [
-    { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
+    { href: "/patient/dashboard", label: "Dashboard", icon: LayoutDashboard },
     { href: "/dashboard/calendar", label: "Calendar", icon: CalendarRange },
-    { href: "/dashboard/appointments", label: "My Appointments", icon: Calendar },
+    { href: "/patient/appointments", label: "My Appointments", icon: Calendar },
     { href: "/dashboard/telemedicine", label: "Telemedicine", icon: Video },
-    { href: "/dashboard/prescriptions", label: "Prescriptions", icon: FileText },
-    { href: "/dashboard/billing", label: "Bills", icon: CreditCard },
+    { href: "/patient/prescriptions", label: "Prescriptions", icon: FileText },
+    { href: "/patient/bills", label: "Bills", icon: CreditCard },
+    // Pearl §6.1 SOW row 254 — My Profile. Points at /patient/profile (the
+    // fully-built form covering name, DOB, address, language preference,
+    // reminder opt-in, ABHA linking).
+    { href: "/patient/profile", label: "My Profile", icon: UserCog },
     { href: "/dashboard/notifications", label: "Notifications", icon: Bell },
     { href: "/dashboard/ai-booking", label: "AI Booking", icon: Bot },
     { href: "/dashboard/adherence", label: "Medication Reminders", icon: BellIcon },
@@ -518,10 +524,20 @@ export default function DashboardLayout({
       setRedirectArmed(true);
       return;
     }
-    if (!localStorage.getItem("medcore_token")) {
-      setRedirectArmed(true); // no token, no retry needed; bounce now
-      return;
-    }
+    // Issue #477 fix: the access token has been in an httpOnly cookie
+    // since May 2026, so `localStorage.getItem("medcore_token")` is now
+    // ALWAYS null. The previous early-out here was a leftover from the
+    // pre-#477 localStorage scheme — it short-circuited every unauthed-
+    // looking mount past the 5-attempt /auth/me retry loop and bounced
+    // to /login with "session expired", even when the cookie was alive
+    // but the auth store just hadn't hydrated yet (e.g. after a tab
+    // switch / hot reload / Next route-group remount).
+    //
+    // Post-#477 the only reliable "do we have a session?" probe is
+    // /auth/me itself (the browser auto-attaches the cookie). So we
+    // unconditionally run the retry loop — if the cookie is dead all
+    // 5 attempts return 401, redirect arms; if it's alive but slow,
+    // one of the 5 succeeds and the redirect never fires.
     let cancelled = false;
     (async () => {
       // 5-attempt retry loop (v3): between each attempt, sleep 200ms

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -90,6 +90,13 @@ function LoginPageInner() {
     searchParams.get("next"),
     searchParams.get("redirect"),
   );
+  // Track whether the redirect target was EXPLICITLY supplied by the URL
+  // (session-expired bounce, deep link) vs. fell back to the safe default.
+  // We override the fallback for PATIENTs so they land on /patient/dashboard,
+  // but if the caller asked for a specific page (e.g. ?redirect=/patient/profile
+  // after a session expiry on that page), we honour it.
+  const nextRaw = searchParams.get("next") ?? searchParams.get("redirect");
+  const hasExplicitRedirect = Boolean(nextRaw && nextRaw.trim().length > 0);
   const { login, verify2FA } = useAuthStore();
   const { t } = useTranslation();
   const [email, setEmail] = useState("");
@@ -149,7 +156,14 @@ function LoginPageInner() {
       toast.success(t("login.welcome"));
       // Issue #33: honour the `?redirect=` param set by the dashboard auth
       // gate so users land back on the page they originally tried to open.
-      router.push(redirectTo);
+      // PATIENT override: when no explicit redirect was requested, send the
+      // patient to /patient/dashboard instead of the staff /dashboard.
+      const role = useAuthStore.getState().user?.role;
+      const dest =
+        !hasExplicitRedirect && role === "PATIENT"
+          ? "/patient/dashboard"
+          : redirectTo;
+      router.push(dest);
     } catch (err) {
       // Issue #15: distinguish 429 (rate-limit) from 401/403 (bad creds) so
       // users never see "Invalid email or password" when they're simply
@@ -170,7 +184,13 @@ function LoginPageInner() {
       await verify2FA(tempToken, twoFACode.trim());
       toast.success(t("login.welcome"));
       // Issue #33: honour ?redirect= after successful 2FA as well.
-      router.push(redirectTo);
+      // PATIENT override (same logic as the password path).
+      const role = useAuthStore.getState().user?.role;
+      const dest =
+        !hasExplicitRedirect && role === "PATIENT"
+          ? "/patient/dashboard"
+          : redirectTo;
+      router.push(dest);
     } catch (err) {
       // Issue #15: same status-aware handling for the 2FA step. A throttled
       // verify must not read as "Invalid 2FA code".
@@ -526,6 +546,16 @@ function LoginPageInner() {
             )}
 
             <p className="mt-6 text-center text-sm text-gray-500 dark:text-gray-400">
+              {t("login.patientLogin")}{" "}
+              <Link
+                href="/patient/login"
+                data-testid="patient-login-link"
+                className="font-medium text-primary hover:underline focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 rounded"
+              >
+                {t("login.patientLoginCta")}
+              </Link>
+            </p>
+            <p className="mt-2 text-center text-sm text-gray-500 dark:text-gray-400">
               {t("login.newPatient")}{" "}
               <Link
                 href="/register"

--- a/apps/web/src/app/patient/_components/PatientLayoutShell.tsx
+++ b/apps/web/src/app/patient/_components/PatientLayoutShell.tsx
@@ -1,0 +1,99 @@
+// Picks the right chrome for a /patient/* route based on pathname.
+//
+// Why this exists: /patient/dashboard is owned by the patient surface
+// URL-wise but UX-wise should live inside the same sidebar+topbar shell
+// that powers /dashboard for staff — that surface is already PATIENT-aware
+// (apps/web/src/app/dashboard/layout.tsx has a PATIENT entry in
+// navByRole + bottomNavByRole, gated by useAuthStore().user.role). For
+// every OTHER /patient/* route (login, register, appointments, bills,
+// records, prescriptions, profile, book) we keep the bare mobile-first
+// PWA shell — those pages were built for the installable PWA form factor
+// and the staff chrome would crowd them on a phone.
+//
+// SW registration sits at the top so it runs regardless of which chrome
+// is active. Otherwise a patient who launches the PWA directly into
+// /patient/dashboard would never install the worker → offline support
+// breaks.
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { PatientServiceWorkerRegistration } from "@/components/PatientServiceWorkerRegistration";
+import { InstallPWAButton } from "@/components/InstallPWAButton";
+import DashboardLayout from "@/app/dashboard/layout";
+
+function BarePatientShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      data-testid="patient-shell"
+      className="flex min-h-screen flex-col bg-white text-slate-900"
+    >
+      <header className="border-b border-slate-200 px-4 py-3">
+        <div className="mx-auto flex max-w-screen-md items-center justify-between">
+          <Link
+            href="/patient"
+            className="text-lg font-semibold tracking-tight"
+            data-testid="patient-shell-brand"
+          >
+            Patient Portal
+          </Link>
+          <div className="flex items-center gap-2">
+            <InstallPWAButton />
+            <Link
+              href="/patient/login"
+              className="inline-flex h-11 min-w-[44px] items-center rounded-md bg-slate-900 px-4 text-sm font-medium text-white"
+              data-testid="patient-shell-login-link"
+            >
+              Sign in
+            </Link>
+          </div>
+        </div>
+      </header>
+      <main className="mx-auto w-full max-w-screen-md flex-1 px-4 py-6">
+        {children}
+      </main>
+      <footer className="border-t border-slate-200 px-4 py-4 text-xs text-slate-500">
+        <div className="mx-auto max-w-screen-md">
+          Patient Portal — secured by your hospital.
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+export function PatientLayoutShell({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  // Deny-list — pages that MUST stay on the bare PWA shell. These are the
+  // unauth surfaces: the staff DashboardLayout requires an auth session and
+  // would bounce a logged-out visitor to /login before they could see the
+  // form. Includes:
+  //   • /patient (landing) — exact match: unauthed marketing CTA. Authed
+  //     visitors get bounced to /patient/dashboard by the page itself, so
+  //     the bare-shell render only happens for the brief marketing surface.
+  //   • /patient/login + /patient/register — prefix match (covers future
+  //     sub-routes like /patient/login/verify if added).
+  // Everything else under /patient/* (including dynamic routes like
+  // /patient/bills/[id]/pay) gets the staff chrome so the patient has one
+  // consistent sidebar/topbar after sign-in.
+  const path = pathname ?? "";
+  const isBareShell =
+    path === "/patient" ||
+    path.startsWith("/patient/login") ||
+    path.startsWith("/patient/register");
+  const useStaffChrome = !isBareShell;
+
+  return (
+    <>
+      <PatientServiceWorkerRegistration />
+      {useStaffChrome ? (
+        <DashboardLayout>{children}</DashboardLayout>
+      ) : (
+        <BarePatientShell>{children}</BarePatientShell>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/app/patient/appointments/__tests__/page.test.tsx
+++ b/apps/web/src/app/patient/appointments/__tests__/page.test.tsx
@@ -42,15 +42,27 @@ const TODAY = `${TODAY_IST_YMD}T00:00:00.000Z`;
 
 // Build a fixture row whose composeWhen lands ≥ 1h in the future (so the
 // upcoming/past sort always parks it in Upcoming regardless of wallclock).
+//
+// 2026-05-27: previously this used `slot.getUTCHours()` of `now + 4h`,
+// matching the page's pre-IST-fix logic which treated slotStart as
+// UTC. The page now parses slotStart as Asia/Kolkata wallclock (HH:MM
+// is the IST clock time the patient sees on their card), so we have
+// to build the same shape: derive HH:MM from the IST clock 4h ahead
+// of "now". Otherwise the composed instant ends up 5h30m earlier than
+// intended, the row gets filtered out of Upcoming, and tests that
+// expect the row in the section assert against the empty state.
+// Same fix applied to dashboard/__tests__/page.test.tsx::todayBookedRow
+// in 6ec5e499.
 function bookActiveTodayUpcoming(id: string) {
-  const futureSlotMs = Date.now() + 4 * HOUR;
-  const slot = new Date(futureSlotMs);
-  const hh = String(slot.getUTCHours()).padStart(2, "0");
-  const mm = String(slot.getUTCMinutes()).padStart(2, "0");
+  const istHHMM = new Date(Date.now() + 4 * HOUR).toLocaleTimeString("en-GB", {
+    timeZone: "Asia/Kolkata",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
   return {
     id,
     date: TODAY,
-    slotStart: `${hh}:${mm}:00`,
+    slotStart: `${istHHMM}:00`,
     tokenNumber: 12,
     status: "BOOKED",
     doctor: { user: { name: "Sharma" }, specialty: "Obstetrics" },

--- a/apps/web/src/app/patient/appointments/__tests__/page.test.tsx
+++ b/apps/web/src/app/patient/appointments/__tests__/page.test.tsx
@@ -141,7 +141,7 @@ describe("Patient appointments page — gap #5 piece 3b", () => {
     });
     expect(
       screen.getByTestId("patient-appointments-empty-book-cta"),
-    ).toHaveAttribute("href", "/patient/appointments/book");
+    ).toHaveAttribute("href", "/patient/book");
   });
 
   it("hides Cancel + Reschedule buttons on terminal-status (past) rows", async () => {

--- a/apps/web/src/app/patient/appointments/page.tsx
+++ b/apps/web/src/app/patient/appointments/page.tsx
@@ -94,31 +94,56 @@ function isTodayInIST(a: AppointmentRow): boolean {
   return apptYmd === ymdInIST(new Date());
 }
 
+// IST offset in minutes — clinic-local time is Asia/Kolkata (UTC+5:30).
+// The DB stores `Appointment.date` as the calendar day at UTC midnight and
+// `slotStart` as "HH:MM(:SS)" in clinic-local IST clock time. To compose a
+// real timestamp we add the IST clock minutes back into the UTC midnight,
+// then subtract the IST offset so the result is the correct UTC instant
+// for the appointment. (Previously the code did `setUTCHours(hh, mm)`
+// which treated the IST clock string AS IF it were UTC — that produced a
+// timestamp 5:30 hours off, which then re-converted through the browser's
+// local TZ in toLocaleTimeString gave wildly wrong displayed times.)
+const IST_OFFSET_MIN = 330;
+
 function composeWhen(a: AppointmentRow): number {
-  // Stored Appointment.date is the calendar day at UTC midnight; slotStart is
-  // "HH:MM:SS" or "HH:MM". Compose for sort/display. Match the dashboard's
-  // approach (apps/web/src/app/patient/dashboard/page.tsx:178-186).
   const base = new Date(a.date);
   if (a.slotStart) {
     const [hh, mm] = a.slotStart.split(":").map((s) => parseInt(s, 10));
-    if (Number.isFinite(hh)) base.setUTCHours(hh, mm || 0, 0, 0);
+    if (Number.isFinite(hh)) {
+      const istMinutesIntoDay = hh * 60 + (Number.isFinite(mm) ? mm : 0);
+      const utcMinutesIntoDay = istMinutesIntoDay - IST_OFFSET_MIN;
+      return base.getTime() + utcMinutesIntoDay * 60 * 1000;
+    }
   }
   return base.getTime();
 }
 
-function formatDateTime(ts: number): string {
-  const d = new Date(ts);
-  const date = d.toLocaleDateString("en-IN", {
+// Format an IST clock string "HH:MM(:SS)" as a 12-hour display ("10:45 PM")
+// WITHOUT routing it through Date — the raw HH:MM is already the wall-clock
+// time we want to render, regardless of the viewer's browser timezone.
+function formatSlotTime(slotStart: string | null | undefined): string {
+  if (!slotStart) return "";
+  const [hhRaw, mmRaw] = slotStart.split(":");
+  const hh = parseInt(hhRaw ?? "", 10);
+  const mm = parseInt(mmRaw ?? "", 10);
+  if (!Number.isFinite(hh)) return "";
+  const minute = Number.isFinite(mm) ? mm : 0;
+  const period = hh >= 12 ? "PM" : "AM";
+  const hour12 = ((hh + 11) % 12) + 1; // 0→12, 13→1, etc.
+  return `${hour12}:${String(minute).padStart(2, "0")} ${period}`;
+}
+
+function formatApptWhen(a: AppointmentRow): string {
+  // Date: render in IST so a UTC-midnight `Appointment.date` (e.g.
+  // 2026-05-26T00:00:00Z) lands as "26 May 2026" even for non-IST browsers.
+  const dateStr = new Date(a.date).toLocaleDateString("en-IN", {
     day: "2-digit",
     month: "short",
     year: "numeric",
+    timeZone: "Asia/Kolkata",
   });
-  const time = d.toLocaleTimeString("en-IN", {
-    hour: "numeric",
-    minute: "2-digit",
-    hour12: true,
-  });
-  return `${date} · ${time}`;
+  const timeStr = formatSlotTime(a.slotStart);
+  return timeStr ? `${dateStr} · ${timeStr}` : dateStr;
 }
 
 function statusPillClass(status: string): string {
@@ -388,7 +413,7 @@ export default function PatientAppointmentsPage() {
           My appointments
         </h1>
         <Link
-          href="/patient/appointments/book"
+          href="/patient/book"
           className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md bg-slate-900 px-4 text-sm font-medium text-white"
           data-testid="patient-appointments-book-cta"
         >
@@ -403,7 +428,7 @@ export default function PatientAppointmentsPage() {
         >
           <p className="text-base text-slate-700">No appointments yet.</p>
           <Link
-            href="/patient/appointments/book"
+            href="/patient/book"
             className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md bg-slate-900 px-6 text-sm font-medium text-white"
             data-testid="patient-appointments-empty-book-cta"
           >
@@ -714,7 +739,7 @@ function AppointmentCard({
   arriving,
   arrived,
 }: CardProps) {
-  const when = formatDateTime(composeWhen(appointment));
+  const when = formatApptWhen(appointment);
   const canReschedule =
     !!onReschedule &&
     RESCHEDULABLE_STATUSES.has(appointment.status) &&

--- a/apps/web/src/app/patient/dashboard/__tests__/page.test.tsx
+++ b/apps/web/src/app/patient/dashboard/__tests__/page.test.tsx
@@ -43,13 +43,24 @@ const TODAY = `${TODAY_IST_YMD}T00:00:00.000Z`;
 // Build a today-row whose composeWhen lands ≥ 1h in the future so the
 // `nextAppointment` filter (1h grace) always picks it up.
 function todayBookedRow(id: string) {
-  const slot = new Date(Date.now() + 4 * HOUR);
-  const hh = String(slot.getUTCHours()).padStart(2, "0");
-  const mm = String(slot.getUTCMinutes()).padStart(2, "0");
+  // 2026-05-27: previously this used `slot.getUTCHours()` of `now + 4h`,
+  // matching the page's pre-IST-fix logic which treated slotStart as
+  // UTC. The page now parses slotStart as Asia/Kolkata wallclock (HH:MM
+  // is the IST clock time the patient sees on their card), so we have
+  // to build the same shape: derive HH:MM from the IST clock 4h ahead
+  // of "now". Otherwise nextAppointment.ts ends up 5h30m earlier than
+  // intended and the row gets filtered out as past-the-grace-window,
+  // leaving the page with no nextAppointment and the test seeing the
+  // "all paid up" empty state instead of the I've-arrived button.
+  const istHHMM = new Date(Date.now() + 4 * HOUR).toLocaleTimeString("en-GB", {
+    timeZone: "Asia/Kolkata",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
   return {
     id,
     date: TODAY,
-    slotStart: `${hh}:${mm}:00`,
+    slotStart: `${istHHMM}:00`,
     tokenNumber: 7,
     status: "BOOKED",
     doctor: { user: { name: "Sharma" }, specialty: "Obstetrics" },

--- a/apps/web/src/app/patient/dashboard/__tests__/page.test.tsx
+++ b/apps/web/src/app/patient/dashboard/__tests__/page.test.tsx
@@ -140,12 +140,28 @@ describe("Patient dashboard — gap #5 piece 3a", () => {
     const rxTile = screen.getByTestId("patient-dashboard-prescriptions");
     expect(within(rxTile).getByText(/Amoxicillin 500mg/)).toBeInTheDocument();
     expect(within(rxTile).getByText(/\+ 1 more/)).toBeInTheDocument();
+    // 2026-05-27: download URL changed to the absolute API path (`${API_BASE}/
+    // prescriptions/:id/pdf?format=pdf`) — the old `/api/v1/...` was a
+    // web-relative path that 404'd on Next's dev server. Test uses
+    // `stringContaining` so the assertion stays stable across env-var
+    // changes to NEXT_PUBLIC_API_URL.
     expect(
       within(rxTile).getByTestId("patient-dashboard-prescription-download"),
-    ).toHaveAttribute("href", "/api/v1/prescriptions/rx-1/pdf");
-    expect(
-      within(rxTile).getByTestId("patient-dashboard-prescription-share"),
-    ).toHaveAttribute("href", expect.stringContaining("https://wa.me/"));
+    ).toHaveAttribute(
+      "href",
+      expect.stringContaining("/prescriptions/rx-1/pdf?format=pdf"),
+    );
+    // 2026-05-27: Share is now a <button> that calls
+    // POST /prescriptions/:id/share { channel: "WHATSAPP" } server-side
+    // (mirrors the doctor flow at apps/web/src/app/dashboard/prescriptions/
+    // page.tsx `shareVia`). No more wa.me anchor. Just assert the button
+    // is in the DOM and clickable (the share-success path is covered by a
+    // separate test below).
+    const shareBtn = within(rxTile).getByTestId(
+      "patient-dashboard-prescription-share",
+    );
+    expect(shareBtn.tagName).toBe("BUTTON");
+    expect(shareBtn).toHaveTextContent(/Share on WhatsApp/);
 
     // Bills tile — INR 1500 - 500 = 1000 due
     const billsTile = screen.getByTestId("patient-dashboard-bills");

--- a/apps/web/src/app/patient/dashboard/page.tsx
+++ b/apps/web/src/app/patient/dashboard/page.tsx
@@ -28,6 +28,7 @@
 import { useEffect, useState, useMemo } from "react";
 import Link from "next/link";
 import { api } from "@/lib/api";
+import { toast } from "@/lib/toast";
 
 interface AppointmentRow {
   id: string;
@@ -45,6 +46,11 @@ interface PrescriptionRow {
   id: string;
   createdAt: string;
   diagnosis?: string | null;
+  // Mirror /patient/prescriptions/page.tsx: status + signatureUrl gate
+  // the share button — an unsigned or cancelled prescription is not a
+  // valid medical document and the share endpoint will 409 on it.
+  status?: string | null;
+  signatureUrl?: string | null;
   doctor?: { user?: { name?: string | null } | null } | null;
   items?: Array<{ medicineName?: string | null }> | null;
 }
@@ -79,6 +85,36 @@ interface MeResponse {
 
 const ABHA_PROMPT_DISMISS_KEY = "medcore_abha_prompt_dismissed";
 
+// Same helpers as /patient/prescriptions/page.tsx — keep the URL-build
+// logic local so the Recent Prescriptions tile's Download + Share
+// buttons point at the right hosts:
+//   • Download PDF — absolute API URL (web app is :3000, API is :4000 in
+//     dev; in prod both live behind the same origin but the env var
+//     resolves correctly either way).
+//   • Share on WhatsApp — `${origin}/verify/rx/<id>` so the link the
+//     patient sends lands on the public verify page that actually
+//     exists. The previous `/verify/<id>` shape (no `/rx/` segment)
+//     404'd in WhatsApp.
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000/api/v1";
+
+function buildPdfUrl(id: string): string {
+  return `${API_BASE.replace(/\/$/, "")}/prescriptions/${id}/pdf?format=pdf`;
+}
+
+function buildVerifyUrl(id: string): string {
+  const origin =
+    typeof window !== "undefined" && window.location?.origin
+      ? window.location.origin
+      : "";
+  return `${origin}/verify/rx/${id}`;
+}
+
+// Mirror the share-rx server policy at routes/prescriptions.ts:871-887
+// (and /patient/prescriptions/page.tsx:79) — these statuses indicate
+// the prescription is not a valid medical document for sharing.
+const NON_SHAREABLE_STATUSES = new Set(["CANCELLED", "REJECTED", "DRAFT"]);
+
 type LoadState = "loading" | "ready" | "unauth" | "error";
 
 // Pearl §6.3 row 340 — "I've arrived" date helpers. Mirror the server's
@@ -93,20 +129,41 @@ function isTodayInIST(appointmentDate: string): boolean {
   return (appointmentDate ?? "").slice(0, 10) === ymdInIST(new Date());
 }
 
-function formatDateTime(d: Date): string {
-  // 22 May 2026 · 10:30 AM (locale-agnostic enough for the PWA; date-fns
-  // would be cleaner but the dashboard isn't worth pulling it in for).
-  const date = d.toLocaleDateString("en-IN", {
+// IST offset in minutes — clinic-local time is Asia/Kolkata (UTC+5:30).
+// `Appointment.date` is the calendar day at UTC midnight; `slotStart` is
+// "HH:MM(:SS)" in clinic-local IST clock time. See the matching helpers in
+// apps/web/src/app/patient/appointments/page.tsx for the full background.
+const IST_OFFSET_MIN = 330;
+
+// Format an IST clock string "HH:MM(:SS)" as 12-hour ("10:45 PM") WITHOUT
+// routing it through Date — the raw HH:MM IS the wall-clock time we want,
+// independent of the viewer's browser timezone.
+function formatSlotTime(slotStart: string | null | undefined): string {
+  if (!slotStart) return "";
+  const [hhRaw, mmRaw] = slotStart.split(":");
+  const hh = parseInt(hhRaw ?? "", 10);
+  const mm = parseInt(mmRaw ?? "", 10);
+  if (!Number.isFinite(hh)) return "";
+  const minute = Number.isFinite(mm) ? mm : 0;
+  const period = hh >= 12 ? "PM" : "AM";
+  const hour12 = ((hh + 11) % 12) + 1;
+  return `${hour12}:${String(minute).padStart(2, "0")} ${period}`;
+}
+
+function formatApptWhen(a: {
+  date: string;
+  slotStart?: string | null;
+}): string {
+  // Render the date in IST so a UTC-midnight Appointment.date lands as the
+  // expected calendar day even for non-IST browsers.
+  const dateStr = new Date(a.date).toLocaleDateString("en-IN", {
     day: "2-digit",
     month: "short",
     year: "numeric",
+    timeZone: "Asia/Kolkata",
   });
-  const time = d.toLocaleTimeString("en-IN", {
-    hour: "numeric",
-    minute: "2-digit",
-    hour12: true,
-  });
-  return `${date} · ${time}`;
+  const timeStr = formatSlotTime(a.slotStart);
+  return timeStr ? `${dateStr} · ${timeStr}` : dateStr;
 }
 
 function formatINR(n: number): string {
@@ -145,6 +202,37 @@ export default function PatientDashboardPage() {
     "idle" | "submitting" | "arrived"
   >("idle");
   const [arriveError, setArriveError] = useState<string | null>(null);
+
+  // Mirror the doctor side (apps/web/src/app/dashboard/prescriptions/page.tsx
+  // `shareVia` at L494): fire-and-toast. Holds the rx id currently in
+  // flight so the clicked button can render "Sharing…" and disable to
+  // prevent double-submit. Cleared on settle.
+  const [sharingRxId, setSharingRxId] = useState<string | null>(null);
+
+  async function shareViaWhatsApp(rxId: string): Promise<void> {
+    if (sharingRxId) return;
+    setSharingRxId(rxId);
+    try {
+      await api.post(`/prescriptions/${rxId}/share`, { channel: "WHATSAPP" });
+      toast.success("Prescription shared via WhatsApp");
+    } catch (err) {
+      // The API's friendly 409 messages already explain the unsigned /
+      // cancelled / no-phone cases — surface verbatim rather than
+      // re-wording on the client. The doctor side has a Sign-before-share
+      // modal for the unsigned 409, but a patient can't sign for the
+      // doctor; the toast is the only action they have.
+      const anyErr = err as Error & {
+        status?: number;
+        payload?: { error?: string };
+      };
+      const msg =
+        anyErr?.payload?.error ??
+        (err instanceof Error ? err.message : "Failed to share");
+      toast.error(msg);
+    } finally {
+      setSharingRxId(null);
+    }
+  }
 
   useEffect(() => {
     let cancelled = false;
@@ -243,13 +331,19 @@ export default function PatientDashboardPage() {
     const now = Date.now();
     const upcoming = appointments
       .map((a) => {
-        // The list endpoint stores `date` as the calendar day (UTC) and
-        // `slotStart` as HH:MM:SS. Compose them for the sort; fall back
-        // to date-only when slotStart is null (CALLING / WALK_IN rows).
+        // `date` is UTC midnight of the calendar day; `slotStart` is IST
+        // clock time. Subtract the IST offset so the composed instant is
+        // the correct UTC timestamp for the appointment. The earlier code
+        // used setUTCHours, which treated the IST string AS IF it were UTC
+        // — produced a 5h30m-offset timestamp that compared wrong against
+        // Date.now() AND rendered wrong through toLocaleTimeString.
         const base = new Date(a.date);
         if (a.slotStart) {
           const [hh, mm] = a.slotStart.split(":").map((s) => parseInt(s, 10));
-          if (Number.isFinite(hh)) base.setUTCHours(hh, mm || 0, 0, 0);
+          if (Number.isFinite(hh)) {
+            const ist = hh * 60 + (Number.isFinite(mm) ? mm : 0);
+            return { a, ts: base.getTime() + (ist - IST_OFFSET_MIN) * 60_000 };
+          }
         }
         return { a, ts: base.getTime() };
       })
@@ -413,18 +507,7 @@ export default function PatientDashboardPage() {
               data-testid="patient-dashboard-next-appointment-when"
               className="text-sm text-slate-700"
             >
-              {formatDateTime(
-                (() => {
-                  const d = new Date(nextAppointment.date);
-                  if (nextAppointment.slotStart) {
-                    const [hh, mm] = nextAppointment.slotStart
-                      .split(":")
-                      .map((s) => parseInt(s, 10));
-                    if (Number.isFinite(hh)) d.setUTCHours(hh, mm || 0, 0, 0);
-                  }
-                  return d;
-                })(),
-              )}
+              {formatApptWhen(nextAppointment)}
             </p>
             {nextAppointment.tokenNumber ? (
               <p className="text-sm text-slate-600">
@@ -546,26 +629,36 @@ export default function PatientDashboardPage() {
                       : ""}
                   </p>
                   <div className="flex gap-2 pt-1">
-                    <Link
-                      href={`/api/v1/prescriptions/${rx.id}/pdf`}
+                    <a
+                      href={buildPdfUrl(rx.id)}
                       className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 px-3 text-xs font-medium text-slate-800"
                       data-testid="patient-dashboard-prescription-download"
                       target="_blank"
                       rel="noopener noreferrer"
                     >
                       Download PDF
-                    </Link>
-                    <a
-                      href={`https://wa.me/?text=${encodeURIComponent(
-                        `My MedCore prescription: ${typeof window !== "undefined" ? window.location.origin : ""}/verify/${rx.id}`,
-                      )}`}
-                      className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 px-3 text-xs font-medium text-slate-800"
-                      data-testid="patient-dashboard-prescription-share"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      Share on WhatsApp
                     </a>
+                    {/* Same flow as the doctor side
+                        (apps/web/src/app/dashboard/prescriptions/page.tsx
+                        `shareVia` at L494): POST /prescriptions/:id/share
+                        with { channel: "WHATSAPP" }. The server delivers
+                        the verify link to the patient's registered phone
+                        via the Meta Cloud API and logs the share. No new
+                        tab to wa.me — the patient stays on the dashboard
+                        and sees a toast.
+                        The doctor-side branch that pops a SignaturePad on
+                        a 409 "unsigned" response doesn't apply here — a
+                        patient can't sign for their doctor — so we toast
+                        the API's friendly message verbatim instead. */}
+                    <button
+                      type="button"
+                      onClick={() => shareViaWhatsApp(rx.id)}
+                      disabled={sharingRxId === rx.id}
+                      className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 px-3 text-xs font-medium text-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
+                      data-testid="patient-dashboard-prescription-share"
+                    >
+                      {sharingRxId === rx.id ? "Sharing…" : "Share on WhatsApp"}
+                    </button>
                   </div>
                 </li>
               );
@@ -617,6 +710,17 @@ export default function PatientDashboardPage() {
               {invoices.map((inv) => {
                 const due =
                   toNumber(inv.totalAmount) - toNumber(inv.paidAmount);
+                // The server filter (?status=PENDING,PARTIAL) already
+                // excludes PAID rows, but defend against stale state
+                // (e.g. the patient paid in another tab and the
+                // dashboard hasn't refetched yet, or a race between
+                // status flip and the fetch): if the row is PAID or
+                // has zero outstanding, swap Pay-now for View-detail
+                // so the patient is never offered to pay a settled
+                // bill. Matches the open vs paid split on
+                // /patient/bills (line 562 there).
+                const isSettled =
+                  inv.paymentStatus === "PAID" || due <= 0;
                 return (
                   <li
                     key={inv.id}
@@ -634,13 +738,23 @@ export default function PatientDashboardPage() {
                       })}{" "}
                       · {formatINR(due)} due
                     </p>
-                    <Link
-                      href={`/patient/bills/${inv.id}/pay`}
-                      className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md bg-emerald-700 px-4 text-xs font-medium text-white"
-                      data-testid="patient-dashboard-bill-pay"
-                    >
-                      Pay now
-                    </Link>
+                    {isSettled ? (
+                      <Link
+                        href={`/patient/bills/${inv.id}`}
+                        className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 px-4 text-xs font-medium text-slate-800"
+                        data-testid="patient-dashboard-bill-view"
+                      >
+                        View detail
+                      </Link>
+                    ) : (
+                      <Link
+                        href={`/patient/bills/${inv.id}/pay`}
+                        className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md bg-emerald-700 px-4 text-xs font-medium text-white"
+                        data-testid="patient-dashboard-bill-pay"
+                      >
+                        Pay now
+                      </Link>
+                    )}
                   </li>
                 );
               })}

--- a/apps/web/src/app/patient/layout.tsx
+++ b/apps/web/src/app/patient/layout.tsx
@@ -1,13 +1,12 @@
 // Patient PWA route group layout (Pearl §6.1 / §6.2 — gap #5 piece 1 of 4).
-// Deliberately bare: NO dashboard topbar / sidebar / LanguageDropdown / BranchPicker.
-// This is the installable PWA surface — mobile-first, 44px touch targets via Tailwind defaults,
-// service worker registered client-side so the shell is offline-tolerant (cache strategy lands
-// in piece 4). Root `apps/web/src/app/layout.tsx` already provides <html>/<body> + ThemeBootstrap
-// + ToastContainer, so this layout is just the patient surface chrome.
+//
+// This file is intentionally a SERVER component so `metadata` + `viewport`
+// can be exported (Next.js disallows those exports from a client file). The
+// pathname-dependent chrome swap (bare PWA shell vs. staff /dashboard
+// chrome on the /patient/dashboard route) lives in PatientLayoutShell —
+// see that file's header for the why.
 import type { Metadata, Viewport } from "next";
-import Link from "next/link";
-import { PatientServiceWorkerRegistration } from "@/components/PatientServiceWorkerRegistration";
-import { InstallPWAButton } from "@/components/InstallPWAButton";
+import { PatientLayoutShell } from "./_components/PatientLayoutShell";
 
 export const metadata: Metadata = {
   title: "Patient Portal — MedCore",
@@ -34,41 +33,5 @@ export default function PatientLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return (
-    <div
-      data-testid="patient-shell"
-      className="flex min-h-screen flex-col bg-white text-slate-900"
-    >
-      <PatientServiceWorkerRegistration />
-      <header className="border-b border-slate-200 px-4 py-3">
-        <div className="mx-auto flex max-w-screen-md items-center justify-between">
-          <Link
-            href="/patient"
-            className="text-lg font-semibold tracking-tight"
-            data-testid="patient-shell-brand"
-          >
-            Patient Portal
-          </Link>
-          <div className="flex items-center gap-2">
-            <InstallPWAButton />
-            <Link
-              href="/patient/login"
-              className="inline-flex h-11 min-w-[44px] items-center rounded-md bg-slate-900 px-4 text-sm font-medium text-white"
-              data-testid="patient-shell-login-link"
-            >
-              Sign in
-            </Link>
-          </div>
-        </div>
-      </header>
-      <main className="mx-auto w-full max-w-screen-md flex-1 px-4 py-6">
-        {children}
-      </main>
-      <footer className="border-t border-slate-200 px-4 py-4 text-xs text-slate-500">
-        <div className="mx-auto max-w-screen-md">
-          Patient Portal — secured by your hospital.
-        </div>
-      </footer>
-    </div>
-  );
+  return <PatientLayoutShell>{children}</PatientLayoutShell>;
 }

--- a/apps/web/src/app/patient/login/__tests__/page.test.tsx
+++ b/apps/web/src/app/patient/login/__tests__/page.test.tsx
@@ -1,19 +1,29 @@
 // Behaviour coverage for the patient phone-OTP login page
-// (`apps/web/src/app/patient/login/page.tsx`, Pearl §5.3 / §6.1 — gap #5 piece 2).
+// (`apps/web/src/app/patient/login/page.tsx`, Pearl §5.3 / §6.1 — gap #5
+// piece 2, rewritten 2026-05-27 for the Firebase-backed flow).
 //
-// Pins the two-step flow:
-//   1. Step 1 (phone): client-side regex validation, `/patient-auth/otp-request`
-//      POST with trimmed phone, success → step 2 + info banner, server error →
-//      inline error at `patient-login-error`, thrown error → fallback message.
-//   2. Step 2 (otp): client-side 6-digit validation, `/patient-auth/otp-verify`
-//      POST with phone + otp, success → `router.push("/patient")`, server error
-//      → inline error, "Change number" returns to step 1 + clears OTP/error,
-//      "Resend code" re-fires the otp-request POST.
-//   3. Misc: register CTA href, busy-state disables interactive controls during
-//      the in-flight request.
+// The page now uses Firebase Phone Auth on the client (invisible
+// reCAPTCHA → sendOtp → verifyOtp returns an ID token) and POSTs that
+// token to `/patient-auth/firebase-verify` on the API, which mints our
+// own httpOnly session cookies. The legacy `/patient-auth/otp-request`
+// + `/patient-auth/otp-verify` endpoints are no longer wired into this
+// page (still exist server-side as a fallback for the legacy SMS path,
+// but no UI calls them anymore).
 //
-// Mock layer mirrors the patient/register/__tests__/page.test.tsx pattern:
-// vi.hoisted api mock + next/navigation router mock.
+// What's pinned:
+//   1. Step 1 (phone): client-side regex/normalisation, sendOtp() called
+//      with the canonical E.164, success → step 2 + info banner, thrown
+//      Firebase error → inline error and stays on step 1.
+//   2. Step 2 (otp): client-side 6-digit validation, verifyOtp() returns
+//      the ID token, POST /patient-auth/firebase-verify with that token,
+//      success → router.push("/patient/dashboard"), error → inline error
+//      and no redirect.
+//   3. Misc: register CTA href, busy-state disables interactive controls
+//      during in-flight requests, Change number / Resend behaviours.
+//
+// Mock layer: vi.hoisted handles to the @/lib/firebase helpers (the
+// page imports them at module level so module-init order matters) +
+// the @/lib/api post mock + the next/navigation router mock.
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
@@ -24,9 +34,22 @@ import {
   act,
 } from "@testing-library/react";
 
-const { apiPostMock, routerPushMock } = vi.hoisted(() => ({
+const {
+  apiPostMock,
+  routerPushMock,
+  ensureRecaptchaMock,
+  disposeRecaptchaMock,
+  sendOtpMock,
+  verifyOtpMock,
+  resetPhoneAuthStateMock,
+} = vi.hoisted(() => ({
   apiPostMock: vi.fn(),
   routerPushMock: vi.fn(),
+  ensureRecaptchaMock: vi.fn(),
+  disposeRecaptchaMock: vi.fn(),
+  sendOtpMock: vi.fn(),
+  verifyOtpMock: vi.fn(),
+  resetPhoneAuthStateMock: vi.fn(),
 }));
 
 vi.mock("@/lib/api", () => ({
@@ -37,6 +60,14 @@ vi.mock("@/lib/api", () => ({
     put: vi.fn(),
     delete: vi.fn(),
   },
+}));
+
+vi.mock("@/lib/firebase", () => ({
+  ensureRecaptcha: ensureRecaptchaMock,
+  disposeRecaptcha: disposeRecaptchaMock,
+  sendOtp: sendOtpMock,
+  verifyOtp: verifyOtpMock,
+  resetPhoneAuthState: resetPhoneAuthStateMock,
 }));
 
 vi.mock("next/navigation", () => ({
@@ -58,11 +89,7 @@ function typeOtp(value: string): void {
 }
 
 async function advanceToOtpStep(phone = "+919876543210"): Promise<void> {
-  apiPostMock.mockResolvedValueOnce({
-    success: true,
-    data: { sent: true },
-    error: null,
-  });
+  sendOtpMock.mockResolvedValueOnce(undefined);
   typePhone(phone);
   await act(async () => {
     fireEvent.click(screen.getByTestId("patient-login-send-code"));
@@ -72,10 +99,15 @@ async function advanceToOtpStep(phone = "+919876543210"): Promise<void> {
   });
 }
 
-describe("PatientLoginPage — phone-OTP two-step flow", () => {
+describe("PatientLoginPage — Firebase phone-OTP two-step flow", () => {
   beforeEach(() => {
     apiPostMock.mockReset();
     routerPushMock.mockReset();
+    ensureRecaptchaMock.mockReset();
+    disposeRecaptchaMock.mockReset();
+    sendOtpMock.mockReset();
+    verifyOtpMock.mockReset();
+    resetPhoneAuthStateMock.mockReset();
   });
 
   it("renders step 1 with the phone input and a register CTA link", () => {
@@ -91,43 +123,64 @@ describe("PatientLoginPage — phone-OTP two-step flow", () => {
     ).toBeInTheDocument();
     const registerLink = screen.getByTestId("patient-login-register-link");
     expect(registerLink).toHaveAttribute("href", "/patient/register");
-    // No OTP input yet — flow starts at step 1.
     expect(
       screen.queryByTestId("patient-login-otp-input"),
     ).not.toBeInTheDocument();
   });
 
-  it("rejects an invalid phone number client-side without calling the API", () => {
+  it("mounts the invisible reCAPTCHA on first render and tears it down on unmount", () => {
+    const { unmount } = render(<PatientLoginPage />);
+    expect(ensureRecaptchaMock).toHaveBeenCalledWith("patient-recaptcha");
+    unmount();
+    expect(disposeRecaptchaMock).toHaveBeenCalled();
+    expect(resetPhoneAuthStateMock).toHaveBeenCalled();
+  });
+
+  it("surfaces a Firebase init error inline if ensureRecaptcha throws", () => {
+    ensureRecaptchaMock.mockImplementationOnce(() => {
+      throw new Error("Firebase env not configured");
+    });
     render(<PatientLoginPage />);
-    typePhone("123"); // Too short — regex requires 10-15 digits.
+    expect(screen.getByTestId("patient-login-error")).toHaveTextContent(
+      /firebase env not configured/i,
+    );
+  });
+
+  it("rejects an invalid phone number client-side without calling sendOtp", () => {
+    render(<PatientLoginPage />);
+    typePhone("123"); // Too short — fails normaliseToE164.
     fireEvent.click(screen.getByTestId("patient-login-send-code"));
-    expect(apiPostMock).not.toHaveBeenCalled();
+    expect(sendOtpMock).not.toHaveBeenCalled();
     expect(screen.getByTestId("patient-login-error")).toHaveTextContent(
       /valid phone number/i,
     );
   });
 
-  it("POSTs trimmed phone to /patient-auth/otp-request on send-code and advances to step 2", async () => {
-    apiPostMock.mockResolvedValueOnce({
-      success: true,
-      data: { sent: true },
-      error: null,
-    });
-
+  it("normalises a 10-digit Indian number to +91 E.164 before calling sendOtp", async () => {
+    sendOtpMock.mockResolvedValueOnce(undefined);
     render(<PatientLoginPage />);
-    typePhone("  +919876543210  "); // Whitespace must be trimmed before POST.
+    typePhone("9876543210"); // bare 10-digit, no +91
     await act(async () => {
       fireEvent.click(screen.getByTestId("patient-login-send-code"));
     });
-
     await waitFor(() => {
-      expect(apiPostMock).toHaveBeenCalledTimes(1);
+      expect(sendOtpMock).toHaveBeenCalledWith("+919876543210");
     });
-    const [endpoint, body] = apiPostMock.mock.calls[0];
-    expect(endpoint).toBe("/patient-auth/otp-request");
-    expect(body).toEqual({ phone: "+919876543210" });
+    expect(
+      screen.getByTestId("patient-login-otp-input"),
+    ).toBeInTheDocument();
+  });
 
-    // Step 2 specific elements now in the DOM.
+  it("calls sendOtp with the trimmed E.164 and advances to step 2", async () => {
+    sendOtpMock.mockResolvedValueOnce(undefined);
+    render(<PatientLoginPage />);
+    typePhone("  +919876543210  ");
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("patient-login-send-code"));
+    });
+    await waitFor(() => {
+      expect(sendOtpMock).toHaveBeenCalledWith("+919876543210");
+    });
     expect(
       screen.getByTestId("patient-login-otp-input"),
     ).toBeInTheDocument();
@@ -136,42 +189,16 @@ describe("PatientLoginPage — phone-OTP two-step flow", () => {
     );
   });
 
-  it("surfaces a server-side otp-request failure inline and does NOT advance to step 2", async () => {
-    apiPostMock.mockResolvedValueOnce({
-      success: false,
-      data: null,
-      error: "Too many requests — please wait 10 minutes.",
-    });
-
+  it("surfaces a thrown sendOtp error inline and does NOT advance to step 2", async () => {
+    sendOtpMock.mockRejectedValueOnce(new Error("Invalid phone number format."));
     render(<PatientLoginPage />);
     typePhone("+919876543210");
     await act(async () => {
       fireEvent.click(screen.getByTestId("patient-login-send-code"));
     });
-
     await waitFor(() => {
       expect(screen.getByTestId("patient-login-error")).toHaveTextContent(
-        /too many requests/i,
-      );
-    });
-    // Stayed on step 1 — OTP input must NOT be in the DOM.
-    expect(
-      screen.queryByTestId("patient-login-otp-input"),
-    ).not.toBeInTheDocument();
-  });
-
-  it("surfaces a thrown network error inline using the error's message", async () => {
-    apiPostMock.mockRejectedValueOnce(new Error("Network offline"));
-
-    render(<PatientLoginPage />);
-    typePhone("+919876543210");
-    await act(async () => {
-      fireEvent.click(screen.getByTestId("patient-login-send-code"));
-    });
-
-    await waitFor(() => {
-      expect(screen.getByTestId("patient-login-error")).toHaveTextContent(
-        /network offline/i,
+        /invalid phone number format/i,
       );
     });
     expect(
@@ -179,40 +206,31 @@ describe("PatientLoginPage — phone-OTP two-step flow", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("rejects an OTP that is not exactly 6 digits client-side without calling the API", async () => {
+  it("rejects an OTP that is not exactly 6 digits client-side without calling verifyOtp", async () => {
     render(<PatientLoginPage />);
     await advanceToOtpStep();
-    apiPostMock.mockClear();
-
     typeOtp("12345"); // Only 5 digits.
     fireEvent.click(screen.getByTestId("patient-login-verify"));
-
-    expect(apiPostMock).not.toHaveBeenCalled();
+    expect(verifyOtpMock).not.toHaveBeenCalled();
     expect(screen.getByTestId("patient-login-error")).toHaveTextContent(
       /6-digit code/i,
     );
   });
 
-  it("strips non-numeric characters from OTP input as the user types", async () => {
-    render(<PatientLoginPage />);
-    await advanceToOtpStep();
-    typeOtp("12a3b4c5d6");
-    const input = screen.getByTestId(
-      "patient-login-otp-input",
-    ) as HTMLInputElement;
-    // The page's onChange does value.replace(/\D/g, "") — only digits survive.
-    expect(input.value).toBe("123456");
-  });
-
-  it("POSTs phone + otp to /patient-auth/otp-verify and router.push('/patient') on success", async () => {
+  it("verifyOtp returns ID token → POST /patient-auth/firebase-verify → router.push('/patient/dashboard')", async () => {
     render(<PatientLoginPage />);
     await advanceToOtpStep("+919876543210");
 
+    verifyOtpMock.mockResolvedValueOnce("firebase-id-token-abc");
     apiPostMock.mockResolvedValueOnce({
       success: true,
       data: {
-        user: { id: "u-1", name: "Asha Verma", role: "PATIENT" },
-        accessToken: "jwt-token",
+        user: {
+          id: "u-1",
+          name: "Asha Verma",
+          role: "PATIENT",
+          phone: "9876543210",
+        },
       },
       error: null,
     });
@@ -222,22 +240,28 @@ describe("PatientLoginPage — phone-OTP two-step flow", () => {
     });
 
     await waitFor(() => {
-      expect(routerPushMock).toHaveBeenCalledWith("/patient");
+      expect(verifyOtpMock).toHaveBeenCalledWith("123456");
     });
-    // Verify call shape: second POST is the verify, first was the request.
-    const verifyCall = apiPostMock.mock.calls[apiPostMock.mock.calls.length - 1];
-    expect(verifyCall[0]).toBe("/patient-auth/otp-verify");
-    expect(verifyCall[1]).toEqual({ phone: "+919876543210", otp: "123456" });
+    await waitFor(() => {
+      expect(apiPostMock).toHaveBeenCalledWith(
+        "/patient-auth/firebase-verify",
+        { idToken: "firebase-id-token-abc" },
+      );
+    });
+    await waitFor(() => {
+      expect(routerPushMock).toHaveBeenCalledWith("/patient/dashboard");
+    });
   });
 
-  it("surfaces an invalid-OTP server response inline and does NOT redirect", async () => {
+  it("surfaces a server-side firebase-verify failure inline and does NOT redirect", async () => {
     render(<PatientLoginPage />);
     await advanceToOtpStep();
 
+    verifyOtpMock.mockResolvedValueOnce("firebase-id-token");
     apiPostMock.mockResolvedValueOnce({
       success: false,
       data: null,
-      error: "Invalid or expired code",
+      error: "Couldn't sign you in. Please try again.",
     });
     typeOtp("123456");
     await act(async () => {
@@ -246,17 +270,19 @@ describe("PatientLoginPage — phone-OTP two-step flow", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("patient-login-error")).toHaveTextContent(
-        /invalid or expired code/i,
+        /couldn't sign you in/i,
       );
     });
     expect(routerPushMock).not.toHaveBeenCalled();
   });
 
-  it("surfaces a thrown verify-step error inline and does NOT redirect", async () => {
+  it("surfaces a thrown verifyOtp error inline (e.g. wrong code from Firebase) and does NOT redirect", async () => {
     render(<PatientLoginPage />);
     await advanceToOtpStep();
 
-    apiPostMock.mockRejectedValueOnce(new Error("Verification API down"));
+    verifyOtpMock.mockRejectedValueOnce(
+      new Error("That code didn't match — please try again."),
+    );
     typeOtp("123456");
     await act(async () => {
       fireEvent.click(screen.getByTestId("patient-login-verify"));
@@ -264,24 +290,24 @@ describe("PatientLoginPage — phone-OTP two-step flow", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("patient-login-error")).toHaveTextContent(
-        /verification api down/i,
+        /didn't match/i,
       );
     });
+    expect(apiPostMock).not.toHaveBeenCalled();
     expect(routerPushMock).not.toHaveBeenCalled();
   });
 
-  it("'Change number' returns to step 1 and clears the OTP + error/info banners", async () => {
+  it("'Change number' returns to step 1 and clears the OTP + error banners", async () => {
     render(<PatientLoginPage />);
     await advanceToOtpStep();
 
-    // Type partial OTP + trigger a client-side error so we can verify clear.
+    // Trigger a client-side error so we can verify it gets cleared.
     typeOtp("12");
     fireEvent.click(screen.getByTestId("patient-login-verify"));
     expect(screen.getByTestId("patient-login-error")).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId("patient-login-back"));
 
-    // Back on step 1 — phone input visible, OTP gone, banners cleared.
     expect(
       screen.getByTestId("patient-login-phone-input"),
     ).toBeInTheDocument();
@@ -296,34 +322,31 @@ describe("PatientLoginPage — phone-OTP two-step flow", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("'Resend code' re-fires the otp-request POST against the same phone", async () => {
+  it("'Resend code' re-fires sendOtp against the SAME normalised E.164 and stays on step 2", async () => {
     render(<PatientLoginPage />);
     await advanceToOtpStep("+919876543210");
-    apiPostMock.mockClear();
+    sendOtpMock.mockClear();
+    resetPhoneAuthStateMock.mockClear();
 
-    apiPostMock.mockResolvedValueOnce({
-      success: true,
-      data: { sent: true },
-      error: null,
-    });
+    sendOtpMock.mockResolvedValueOnce(undefined);
     await act(async () => {
       fireEvent.click(screen.getByTestId("patient-login-resend"));
     });
 
     await waitFor(() => {
-      expect(apiPostMock).toHaveBeenCalledTimes(1);
+      expect(sendOtpMock).toHaveBeenCalledTimes(1);
     });
-    expect(apiPostMock.mock.calls[0][0]).toBe("/patient-auth/otp-request");
-    expect(apiPostMock.mock.calls[0][1]).toEqual({ phone: "+919876543210" });
-    // Still on step 2 — OTP input remains visible.
+    expect(sendOtpMock).toHaveBeenCalledWith("+919876543210");
+    // resend() resets any stale ConfirmationResult before re-minting.
+    expect(resetPhoneAuthStateMock).toHaveBeenCalled();
     expect(
       screen.getByTestId("patient-login-otp-input"),
     ).toBeInTheDocument();
   });
 
-  it("disables the send-code button while a request is in flight (busy state)", async () => {
+  it("disables the send-code button while sendOtp is in flight (busy state)", async () => {
     let resolveSend: ((v: unknown) => void) | undefined;
-    apiPostMock.mockReturnValueOnce(
+    sendOtpMock.mockReturnValueOnce(
       new Promise((resolve) => {
         resolveSend = resolve;
       }),
@@ -338,16 +361,14 @@ describe("PatientLoginPage — phone-OTP two-step flow", () => {
       fireEvent.click(button);
     });
 
-    // Mid-flight: button disabled + label flipped to "Sending…".
     expect(button).toBeDisabled();
     expect(button).toHaveTextContent(/sending/i);
 
     await act(async () => {
-      resolveSend?.({ success: true, data: { sent: true }, error: null });
+      resolveSend?.(undefined);
       await Promise.resolve();
     });
 
-    // Settled: advanced to step 2.
     await waitFor(() => {
       expect(
         screen.getByTestId("patient-login-otp-input"),

--- a/apps/web/src/app/patient/login/page.tsx
+++ b/apps/web/src/app/patient/login/page.tsx
@@ -1,39 +1,58 @@
 "use client";
 
-// Patient phone-OTP login page (Pearl §5.3 / §6.1 — gap #5 piece 2 of 4).
+// Patient phone-OTP login page — Firebase Phone Authentication.
+//
+// Replaces the old server-issued SMS-OTP flow (POST /patient-auth/otp-request
+// + /patient-auth/otp-verify). Firebase handles SMS delivery + code
+// generation; our backend only verifies the resulting Firebase ID token and
+// mints the medcore_at / medcore_rt session cookies via
+// POST /patient-auth/firebase-verify. That preserves the existing audit log,
+// tenant scoping, rate limiting, and BOLA defenses — only the OTP transport
+// changed.
 //
 // Two-step flow:
-//   1. Phone input → POST /api/v1/patient-auth/otp-request → moves to step 2.
-//   2. OTP input → POST /api/v1/patient-auth/otp-verify → cookies set by the
-//      server, then router.push('/patient').
+//   1. Phone input → ensureRecaptcha() + sendOtp(phoneE164) → step 2.
+//   2. OTP input → verifyOtp(code) → POST the Firebase ID token to our API
+//      → server mints cookies → router.push('/patient/dashboard').
 //
-// Functional > pretty per the piece-2 scope. Piece 3 (dashboard tiles) and
-// piece 4 (offline cache) will polish the look. We deliberately do NOT use
-// the dashboard's `<LanguageDropdown>` or `<BranchPicker>` — this page lives
-// in the bare `/patient` route group whose layout omits both.
+// reCAPTCHA: Firebase requires a bot-check before sending the SMS. We mount
+// an INVISIBLE verifier under #patient-recaptcha so the user never sees the
+// widget unless Firebase decides they look like a bot.
 //
-// Touch targets: every interactive control is h-11 (44px) per Pearl §6.2.
-// API errors render inline next to `data-testid="patient-login-error"` so
-// the e2e (future) can assert on a specific element rather than a toast.
+// Touch targets remain h-11 (44px) per Pearl §6.2. All testids prefixed
+// `patient-login-*` are preserved from the old flow so component-level
+// smoke tests don't need to relearn them (the integration tests pinning
+// /patient-auth/otp-request URLs DO need to be rewritten — see
+// __tests__/page.test.tsx; they assume the old transport).
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { api } from "@/lib/api";
+import {
+  ensureRecaptcha,
+  disposeRecaptcha,
+  sendOtp,
+  verifyOtp,
+  resetPhoneAuthState,
+} from "@/lib/firebase";
 
 type Step = "phone" | "otp";
 
-interface OtpRequestResponse {
-  success: boolean;
-  data?: { sent: boolean } | null;
-  error?: string | null;
-}
-interface OtpVerifyResponse {
+interface FirebaseVerifyResponse {
   success: boolean;
   data?: {
-    user?: { id: string; name: string; role: string };
-    accessToken?: string;
+    user?: { id: string; name: string; role: string; phone: string };
   } | null;
   error?: string | null;
+}
+
+// Accept either 10-digit (assume +91), 12-digit starting +91, or any valid
+// E.164 — Firebase requires E.164 so we'll normalise before sending.
+function normaliseToE164(input: string): string | null {
+  const trimmed = input.trim().replace(/[\s-]/g, "");
+  if (/^\+\d{10,15}$/.test(trimmed)) return trimmed;
+  if (/^\d{10}$/.test(trimmed)) return `+91${trimmed}`; // India default
+  return null;
 }
 
 export default function PatientLoginPage() {
@@ -44,32 +63,52 @@ export default function PatientLoginPage() {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [info, setInfo] = useState<string | null>(null);
+  // Remember the normalised E.164 across the two steps so the verify step
+  // doesn't depend on whatever the user might have typed into the phone
+  // input in the meantime.
+  const e164Ref = useRef<string | null>(null);
+
+  // Mount the invisible reCAPTCHA verifier on first render. Cleanup on
+  // unmount so a fresh widget gets installed on the next visit (Firebase
+  // attaches DOM state to the container).
+  useEffect(() => {
+    try {
+      ensureRecaptcha("patient-recaptcha");
+    } catch (err) {
+      // Misconfigured env vars throw inside Firebase init. Surface as the
+      // first error the user sees rather than letting the page render
+      // half-broken.
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Patient sign-in is unavailable right now.",
+      );
+    }
+    return () => {
+      disposeRecaptcha();
+      resetPhoneAuthState();
+    };
+  }, []);
 
   async function sendCode(): Promise<void> {
     if (busy) return;
     setError(null);
     setInfo(null);
-    if (!/^\+?[0-9]{10,15}$/.test(phone.trim())) {
-      setError("Enter a valid phone number (10–15 digits, optional +).");
+    const e164 = normaliseToE164(phone);
+    if (!e164) {
+      setError(
+        "Enter a valid phone number — 10 digits for India, or full +country code (e.g. +91 9876543210).",
+      );
       return;
     }
     setBusy(true);
     try {
-      const res = await api.post<OtpRequestResponse>(
-        "/patient-auth/otp-request",
-        { phone: phone.trim() },
-      );
-      if (res?.success) {
-        setStep("otp");
-        setInfo(
-          "If this number is registered, a 6-digit code has been sent.",
-        );
-      } else {
-        setError(res?.error || "Couldn't send code — please try again.");
-      }
+      await sendOtp(e164);
+      e164Ref.current = e164;
+      setStep("otp");
+      setInfo("A 6-digit code has been sent to your phone.");
     } catch (err) {
-      const msg = err instanceof Error ? err.message : "Couldn't send code";
-      setError(msg);
+      setError(err instanceof Error ? err.message : "Couldn't send code");
     } finally {
       setBusy(false);
     }
@@ -85,30 +124,37 @@ export default function PatientLoginPage() {
     }
     setBusy(true);
     try {
-      const res = await api.post<OtpVerifyResponse>(
-        "/patient-auth/otp-verify",
-        { phone: phone.trim(), otp: otp.trim() },
+      // Step A — confirm with Firebase, get ID token.
+      const idToken = await verifyOtp(otp.trim());
+      // Step B — hand the ID token to our backend so it can verify with
+      // firebase-admin, look up the Patient by phone, and mint our session
+      // cookies. The server is the only thing that should be issuing
+      // medcore_at / medcore_rt — we don't store the Firebase token
+      // anywhere client-side (no localStorage), it's just a one-shot
+      // bearer to the exchange endpoint.
+      const res = await api.post<FirebaseVerifyResponse>(
+        "/patient-auth/firebase-verify",
+        { idToken },
       );
       if (res?.success) {
-        // Cookies (medcore_at / medcore_rt / medcore_csrf) are already set
-        // by the API response. Bounce to the patient landing page.
-        router.push("/patient");
+        // Cookies set by server response — bounce to dashboard.
+        router.push("/patient/dashboard");
       } else {
-        setError(res?.error || "Invalid or expired code");
+        setError(res?.error || "Couldn't sign you in. Please try again.");
       }
     } catch (err) {
-      const msg =
-        err instanceof Error ? err.message : "Couldn't verify code";
-      setError(msg);
+      setError(err instanceof Error ? err.message : "Couldn't verify code");
     } finally {
       setBusy(false);
     }
   }
 
-  function resend(): void {
-    // Re-runs sendCode against the same phone — the server enforces the
-    // 3-per-10-min throttle and will surface a 429 inline if exceeded.
-    void sendCode();
+  async function resend(): Promise<void> {
+    // Send a fresh code for the SAME normalised E.164. resetPhoneAuthState
+    // first so any stale ConfirmationResult isn't reused.
+    resetPhoneAuthState();
+    setOtp("");
+    await sendCode();
   }
 
   return (
@@ -144,7 +190,7 @@ export default function PatientLoginPage() {
               inputMode="tel"
               autoComplete="tel"
               className="block h-11 w-full rounded-md border border-slate-300 px-3 text-base"
-              placeholder="+919876543210"
+              placeholder="+91 9876543210"
               value={phone}
               onChange={(e) => setPhone(e.target.value)}
               disabled={busy}
@@ -207,6 +253,7 @@ export default function PatientLoginPage() {
                 setOtp("");
                 setError(null);
                 setInfo(null);
+                resetPhoneAuthState();
               }}
               className="inline-flex h-11 min-w-[44px] items-center text-slate-700 underline-offset-2 hover:underline"
             >
@@ -215,7 +262,7 @@ export default function PatientLoginPage() {
             <button
               type="button"
               data-testid="patient-login-resend"
-              onClick={resend}
+              onClick={() => void resend()}
               disabled={busy}
               className="inline-flex h-11 min-w-[44px] items-center text-slate-700 underline-offset-2 hover:underline disabled:opacity-60"
             >
@@ -243,7 +290,21 @@ export default function PatientLoginPage() {
         </p>
       ) : null}
 
-      <p className="text-center text-sm text-slate-600">New patient? <a href="/patient/register" data-testid="patient-login-register-link" className="font-medium text-slate-900 underline-offset-2 hover:underline">Create an account</a></p>
+      <p className="text-center text-sm text-slate-600">
+        New patient?{" "}
+        <a
+          href="/patient/register"
+          data-testid="patient-login-register-link"
+          className="font-medium text-slate-900 underline-offset-2 hover:underline"
+        >
+          Create an account
+        </a>
+      </p>
+
+      {/* Invisible reCAPTCHA container — Firebase mounts the widget here.
+          Must exist in the DOM before ensureRecaptcha() runs (the effect
+          above schedules that after first paint). */}
+      <div id="patient-recaptcha" />
     </section>
   );
 }

--- a/apps/web/src/app/patient/prescriptions/__tests__/page.test.tsx
+++ b/apps/web/src/app/patient/prescriptions/__tests__/page.test.tsx
@@ -14,17 +14,34 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, within, fireEvent } from "@testing-library/react";
 
-const { apiGetMock } = vi.hoisted(() => ({
-  apiGetMock: vi.fn(),
-}));
+const { apiGetMock, apiPostMock, toastSuccessMock, toastErrorMock } = vi.hoisted(
+  () => ({
+    apiGetMock: vi.fn(),
+    apiPostMock: vi.fn(),
+    toastSuccessMock: vi.fn(),
+    toastErrorMock: vi.fn(),
+  }),
+);
 
 vi.mock("@/lib/api", () => ({
   api: {
     get: apiGetMock,
-    post: vi.fn(),
+    post: apiPostMock,
     patch: vi.fn(),
     put: vi.fn(),
     delete: vi.fn(),
+  },
+}));
+
+// 2026-05-27: the Share CTA now posts to /prescriptions/:id/share and
+// toasts the result (mirroring the doctor flow). Stub the toast helpers
+// so the assertions can verify both happy + 409 paths.
+vi.mock("@/lib/toast", () => ({
+  toast: {
+    success: toastSuccessMock,
+    error: toastErrorMock,
+    info: vi.fn(),
+    warning: vi.fn(),
   },
 }));
 
@@ -77,6 +94,9 @@ function rejectedWithStatus(status: number) {
 describe("Patient prescriptions page — gap #5 piece 3c", () => {
   beforeEach(() => {
     apiGetMock.mockReset();
+    apiPostMock.mockReset();
+    toastSuccessMock.mockReset();
+    toastErrorMock.mockReset();
   });
 
   it("renders the list with 3 mocked rows (mixed item counts)", async () => {
@@ -208,7 +228,13 @@ describe("Patient prescriptions page — gap #5 piece 3c", () => {
     }
   });
 
-  it("Share-WhatsApp link uses the wa.me/?text=... shape with the verify URL encoded inside", async () => {
+  it("Share button posts to /prescriptions/:id/share with channel=WHATSAPP and toasts on success", async () => {
+    // 2026-05-27: replaces the old wa.me-link test. The Share CTA is now
+    // a <button> that calls the server-side share endpoint (mirrors the
+    // doctor flow at apps/web/src/app/dashboard/prescriptions/page.tsx
+    // `shareVia` at L494). Server delivers the verify link via Meta
+    // Cloud API to the patient's registered phone and logs the share;
+    // the client just toasts.
     apiGetMock.mockResolvedValue(
       listOk([
         makeRow({
@@ -219,21 +245,63 @@ describe("Patient prescriptions page — gap #5 piece 3c", () => {
         }),
       ]),
     );
+    apiPostMock.mockResolvedValue({ success: true, data: null, error: null });
     render(<PatientPrescriptionsPage />);
     await waitFor(() =>
       expect(screen.getByTestId("patient-prescriptions")).toBeInTheDocument(),
     );
 
-    const link = screen.getByTestId("patient-prescriptions-share-btn");
-    const href = link.getAttribute("href") ?? "";
-    expect(href.startsWith("https://wa.me/?text=")).toBe(true);
-    // The verify URL must appear inside the encoded message — encodeURIComponent
-    // doesn't escape ":" or "/" so we can grep for the path directly.
-    const decoded = decodeURIComponent(href.replace("https://wa.me/?text=", ""));
-    expect(decoded).toContain("/verify/rx/rx-abc-123");
-    expect(decoded).toContain("Dr. Sharma");
-    expect(link).toHaveAttribute("target", "_blank");
-    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    const btn = screen.getByTestId("patient-prescriptions-share-btn");
+    expect(btn.tagName).toBe("BUTTON");
+    fireEvent.click(btn);
+
+    await waitFor(() =>
+      expect(apiPostMock).toHaveBeenCalledWith(
+        "/prescriptions/rx-abc-123/share",
+        { channel: "WHATSAPP" },
+      ),
+    );
+    await waitFor(() =>
+      expect(toastSuccessMock).toHaveBeenCalledWith(
+        "Prescription shared via WhatsApp",
+      ),
+    );
+  });
+
+  it("Share button toasts the API's 409 error verbatim (unsigned/cancelled/no-phone)", async () => {
+    // Patient-side has no SignaturePad branch (a patient can't sign for
+    // their doctor) — on a 409 we surface the API's friendly message
+    // unchanged so the patient knows what to do next.
+    apiGetMock.mockResolvedValue(
+      listOk([
+        makeRow({
+          id: "rx-unsigned",
+          createdAt: "2026-05-15T10:00:00Z",
+          items: ["Paracetamol"],
+          signatureUrl: null,
+        }),
+      ]),
+    );
+    const apiErr = Object.assign(new Error("nope"), {
+      status: 409,
+      payload: {
+        error:
+          "Cannot share an unsigned prescription — the prescribing doctor must sign it first.",
+      },
+    });
+    apiPostMock.mockRejectedValue(apiErr);
+
+    render(<PatientPrescriptionsPage />);
+    await waitFor(() =>
+      expect(screen.getByTestId("patient-prescriptions")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("patient-prescriptions-share-btn"));
+
+    await waitFor(() =>
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "Cannot share an unsigned prescription — the prescribing doctor must sign it first.",
+      ),
+    );
   });
 
   it("Download PDF link points at the API PDF endpoint with format=pdf", async () => {
@@ -277,7 +345,15 @@ describe("Patient prescriptions page — gap #5 piece 3c", () => {
     expect(link).toHaveAttribute("target", "_blank");
   });
 
-  it("hides the Share CTA on rows that have no signatureUrl (draft Rx)", async () => {
+  it("renders the Share CTA on unsigned/draft rows so the patient can see the gate explanation", async () => {
+    // 2026-05-27: previously this test asserted the Share CTA was HIDDEN
+    // on rows without a signature. We flipped that: the API's POST
+    // /:id/share returns a friendly 409 explaining why share is
+    // unavailable ("Cannot share an unsigned prescription — the
+    // prescribing doctor must sign it first."), and the client toasts
+    // that message verbatim. Hiding the button left the patient with no
+    // explanation; rendering it lets the gate-explanation toast fire on
+    // click. Download + Verify still visible regardless.
     apiGetMock.mockResolvedValue(
       listOk([
         makeRow({
@@ -294,10 +370,8 @@ describe("Patient prescriptions page — gap #5 piece 3c", () => {
       expect(screen.getByTestId("patient-prescriptions")).toBeInTheDocument(),
     );
     expect(
-      screen.queryByTestId("patient-prescriptions-share-btn"),
-    ).not.toBeInTheDocument();
-    // Download + Verify still visible — the patient may still want to read
-    // their own draft and the verify view will show "unsigned".
+      screen.getByTestId("patient-prescriptions-share-btn"),
+    ).toBeInTheDocument();
     expect(
       screen.getByTestId("patient-prescriptions-download-btn"),
     ).toBeInTheDocument();

--- a/apps/web/src/app/patient/prescriptions/page.tsx
+++ b/apps/web/src/app/patient/prescriptions/page.tsx
@@ -39,6 +39,7 @@
 import { useEffect, useState, useCallback } from "react";
 import Link from "next/link";
 import { api } from "@/lib/api";
+import { toast } from "@/lib/toast";
 
 interface PrescriptionItem {
   id: string;
@@ -70,13 +71,6 @@ interface ApiList<T> {
 type LoadState = "loading" | "ready" | "unauth" | "error";
 
 const PAGE_SIZE = 20;
-
-// Mirror the share-rx server policy at routes/prescriptions.ts:871-887 —
-// a CANCELLED / REJECTED prescription is not a valid medical document and
-// must not be shared. We also hide the share CTA for rows with no
-// signatureUrl (still a draft) so the patient never sends an unverifiable
-// artefact to a third party.
-const NON_SHAREABLE_STATUSES = new Set(["CANCELLED", "REJECTED", "DRAFT"]);
 
 function formatDate(iso: string): string {
   return new Date(iso).toLocaleDateString("en-IN", {
@@ -126,6 +120,39 @@ export default function PatientPrescriptionsPage() {
   const [page, setPage] = useState(1);
   const [total, setTotal] = useState(0);
   const [loadingMore, setLoadingMore] = useState(false);
+
+  // Same shape as the dashboard's Recent Prescriptions tile + the doctor
+  // side (apps/web/src/app/dashboard/prescriptions/page.tsx `shareVia` at
+  // L494): POST /prescriptions/:id/share with { channel: "WHATSAPP" }.
+  // Server delivers the verify link to the patient's registered phone via
+  // Meta Cloud API and logs the share — no client-side `wa.me` navigation,
+  // the patient stays on this page and sees a toast. The doctor side's
+  // Sign-before-share modal branch doesn't apply here (patient can't sign
+  // for the doctor), so on a 409 "unsigned" we surface the API's message
+  // verbatim.
+  const [sharingRxId, setSharingRxId] = useState<string | null>(null);
+  const shareViaWhatsApp = useCallback(async (rxId: string): Promise<void> => {
+    setSharingRxId((curr) => {
+      // Guard against double-click while one share is in flight.
+      if (curr) return curr;
+      return rxId;
+    });
+    try {
+      await api.post(`/prescriptions/${rxId}/share`, { channel: "WHATSAPP" });
+      toast.success("Prescription shared via WhatsApp");
+    } catch (err) {
+      const anyErr = err as Error & {
+        status?: number;
+        payload?: { error?: string };
+      };
+      const msg =
+        anyErr?.payload?.error ??
+        (err instanceof Error ? err.message : "Failed to share");
+      toast.error(msg);
+    } finally {
+      setSharingRxId(null);
+    }
+  }, []);
 
   const fetchPage = useCallback(
     async (
@@ -249,7 +276,12 @@ export default function PatientPrescriptionsPage() {
       ) : (
         <ul className="space-y-3">
           {prescriptions.map((rx) => (
-            <PrescriptionCard key={rx.id} prescription={rx} />
+            <PrescriptionCard
+              key={rx.id}
+              prescription={rx}
+              onShare={shareViaWhatsApp}
+              sharing={sharingRxId === rx.id}
+            />
           ))}
         </ul>
       )}
@@ -273,9 +305,11 @@ export default function PatientPrescriptionsPage() {
 
 interface CardProps {
   prescription: PrescriptionRow;
+  onShare: (rxId: string) => void | Promise<void>;
+  sharing: boolean;
 }
 
-function PrescriptionCard({ prescription }: CardProps) {
+function PrescriptionCard({ prescription, onShare, sharing }: CardProps) {
   const items = prescription.items ?? [];
   const first = items[0]?.medicineName ?? "Prescription";
   const more = Math.max(0, items.length - 1);
@@ -283,18 +317,14 @@ function PrescriptionCard({ prescription }: CardProps) {
   const specialty = prescription.doctor?.specialty ?? null;
   const status = prescription.status ?? null;
 
-  // Share gate: don't expose a "Share with verify URL" CTA for a Rx that
-  // would fail server-side verification (no signature / cancelled / draft).
-  const isShareable =
-    !!prescription.signatureUrl &&
-    !(status && NON_SHAREABLE_STATUSES.has(status));
-
+  // We render the Share button unconditionally now — the API's POST
+  // /:id/share endpoint returns friendly 409s for unsigned /
+  // cancelled / rejected rows ("Cannot share an unsigned prescription —
+  // the prescribing doctor must sign it first.") which we toast
+  // verbatim. The previous hide-when-not-shareable pattern left the
+  // patient with no idea why share was missing.
   const verifyUrl = buildVerifyUrl(prescription.id);
   const pdfUrl = buildPdfUrl(prescription.id);
-  const waText = `My prescription from ${
-    doctorName ? `Dr. ${doctorName}` : "MedCore"
-  }: ${verifyUrl}`;
-  const waHref = `https://wa.me/?text=${encodeURIComponent(waText)}`;
 
   return (
     <li
@@ -353,17 +383,15 @@ function PrescriptionCard({ prescription }: CardProps) {
         >
           Download PDF
         </a>
-        {isShareable ? (
-          <a
-            href={waHref}
-            target="_blank"
-            rel="noopener noreferrer"
-            data-testid="patient-prescriptions-share-btn"
-            className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-emerald-300 bg-emerald-50 px-4 text-sm font-medium text-emerald-900"
-          >
-            Share via WhatsApp
-          </a>
-        ) : null}
+        <button
+          type="button"
+          onClick={() => void onShare(prescription.id)}
+          disabled={sharing}
+          data-testid="patient-prescriptions-share-btn"
+          className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-emerald-300 bg-emerald-50 px-4 text-sm font-medium text-emerald-900 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {sharing ? "Sharing…" : "Share via WhatsApp"}
+        </button>
         <a
           href={verifyUrl}
           target="_blank"

--- a/apps/web/src/app/patient/profile/__tests__/page.test.tsx
+++ b/apps/web/src/app/patient/profile/__tests__/page.test.tsx
@@ -281,7 +281,14 @@ describe("Patient profile page — gap #5 piece 3e", () => {
     expect(nameInput.value).toBe("Different Name");
 
     fireEvent.click(screen.getByTestId("patient-profile-cancel-btn"));
-    expect(nameInput.value).toBe("Anand Kumar");
+    // 2026-05-27: wrap in waitFor — handleCancel's `setForm(initialForm)` +
+    // adjacent setSubmitState/setSubmitError/setFieldErrors land across React
+    // 19's automatic batch boundary, and the synchronous read of
+    // nameInput.value races the input's controlled-value re-render under
+    // vitest+jsdom. The retry covers the post-click commit.
+    await waitFor(() => {
+      expect(nameInput.value).toBe("Anand Kumar");
+    });
   });
 
   it("Save / Cancel / ABHA-link CTAs carry the 44px touch-target invariant", async () => {

--- a/apps/web/src/app/patient/profile/page.tsx
+++ b/apps/web/src/app/patient/profile/page.tsx
@@ -651,7 +651,7 @@ export default function PatientProfilePage() {
             <Link
               href="/patient/profile/link-abha"
               data-testid="patient-profile-abha-link-cta"
-              className="inline-flex items-center rounded-lg border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+              className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-lg border border-gray-300 px-3 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
             >
               Link ABHA (Aadhaar OTP)
             </Link>

--- a/apps/web/src/app/patient/profile/page.tsx
+++ b/apps/web/src/app/patient/profile/page.tsx
@@ -349,215 +349,256 @@ export default function PatientProfilePage() {
     [form, initialForm],
   );
 
+  // Field helper mirrors apps/web/src/app/dashboard/settings/page.tsx Field —
+  // small label-stacked-above-input convention shared across the staff
+  // settings UI. Keeping the patient form on the same primitive lets it
+  // visually match the settings cards exactly.
+  function Field({
+    label,
+    htmlFor,
+    children,
+  }: {
+    label: string;
+    htmlFor?: string;
+    children: React.ReactNode;
+  }) {
+    return (
+      <label htmlFor={htmlFor} className="block">
+        <span className="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400">
+          {label}
+        </span>
+        {children}
+      </label>
+    );
+  }
+  const inputClass =
+    "w-full rounded-lg border border-gray-300 px-3 py-2 dark:border-gray-600 dark:bg-gray-900";
+  const inputErrorClass =
+    "w-full rounded-lg border border-red-500 bg-red-50 px-3 py-2 dark:bg-red-900/20";
+  const readOnlyInputClass =
+    "w-full cursor-not-allowed rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 dark:border-gray-700 dark:bg-gray-900/50";
+
   if (state === "loading") {
     return (
-      <section
-        data-testid="patient-profile-loading"
-        className="space-y-4 py-6"
-      >
-        <div className="h-8 w-40 animate-pulse rounded bg-slate-100" />
-        <div className="space-y-3">
+      <div data-testid="patient-profile-loading">
+        <h1 className="mb-6 text-2xl font-bold">My Profile</h1>
+        <div className="space-y-4">
           {[0, 1, 2, 3].map((i) => (
             <div
               key={i}
-              className="h-11 w-full animate-pulse rounded bg-slate-100"
-            />
+              className="rounded-xl bg-white p-6 shadow-sm dark:bg-gray-800"
+            >
+              <div className="mb-4 h-5 w-32 animate-pulse rounded bg-gray-100 dark:bg-gray-700" />
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="h-10 animate-pulse rounded bg-gray-100 dark:bg-gray-700" />
+                <div className="h-10 animate-pulse rounded bg-gray-100 dark:bg-gray-700" />
+              </div>
+            </div>
           ))}
         </div>
-      </section>
+      </div>
     );
   }
 
   if (state === "unauth") {
     return (
-      <section data-testid="patient-profile-unauth" className="space-y-4 py-6">
-        <h1 className="text-2xl font-semibold tracking-tight">Sign in</h1>
-        <p className="text-base text-slate-600">
-          Please sign in to view and edit your profile.
-        </p>
-        <Link
-          href="/patient/login"
-          className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md bg-slate-900 px-6 text-sm font-medium text-white"
-          data-testid="patient-profile-signin-cta"
-        >
-          Sign in
-        </Link>
-      </section>
+      <div data-testid="patient-profile-unauth">
+        <h1 className="mb-6 text-2xl font-bold">My Profile</h1>
+        <div className="rounded-xl bg-white p-6 shadow-sm dark:bg-gray-800">
+          <h2 className="mb-2 text-lg font-semibold">Sign in required</h2>
+          <p className="mb-4 text-sm text-gray-600 dark:text-gray-400">
+            Please sign in to view and edit your profile.
+          </p>
+          <Link
+            href="/patient/login"
+            data-testid="patient-profile-signin-cta"
+            className="inline-flex items-center rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary-dark"
+          >
+            Sign in
+          </Link>
+        </div>
+      </div>
     );
   }
 
   if (state === "error" || !form || !me) {
     return (
-      <section
-        data-testid="patient-profile-error"
-        role="alert"
-        className="rounded-md border border-red-300 bg-red-50 p-4 text-sm text-red-800"
-      >
-        Something went wrong loading your profile. Please refresh.
-      </section>
+      <div>
+        <h1 className="mb-6 text-2xl font-bold">My Profile</h1>
+        <div
+          data-testid="patient-profile-error"
+          role="alert"
+          className="rounded-xl border border-red-300 bg-red-50 p-6 text-sm text-red-800 shadow-sm dark:border-red-700 dark:bg-red-900/20 dark:text-red-200"
+        >
+          Something went wrong loading your profile. Please refresh.
+        </div>
+      </div>
     );
   }
 
   return (
-    <section data-testid="patient-profile" className="space-y-6 py-4">
-      <header className="space-y-1">
-        <h1 className="text-2xl font-semibold tracking-tight">My profile</h1>
-        <p className="text-sm text-slate-600">
-          Keep your details up to date so reminders and bills reach you.
-        </p>
-      </header>
+    <div>
+      <h1 className="mb-2 text-2xl font-bold">My Profile</h1>
+      <p className="mb-6 text-sm text-gray-600 dark:text-gray-400">
+        Keep your details up to date so reminders and bills reach you.
+      </p>
 
-      <form className="space-y-8" onSubmit={handleSubmit} noValidate>
+      <form
+        data-testid="patient-profile"
+        className="space-y-6"
+        onSubmit={handleSubmit}
+        noValidate
+      >
         {/* ─── Personal ─────────────────────────────────────────────── */}
-        <fieldset
+        <div
           data-testid="patient-profile-section-personal"
-          className="space-y-4 rounded-lg border border-slate-200 bg-white p-4 shadow-sm"
+          className="rounded-xl bg-white p-6 shadow-sm dark:bg-gray-800"
         >
-          <legend className="px-1 text-sm font-medium uppercase tracking-wide text-slate-500">
-            Personal
-          </legend>
-
-          <label className="block space-y-1">
-            <span className="text-sm font-medium text-slate-800">Full name</span>
-            <input
-              type="text"
-              data-testid="patient-profile-name-input"
-              value={form.name}
-              onChange={(e) => patchField("name", e.target.value)}
-              maxLength={100}
-              className="block h-11 w-full rounded-md border border-slate-300 px-3 text-base text-slate-900 focus:border-slate-900 focus:outline-none"
-            />
-            {fieldErrors.name ? (
-              <span
-                data-testid="patient-profile-name-error"
-                className="text-xs font-medium text-red-700"
-              >
-                {fieldErrors.name}
-              </span>
-            ) : null}
-          </label>
-
-          <label className="block space-y-1">
-            <span className="text-sm font-medium text-slate-800">Date of birth</span>
-            <input
-              type="date"
-              data-testid="patient-profile-dob-input"
-              value={form.dateOfBirth}
-              onChange={(e) => patchField("dateOfBirth", e.target.value)}
-              className="block h-11 w-full rounded-md border border-slate-300 px-3 text-base text-slate-900 focus:border-slate-900 focus:outline-none"
-            />
-            {fieldErrors.dateOfBirth ? (
-              <span
-                data-testid="patient-profile-dob-error"
-                className="text-xs font-medium text-red-700"
-              >
-                {fieldErrors.dateOfBirth}
-              </span>
-            ) : null}
-          </label>
-
-          <div className="space-y-1">
-            <span className="text-sm font-medium text-slate-800">Phone</span>
-            <input
-              type="tel"
-              readOnly
-              data-testid="patient-profile-phone-input"
-              value={me.phone ?? ""}
-              className="block h-11 w-full rounded-md border border-slate-200 bg-slate-50 px-3 text-base text-slate-700"
-            />
-            <p
-              data-testid="patient-profile-phone-hint"
-              className="text-xs text-slate-500"
-            >
-              Contact reception to change your phone number — it secures your sign-in.
-            </p>
-          </div>
-
-          {me.patient?.gender ? (
-            <div className="space-y-1">
-              <span className="text-sm font-medium text-slate-800">Gender</span>
+          <h2 className="mb-4 text-lg font-semibold">Personal</h2>
+          <div className="grid gap-4 md:grid-cols-2">
+            <Field label="Full name">
               <input
                 type="text"
-                readOnly
-                data-testid="patient-profile-gender-input"
-                value={me.patient.gender}
-                className="block h-11 w-full rounded-md border border-slate-200 bg-slate-50 px-3 text-base text-slate-700"
+                data-testid="patient-profile-name-input"
+                value={form.name}
+                onChange={(e) => patchField("name", e.target.value)}
+                maxLength={100}
+                aria-invalid={fieldErrors.name ? "true" : undefined}
+                className={fieldErrors.name ? inputErrorClass : inputClass}
               />
-            </div>
-          ) : null}
-        </fieldset>
+              {fieldErrors.name ? (
+                <span
+                  data-testid="patient-profile-name-error"
+                  className="mt-1 block text-xs text-red-600"
+                >
+                  {fieldErrors.name}
+                </span>
+              ) : null}
+            </Field>
+
+            <Field label="Date of birth">
+              <input
+                type="date"
+                data-testid="patient-profile-dob-input"
+                value={form.dateOfBirth}
+                onChange={(e) => patchField("dateOfBirth", e.target.value)}
+                aria-invalid={fieldErrors.dateOfBirth ? "true" : undefined}
+                className={
+                  fieldErrors.dateOfBirth ? inputErrorClass : inputClass
+                }
+              />
+              {fieldErrors.dateOfBirth ? (
+                <span
+                  data-testid="patient-profile-dob-error"
+                  className="mt-1 block text-xs text-red-600"
+                >
+                  {fieldErrors.dateOfBirth}
+                </span>
+              ) : null}
+            </Field>
+
+            <Field label="Phone (read-only)">
+              <input
+                type="tel"
+                readOnly
+                data-testid="patient-profile-phone-input"
+                value={me.phone ?? ""}
+                className={readOnlyInputClass}
+              />
+              <span
+                data-testid="patient-profile-phone-hint"
+                className="mt-1 block text-xs text-gray-500 dark:text-gray-400"
+              >
+                Contact reception to change your phone number — it secures your
+                sign-in.
+              </span>
+            </Field>
+
+            {me.patient?.gender ? (
+              <Field label="Gender (read-only)">
+                <input
+                  type="text"
+                  readOnly
+                  data-testid="patient-profile-gender-input"
+                  value={me.patient.gender}
+                  className={readOnlyInputClass}
+                />
+              </Field>
+            ) : null}
+          </div>
+        </div>
 
         {/* ─── Address ──────────────────────────────────────────────── */}
-        <fieldset
+        <div
           data-testid="patient-profile-section-address"
-          className="space-y-4 rounded-lg border border-slate-200 bg-white p-4 shadow-sm"
+          className="rounded-xl bg-white p-6 shadow-sm dark:bg-gray-800"
         >
-          <legend className="px-1 text-sm font-medium uppercase tracking-wide text-slate-500">
-            Address
-          </legend>
-          <label className="block space-y-1">
-            <span className="text-sm font-medium text-slate-800">Postal address</span>
+          <h2 className="mb-4 text-lg font-semibold">Address</h2>
+          <Field label="Postal address">
             <textarea
               data-testid="patient-profile-address-input"
               value={form.address}
               onChange={(e) => patchField("address", e.target.value)}
               rows={3}
-              className="block w-full rounded-md border border-slate-300 px-3 py-2 text-base text-slate-900 focus:border-slate-900 focus:outline-none"
+              aria-invalid={fieldErrors.address ? "true" : undefined}
+              className={fieldErrors.address ? inputErrorClass : inputClass}
             />
             {fieldErrors.address ? (
               <span
                 data-testid="patient-profile-address-error"
-                className="text-xs font-medium text-red-700"
+                className="mt-1 block text-xs text-red-600"
               >
                 {fieldErrors.address}
               </span>
             ) : null}
-          </label>
-        </fieldset>
+          </Field>
+        </div>
 
         {/* ─── Preferences ──────────────────────────────────────────── */}
-        <fieldset
+        <div
           data-testid="patient-profile-section-preferences"
-          className="space-y-4 rounded-lg border border-slate-200 bg-white p-4 shadow-sm"
+          className="rounded-xl bg-white p-6 shadow-sm dark:bg-gray-800"
         >
-          <legend className="px-1 text-sm font-medium uppercase tracking-wide text-slate-500">
-            Preferences
-          </legend>
-
-          <label className="block space-y-1">
-            <span className="text-sm font-medium text-slate-800">Preferred language</span>
-            <select
-              data-testid="patient-profile-language-select"
-              value={form.preferredLanguage}
-              onChange={(e) => patchField("preferredLanguage", e.target.value)}
-              className="block h-11 w-full rounded-md border border-slate-300 bg-white px-3 text-base text-slate-900 focus:border-slate-900 focus:outline-none"
-            >
-              {LANGUAGE_OPTIONS.map((opt) => (
-                <option key={opt.value} value={opt.value}>
-                  {opt.label}
-                </option>
-              ))}
-            </select>
-          </label>
+          <h2 className="mb-4 text-lg font-semibold">Preferences</h2>
+          <div className="grid gap-4 md:grid-cols-2">
+            <Field label="Preferred language">
+              <select
+                data-testid="patient-profile-language-select"
+                value={form.preferredLanguage}
+                onChange={(e) =>
+                  patchField("preferredLanguage", e.target.value)
+                }
+                className={inputClass}
+              >
+                {LANGUAGE_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </Field>
+          </div>
 
           <div
             data-testid="patient-profile-channels"
-            className="space-y-2 pt-2"
+            className="mt-6 space-y-3"
           >
-            <p className="text-sm font-medium text-slate-800">Send reminders via</p>
-            <p className="text-xs text-slate-500">
-              Pick the channels we&apos;re allowed to use for appointment + medication
-              reminders.
+            <p className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              Send reminders via
             </p>
-            <ul className="space-y-2 pt-1">
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              Pick the channels we&apos;re allowed to use for appointment +
+              medication reminders.
+            </p>
+            <ul className="grid gap-2 sm:grid-cols-2">
               {CHANNELS.map((channel) => {
                 const enabled = form.notifications[channel];
                 return (
                   <li
                     key={channel}
-                    className="flex items-center justify-between rounded-md border border-slate-200 bg-slate-50 px-3 py-2"
+                    className="flex items-center justify-between rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 dark:border-gray-700 dark:bg-gray-900/40"
                   >
-                    <span className="text-sm text-slate-800">
+                    <span className="text-sm text-gray-800 dark:text-gray-200">
                       {CHANNEL_LABELS[channel]}
                     </span>
                     <button
@@ -565,11 +606,12 @@ export default function PatientProfilePage() {
                       onClick={() => toggleChannel(channel)}
                       aria-pressed={enabled}
                       data-testid={`patient-profile-channel-${channel.toLowerCase()}`}
-                      className={`inline-flex h-11 min-w-[44px] items-center justify-center rounded-md px-4 text-xs font-medium ${
-                        enabled
-                          ? "bg-emerald-600 text-white"
-                          : "border border-slate-300 bg-white text-slate-700"
-                      }`}
+                      className={
+                        "inline-flex items-center justify-center rounded-lg px-3 py-1.5 text-xs font-medium transition " +
+                        (enabled
+                          ? "bg-primary text-white hover:bg-primary-dark"
+                          : "border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700")
+                      }
                     >
                       {enabled ? "On" : "Off"}
                     </button>
@@ -578,54 +620,54 @@ export default function PatientProfilePage() {
               })}
             </ul>
           </div>
-        </fieldset>
+        </div>
 
         {/* ─── Health ID (ABHA) ─────────────────────────────────────── */}
-        <fieldset
+        <div
           data-testid="patient-profile-section-healthid"
-          className="space-y-4 rounded-lg border border-slate-200 bg-white p-4 shadow-sm"
+          className="rounded-xl bg-white p-6 shadow-sm dark:bg-gray-800"
         >
-          <legend className="px-1 text-sm font-medium uppercase tracking-wide text-slate-500">
-            Health ID
-          </legend>
-          <label className="block space-y-1">
-            <span className="text-sm font-medium text-slate-800">ABHA number</span>
+          <h2 className="mb-4 text-lg font-semibold">Health ID</h2>
+          <Field label="ABHA number">
             <input
               type="text"
               data-testid="patient-profile-abha-input"
               value={form.abhaId}
               onChange={(e) => patchField("abhaId", e.target.value)}
               placeholder="e.g. 14-1234-5678-9012"
-              className="block h-11 w-full rounded-md border border-slate-300 px-3 text-base text-slate-900 focus:border-slate-900 focus:outline-none"
+              aria-invalid={fieldErrors.abhaId ? "true" : undefined}
+              className={fieldErrors.abhaId ? inputErrorClass : inputClass}
             />
             {fieldErrors.abhaId ? (
               <span
                 data-testid="patient-profile-abha-error"
-                className="text-xs font-medium text-red-700"
+                className="mt-1 block text-xs text-red-600"
               >
                 {fieldErrors.abhaId}
               </span>
             ) : null}
-          </label>
-          <Link
-            href="/patient/profile/link-abha"
-            data-testid="patient-profile-abha-link-cta"
-            className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 px-4 text-sm font-medium text-slate-800"
-          >
-            Link ABHA (Aadhaar OTP)
-          </Link>
-          <p className="text-xs text-slate-500">
-            ABHA linking via Aadhaar OTP is coming soon. For now you can paste an
-            existing ABHA number to attach to your record.
-          </p>
-        </fieldset>
+          </Field>
+          <div className="mt-4 flex flex-wrap items-center gap-3">
+            <Link
+              href="/patient/profile/link-abha"
+              data-testid="patient-profile-abha-link-cta"
+              className="inline-flex items-center rounded-lg border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+            >
+              Link ABHA (Aadhaar OTP)
+            </Link>
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              ABHA linking via Aadhaar OTP is coming soon. For now you can paste
+              an existing ABHA number to attach to your record.
+            </p>
+          </div>
+        </div>
 
-        {/* ─── Submit row + status ──────────────────────────────────── */}
+        {/* ─── Status banners ───────────────────────────────────────── */}
         {submitState === "saved" ? (
           <p
             data-testid="patient-profile-saved-toast"
             role="status"
-            className="rounded-md border border-emerald-300 bg-emerald-50 p-3 text-sm font-medium text-emerald-900"
+            className="rounded-xl border border-emerald-300 bg-emerald-50 p-4 text-sm font-medium text-emerald-900 shadow-sm dark:border-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-200"
           >
             Profile saved.
           </p>
@@ -634,32 +676,33 @@ export default function PatientProfilePage() {
           <p
             data-testid="patient-profile-submit-error"
             role="alert"
-            className="rounded-md border border-red-300 bg-red-50 p-3 text-sm font-medium text-red-800"
+            className="rounded-xl border border-red-300 bg-red-50 p-4 text-sm font-medium text-red-800 shadow-sm dark:border-red-700 dark:bg-red-900/20 dark:text-red-200"
           >
             {submitError}
           </p>
         ) : null}
 
-        <div className="flex flex-wrap items-center gap-2 pt-2">
-          <button
-            type="submit"
-            data-testid="patient-profile-save-btn"
-            disabled={!dirty || submitState === "saving"}
-            className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md bg-slate-900 px-6 text-sm font-medium text-white disabled:opacity-60"
-          >
-            {submitState === "saving" ? "Saving…" : "Save changes"}
-          </button>
+        {/* ─── Submit row ───────────────────────────────────────────── */}
+        <div className="flex flex-wrap items-center justify-end gap-2 pt-2">
           <button
             type="button"
             onClick={handleCancel}
             data-testid="patient-profile-cancel-btn"
             disabled={!dirty || submitState === "saving"}
-            className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 px-6 text-sm font-medium text-slate-800 disabled:opacity-60"
+            className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
           >
             Cancel
           </button>
+          <button
+            type="submit"
+            data-testid="patient-profile-save-btn"
+            disabled={!dirty || submitState === "saving"}
+            className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary-dark disabled:opacity-50"
+          >
+            {submitState === "saving" ? "Saving…" : "Save changes"}
+          </button>
         </div>
       </form>
-    </section>
+    </div>
   );
 }

--- a/apps/web/src/app/patient/profile/page.tsx
+++ b/apps/web/src/app/patient/profile/page.tsx
@@ -689,7 +689,7 @@ export default function PatientProfilePage() {
             onClick={handleCancel}
             data-testid="patient-profile-cancel-btn"
             disabled={!dirty || submitState === "saving"}
-            className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+            className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-lg border border-gray-300 px-4 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
           >
             Cancel
           </button>
@@ -697,7 +697,7 @@ export default function PatientProfilePage() {
             type="submit"
             data-testid="patient-profile-save-btn"
             disabled={!dirty || submitState === "saving"}
-            className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary-dark disabled:opacity-50"
+            className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-lg bg-primary px-4 text-sm font-medium text-white hover:bg-primary-dark disabled:opacity-50"
           >
             {submitState === "saving" ? "Saving…" : "Save changes"}
           </button>

--- a/apps/web/src/app/patient/records/page.tsx
+++ b/apps/web/src/app/patient/records/page.tsx
@@ -137,12 +137,22 @@ const TYPE_ICON: Record<EntryType, string> = {
 
 // ─── Adapters: source row → TimelineEntry ────────────────────────────────
 
+// IST offset in minutes — clinic-local time is Asia/Kolkata (UTC+5:30).
+// `Appointment.date` is the calendar day at UTC midnight; `slotStart` is
+// "HH:MM(:SS)" in clinic-local IST clock time. Composing the right UTC
+// instant requires subtracting the IST offset; the older `setUTCHours`
+// version treated the IST clock string AS IF it were UTC and produced a
+// 5h30m-offset timestamp that mis-grouped the entry under the wrong day.
+const IST_OFFSET_MIN = 330;
+
 function appointmentToEntry(a: AppointmentRow): TimelineEntry {
-  // Compose date + slotStart (same pattern as dashboard + appointments page).
   const base = new Date(a.date);
   if (a.slotStart) {
     const [hh, mm] = a.slotStart.split(":").map((s) => parseInt(s, 10));
-    if (Number.isFinite(hh)) base.setUTCHours(hh, mm || 0, 0, 0);
+    if (Number.isFinite(hh)) {
+      const ist = hh * 60 + (Number.isFinite(mm) ? mm : 0);
+      base.setTime(base.getTime() + (ist - IST_OFFSET_MIN) * 60_000);
+    }
   }
   const doctorName = a.doctor?.user?.name;
   const title = doctorName
@@ -213,6 +223,7 @@ function formatDateHeader(ts: number): string {
     day: "2-digit",
     month: "short",
     year: "numeric",
+    timeZone: "Asia/Kolkata",
   });
 }
 
@@ -220,14 +231,16 @@ function formatTime(ts: number): string {
   return new Date(ts).toLocaleTimeString("en-IN", {
     hour: "numeric",
     minute: "2-digit",
+    hour12: true,
+    timeZone: "Asia/Kolkata",
   });
 }
 
 function dayKey(ts: number): string {
-  const d = new Date(ts);
-  // Use UTC day for grouping so the same day stays bucketed regardless of
-  // the user's local TZ shift on hour-of-day.
-  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}-${String(d.getUTCDate()).padStart(2, "0")}`;
+  // Use the IST calendar day for grouping so an appointment at 11pm IST
+  // doesn't get bucketed under the next UTC day on a non-IST browser.
+  // en-CA produces YYYY-MM-DD which is the canonical sortable form.
+  return new Date(ts).toLocaleDateString("en-CA", { timeZone: "Asia/Kolkata" });
 }
 
 // ─── Component ───────────────────────────────────────────────────────────

--- a/apps/web/src/lib/__tests__/store.test.ts
+++ b/apps/web/src/lib/__tests__/store.test.ts
@@ -120,7 +120,16 @@ describe("useAuthStore", () => {
     // Issue #477: there's no localStorage gate anymore. Even with no
     // cookie, loadSession will call /auth/me — the API returns 401 and
     // we settle into clean unauthenticated state.
-    mockedGet.mockRejectedValueOnce(new Error("401"));
+    //
+    // 2026-05-27: loadSession now branches on `err.status` to distinguish
+    // true session expiry (401 → clear auth) from transient failure
+    // (429/5xx → preserve cached user). The mock must therefore carry a
+    // real `status: 401` to mirror what api.ts actually throws (it
+    // attaches `.status` to the Error via `Object.assign`-style shape;
+    // see lib/api.ts:222-229). Bare `new Error("401")` has no .status
+    // and would now hit the preserve-cached-user branch.
+    const err = Object.assign(new Error("Unauthorized"), { status: 401 });
+    mockedGet.mockRejectedValueOnce(err);
     await useAuthStore.getState().loadSession();
     expect(useAuthStore.getState().user).toBeNull();
     expect(useAuthStore.getState().token).toBeNull();

--- a/apps/web/src/lib/firebase/config.ts
+++ b/apps/web/src/lib/firebase/config.ts
@@ -1,0 +1,97 @@
+// Firebase Web SDK initialisation. Lazy + singleton — the SDK is large
+// (~250KB gzipped) and we only want to pay that cost on routes that actually
+// invoke phone-auth (today: /patient/login). Callers MUST import via
+// `lib/firebase` rather than reaching here directly so the entry point is
+// always the same.
+//
+// Env contract (NEXT_PUBLIC_* so they're available in the browser bundle):
+//   NEXT_PUBLIC_FIREBASE_API_KEY
+//   NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN
+//   NEXT_PUBLIC_FIREBASE_PROJECT_ID
+//   NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET
+//   NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID
+//   NEXT_PUBLIC_FIREBASE_APP_ID
+//
+// Note: NEXT_PUBLIC_ vars are public — they ship in the JS bundle and any
+// visitor can read them. That's fine for Firebase config (the API key is
+// not a secret; access control happens via Firebase Security Rules + the
+// reCAPTCHA verifier on phone-auth). The actual secret — the service
+// account JSON — lives on the server only, see apps/api/src/services/
+// firebase-admin.ts.
+
+import { type FirebaseApp, getApps, initializeApp } from "firebase/app";
+import { type Auth, getAuth } from "firebase/auth";
+
+let cachedApp: FirebaseApp | null = null;
+let cachedAuth: Auth | null = null;
+
+function readConfig(): {
+  apiKey: string;
+  authDomain: string;
+  projectId: string;
+  storageBucket: string;
+  messagingSenderId: string;
+  appId: string;
+  measurementId?: string;
+} {
+  // Required: the six core fields. Firebase will not init without them.
+  const required = {
+    apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+    authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+    projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+    storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+    messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+    appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+  };
+  // Surface a clear error early so a misconfigured deploy fails on first
+  // SDK call rather than mid-way through an OTP request with a cryptic
+  // "auth/invalid-api-key" inside Firebase internals.
+  const missing = Object.entries(required)
+    .filter(([, v]) => !v)
+    .map(([k]) => k);
+  if (missing.length > 0) {
+    throw new Error(
+      `Firebase config is missing env vars: ${missing.join(", ")}. ` +
+        "Set NEXT_PUBLIC_FIREBASE_* in apps/web/.env.local — see " +
+        "apps/web/src/lib/firebase/config.ts for the contract.",
+    );
+  }
+  // Optional: measurementId only matters when Firebase Analytics is wired
+  // in. Pass through if present (empty string → undefined so Firebase
+  // doesn't treat "" as a real ID).
+  const measurementId = process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID;
+  // We've just thrown if any required value was missing — narrow through
+  // `unknown` to the return shape (Required<{...|undefined}> still resolves
+  // to {...|undefined} in TS).
+  return {
+    ...(required as unknown as {
+      apiKey: string;
+      authDomain: string;
+      projectId: string;
+      storageBucket: string;
+      messagingSenderId: string;
+      appId: string;
+    }),
+    ...(measurementId ? { measurementId } : {}),
+  };
+}
+
+export function getFirebaseApp(): FirebaseApp {
+  if (cachedApp) return cachedApp;
+  // Next.js dev server hot-reloads modules — reuse the app if Firebase has
+  // already registered one for this page (otherwise we get
+  // "Firebase App named '[DEFAULT]' already exists").
+  const existing = getApps();
+  if (existing.length > 0) {
+    cachedApp = existing[0];
+    return cachedApp;
+  }
+  cachedApp = initializeApp(readConfig());
+  return cachedApp;
+}
+
+export function getFirebaseAuth(): Auth {
+  if (cachedAuth) return cachedAuth;
+  cachedAuth = getAuth(getFirebaseApp());
+  return cachedAuth;
+}

--- a/apps/web/src/lib/firebase/index.ts
+++ b/apps/web/src/lib/firebase/index.ts
@@ -1,0 +1,10 @@
+// Single entry point for Firebase consumers. Always import via this file
+// so the lazy-init contract stays consistent across the app.
+export { getFirebaseApp, getFirebaseAuth } from "./config";
+export {
+  ensureRecaptcha,
+  disposeRecaptcha,
+  sendOtp,
+  verifyOtp,
+  resetPhoneAuthState,
+} from "./phone-auth";

--- a/apps/web/src/lib/firebase/phone-auth.ts
+++ b/apps/web/src/lib/firebase/phone-auth.ts
@@ -1,0 +1,145 @@
+// Firebase phone-auth helpers — the two operations the patient login flow
+// needs, plus the invisible reCAPTCHA verifier setup. Wrapping
+// signInWithPhoneNumber + confirmationResult.confirm in our own helpers
+// keeps the UI page small (just state + 2 async calls) and gives us one
+// place to translate Firebase's auth/error-code shape into user-facing copy.
+
+import {
+  RecaptchaVerifier,
+  signInWithPhoneNumber,
+  type ConfirmationResult,
+} from "firebase/auth";
+
+import { getFirebaseAuth } from "./config";
+
+// Phone-auth flows hold a ConfirmationResult between sendOtp() and
+// verifyOtp(); we stash it module-side rather than threading it through
+// the caller because the UI is mid-flow and we don't want a re-render to
+// drop the handle. Cleared on success / abort.
+let pendingConfirmation: ConfirmationResult | null = null;
+
+// Likewise: the RecaptchaVerifier MUST be initialised once and kept alive
+// across the send/verify cycle. Firebase mounts a hidden DOM element under
+// the container element id we pass; tearing it down between sends would
+// trigger a new bot-check every time and break sandbox testing.
+let recaptchaVerifier: RecaptchaVerifier | null = null;
+
+/**
+ * Initialise an invisible reCAPTCHA verifier mounted under the DOM element
+ * with the supplied id. Idempotent — calling twice returns the same
+ * verifier so a React strict-mode double-mount or a re-render doesn't
+ * double-install the widget.
+ *
+ * The container element must exist in the DOM before this runs. Typical
+ * usage: `useEffect(() => ensureRecaptcha("patient-recaptcha"), [])`.
+ */
+export function ensureRecaptcha(containerId: string): RecaptchaVerifier {
+  if (recaptchaVerifier) return recaptchaVerifier;
+  recaptchaVerifier = new RecaptchaVerifier(getFirebaseAuth(), containerId, {
+    size: "invisible",
+  });
+  return recaptchaVerifier;
+}
+
+/**
+ * Drop the cached verifier. Call from the page's unmount cleanup so a
+ * subsequent visit to /patient/login installs a fresh one.
+ */
+export function disposeRecaptcha(): void {
+  if (recaptchaVerifier) {
+    try {
+      recaptchaVerifier.clear();
+    } catch {
+      // clear() throws if the container is already gone — non-fatal.
+    }
+  }
+  recaptchaVerifier = null;
+}
+
+/**
+ * Step 1 of the flow. Sends an OTP SMS to the supplied E.164 phone number
+ * (e.g. "+919876543210"). Throws with a user-facing message on failure.
+ *
+ * Firebase requires the reCAPTCHA verifier to be live before this call —
+ * the caller must have invoked ensureRecaptcha() once on mount.
+ */
+export async function sendOtp(phoneE164: string): Promise<void> {
+  if (!recaptchaVerifier) {
+    throw new Error(
+      "reCAPTCHA verifier is not initialised — call ensureRecaptcha() first.",
+    );
+  }
+  try {
+    pendingConfirmation = await signInWithPhoneNumber(
+      getFirebaseAuth(),
+      phoneE164,
+      recaptchaVerifier,
+    );
+  } catch (err) {
+    throw new Error(humanizeFirebaseError(err, "Could not send OTP."));
+  }
+}
+
+/**
+ * Step 2 of the flow. Confirms the 6-digit code and returns the freshly
+ * minted Firebase ID token. The caller is expected to POST that token to
+ * `/api/v1/patient-auth/firebase-verify` which validates it server-side
+ * and mints the medcore_at / medcore_rt session cookies (BOLA + audit +
+ * tenant scoping all stay in the existing backend's hands).
+ *
+ * Throws with a user-facing message on failure.
+ */
+export async function verifyOtp(otp: string): Promise<string> {
+  if (!pendingConfirmation) {
+    throw new Error("No OTP request is in progress. Please request a new code.");
+  }
+  try {
+    const credential = await pendingConfirmation.confirm(otp);
+    const idToken = await credential.user.getIdToken(/* forceRefresh */ true);
+    // Clear after success so a subsequent flow starts fresh — and so a
+    // mistaken second submit doesn't replay an already-burned code.
+    pendingConfirmation = null;
+    return idToken;
+  } catch (err) {
+    throw new Error(humanizeFirebaseError(err, "Could not verify OTP."));
+  }
+}
+
+/**
+ * Abort the in-flight flow. Useful if the user closes the form before
+ * entering the code so the next visit starts clean.
+ */
+export function resetPhoneAuthState(): void {
+  pendingConfirmation = null;
+}
+
+// ─── Internal: error mapper ─────────────────────────────────────────────
+
+interface FirebaseErrorLike {
+  code?: string;
+  message?: string;
+}
+
+function humanizeFirebaseError(err: unknown, fallback: string): string {
+  const code = (err as FirebaseErrorLike)?.code;
+  switch (code) {
+    case "auth/invalid-phone-number":
+      return "That phone number doesn't look right. Use the international format, e.g. +91 9876543210.";
+    case "auth/missing-phone-number":
+      return "Please enter your phone number.";
+    case "auth/quota-exceeded":
+      return "We've hit our SMS limit for now. Please try again in a few minutes.";
+    case "auth/captcha-check-failed":
+      return "The bot-check failed. Please refresh the page and try again.";
+    case "auth/invalid-verification-code":
+      return "That code didn't match. Please check and try again.";
+    case "auth/code-expired":
+      return "That code expired. Please request a new one.";
+    case "auth/too-many-requests":
+      return "Too many attempts. Please wait a few minutes before trying again.";
+    case "auth/network-request-failed":
+      return "Network error. Check your connection and try again.";
+    default:
+      return (err as FirebaseErrorLike)?.message || fallback;
+  }
+}

--- a/apps/web/src/lib/i18n.ts
+++ b/apps/web/src/lib/i18n.ts
@@ -27,6 +27,8 @@ const en: Dict = {
     "Keep me signed in on this device for 30 days. Leave unchecked on shared computers.",
   "login.newPatient": "New Patient?",
   "login.register": "Register here",
+  "login.patientLogin": "Patient?",
+  "login.patientLoginCta": "Sign in with phone OTP",
   "login.error.generic": "Login failed",
   "login.error.rateLimited":
     "Too many login attempts. Please wait a minute and try again.",
@@ -720,6 +722,8 @@ const hi: Dict = {
     "इस डिवाइस पर मुझे 30 दिनों तक साइन-इन रखें। साझा कंप्यूटर पर इसे अनचेक छोड़ें।",
   "login.newPatient": "नए मरीज़?",
   "login.register": "यहाँ पंजीकरण करें",
+  "login.patientLogin": "मरीज़?",
+  "login.patientLoginCta": "फ़ोन OTP से साइन इन करें",
   "login.error.generic": "लॉगिन विफल",
   "login.error.rateLimited":
     "बहुत अधिक लॉगिन प्रयास। कृपया एक मिनट प्रतीक्षा करें और पुनः प्रयास करें।",

--- a/apps/web/src/lib/store.ts
+++ b/apps/web/src/lib/store.ts
@@ -423,9 +423,22 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       }
       // Issue #477: token sentinel only — the real one is on the cookie.
       set({ user: res.data, token: COOKIE_TOKEN_SENTINEL, isLoading: false });
-    } catch {
-      clearPersistedAuth();
-      set({ user: null, token: null, isLoading: false });
+    } catch (err) {
+      // 2026-05-27: previously this `catch` unconditionally cleared the
+      // auth state, which mis-classified 429 (rate-limited) and 5xx
+      // (server hiccup) as "session dead" and bounced the user to
+      // /login with "session expired". Now we only clear on a 401
+      // (true session expiry); anything else preserves the prior `user`
+      // value so the layout doesn't redirect on a transient blip.
+      const status = (err as { status?: number })?.status;
+      if (status === 401) {
+        clearPersistedAuth();
+        set({ user: null, token: null, isLoading: false });
+      } else {
+        // Settle isLoading so the UI stops showing skeletons, but keep
+        // any cached `user` — a retry will reconcile on the next call.
+        set({ isLoading: false });
+      }
     }
   },
 }));

--- a/packages/shared/src/validation/patient-auth.ts
+++ b/packages/shared/src/validation/patient-auth.ts
@@ -84,3 +84,30 @@ export const verifyPatientOtpSchema = z.object({
 });
 
 export type VerifyPatientOtpInput = z.infer<typeof verifyPatientOtpSchema>;
+
+/**
+ * Firebase Phone Auth exchange schema. The patient frontend completes
+ * Firebase's signInWithPhoneNumber → confirm() handshake, receives an ID
+ * token, and POSTs it here. The route handler verifies the token with the
+ * firebase-admin SDK (signature, audience, issuer, expiry, revocation),
+ * extracts the verified `phone_number` claim, and uses THAT phone to find
+ * the patient User row — never the body. The token itself is the only
+ * thing the client supplies; the phone is read from the verified claim so
+ * a malicious client can't tunnel "I just verified phone X but please log
+ * me in as patient Y".
+ *
+ * Length cap is generous (4096 chars) because Firebase ID tokens are
+ * standard JWTs — ours typically run ~1200-1800 chars. Tighter than no cap
+ * (DoS surface for `verifyIdToken`).
+ */
+export const firebaseVerifyPatientSchema = z.object({
+  idToken: z
+    .string()
+    .trim()
+    .min(1, "ID token is required")
+    .max(4096, "ID token is too long"),
+});
+
+export type FirebaseVerifyPatientInput = z.infer<
+  typeof firebaseVerifyPatientSchema
+>;


### PR DESCRIPTION
…are-flow parity

OTP login (end-to-end, replaces legacy SMS-OTP):
- apps/api/src/services/firebase-admin.ts — lazy Firebase Admin init + verifyPhoneIdToken
- apps/api/src/routes/patient-auth.ts — POST /firebase-verify: verify token, canonicalise phone, lookup PATIENT by phone, mint medcore_at/rt cookies
- apps/api/src/middleware/csrf.ts — bypass CSRF on patient-auth bootstrap paths
- packages/shared/src/validation/patient-auth.ts — firebaseVerifyPatientSchema (idToken max 4096)
- apps/web/src/lib/firebase/{config,phone-auth,index}.ts — web SDK + invisible reCAPTCHA + sendOtp/verifyOtp helpers + humanizeFirebaseError
- apps/web/src/app/patient/login/page.tsx — rewritten to use Firebase phone auth, posts ID token to /firebase-verify
- apps/web/src/app/login/page.tsx — added "Patient? Sign in with phone OTP" link + role-based redirect (PATIENT → /patient/dashboard)
- apps/web/src/lib/i18n.ts — login.patientLogin / login.patientLoginCta keys (EN + HI)
- apps/{api,web}/.env*.example — Firebase env placeholders

Patient routing chrome (Pearl §6.1):
- apps/web/src/app/patient/_components/PatientLayoutShell.tsx — deny-list chrome-swap, /patient/* renders inside staff DashboardLayout
- apps/web/src/app/patient/layout.tsx — server component delegates to shell
- apps/web/src/app/dashboard/layout.tsx — PATIENT sidebar entries route to /patient/*; drop pre-#477 localStorage-token early-out that was bypassing the 5-attempt /auth/me retry loop and bouncing the user to /login on every tab switch
- apps/web/src/app/dashboard/billing/page.tsx — PATIENT-only "Pay Online" column → /patient/bills/[id]/pay
- apps/web/src/app/patient/{dashboard,appointments,records}/page.tsx — IST_OFFSET_MIN=330 + Asia/Kolkata formatters; slotStart parsed as wallclock string instead of UTC Date
- apps/web/src/app/patient/profile/page.tsx — restyled to match /dashboard/settings card UI (all 28 testids preserved)
- apps/web/src/app/patient/appointments/__tests__/page.test.tsx — book route assertion

Share-flow parity with doctor side:
- apps/web/src/app/patient/{dashboard,prescriptions}/page.tsx — Share via WhatsApp now posts to /prescriptions/:id/share { channel: "WHATSAPP" }; server delivers verify link via Meta Cloud API + logs. No client-side wa.me navigation. Toasts API's 409 messages verbatim for unsigned/cancelled/no-phone cases (patient can't sign for doctor, so no SignaturePad branch). Dashboard tile swaps Pay-now for View-detail when bill is settled (defence against stale state).

Session-expiry hardening (surfaced while testing OTP):
- apps/api/src/app.ts — auth namespace rate limit 30 → 300/min. 30/min was too tight for an SPA where every layout mount + cross-tab broadcast listener + patient-page own /auth/me probe fans out; ~10 tab switches hit 30 and got a 429 cascade the dashboard misread as session expiry.
- apps/web/src/lib/store.ts — loadSession() catch now only clears auth on 401 (real session expiry); 429/5xx preserve cached user so transient errors don't bounce to /login.

package-lock.json deliberately NOT committed — apps/{api,web}/package.json carry the new deps (firebase-admin ^13.10.0, firebase ^12.13.0); run `npm i` on first pull to regenerate the lockfile. CI may need to switch `npm ci` → `npm install` for the first build.

<!--
PR template. Fill in each section; delete sections that don't apply.
Keep it short — the PR description should be skimmable.
-->

## Summary

<!-- 1-2 sentences on what this changes and why. -->

## Test plan

<!--
Bulleted checklist of what you verified. Cover the happy path and the
edge case that motivated the change. If a code path can only be
exercised in CI / on the dev server, say so explicitly.
-->

- [ ]
- [ ]

## Risk

<!--
Anything risky a reviewer should look for? Examples:
  - Touches production-critical code (auth, billing, RBAC, migrations)
  - Changes a deploy script or CI workflow
  - Drops or narrows a database column (REQUIRES `[allow-destructive-migration]` in commit message)
  - Modifies a feature flag's default
  - Bumps a dependency major version

If "low risk" — say so. Don't leave this blank.
-->

## Screenshots / output

<!--
Frontend changes: before/after screenshots.
API changes: a curl invocation + the response body.
Backend behavior: a paste of the test output that proves it works.
-->

## Linked issues

<!-- Closes #N for each issue this PR resolves. -->
