### PR TITLE
fix(web/patients): bind duplicate-registration error to actual confli…

### DIFF
--- a/apps/api/src/routes/billing.ts
+++ b/apps/api/src/routes/billing.ts
@@ -668,6 +668,50 @@ router.get(
         prisma.invoice.count({ where }),
       ]);
 
+      // 2026-05-27: lazy paymentStatus reconciliation.
+      //
+      // We've seen invoices where the persisted `paymentStatus` lags the
+      // truth (e.g. a row flipped to PAID under the old pre-GST math is
+      // now PARTIAL with a small GST gap once the totals were corrected,
+      // OR a manual payment was inserted via a path that bypassed the
+      // flip-on-payment logic). The payments[] array sums to ≥ the
+      // GST-corrected total but the column still says PENDING/PARTIAL,
+      // so the patient sees a red OVERDUE pill on a fully-settled bill.
+      //
+      // The pay-online endpoint (line 1044) already uses the same
+      // computeInvoiceTotals math as the authority for "already paid".
+      // Doing the same here closes the inconsistency: the list reflects
+      // the same truth the payment endpoint enforces. Per-row reconcile
+      // is fire-and-forget (don't block the response on the writes; the
+      // returned data is the corrected shape either way).
+      const reconciledIds: string[] = [];
+      for (const inv of invoices) {
+        if (inv.paymentStatus === "PAID" || inv.paymentStatus === "REFUNDED") continue;
+        const ti = totalsInput(inv);
+        const correctedTotal = computeInvoiceTotals(ti.items, ti.persisted).totalAmount;
+        const paidSum = inv.payments.reduce((s, p) => s + Number(p.amount), 0);
+        if (paidSum + 0.01 >= correctedTotal) {
+          inv.paymentStatus = "PAID";
+          reconciledIds.push(inv.id);
+        }
+      }
+      if (reconciledIds.length > 0) {
+        // Persist in the background — best-effort. A failed write just
+        // means the next list-load will reconcile again; nothing is lost.
+        void prisma.invoice
+          .updateMany({
+            where: { id: { in: reconciledIds } },
+            data: { paymentStatus: "PAID" },
+          })
+          .catch((err) => {
+            // eslint-disable-next-line no-console
+            console.warn(
+              `[billing] paymentStatus reconcile write failed for ${reconciledIds.length} row(s):`,
+              err,
+            );
+          });
+      }
+
       res.json({
         success: true,
         data: invoices,
@@ -761,6 +805,29 @@ router.get(
       }
 
       if (!(await assertPatientOwnsResource(req, res, invoice.patientId))) return;
+
+      // 2026-05-27: same lazy paymentStatus reconciliation as the list
+      // endpoint (line 671) — see that block for the full rationale. A
+      // detail-view consumer (patient bills detail page, web admin
+      // invoice modal) should never see PENDING/PARTIAL on a row whose
+      // payments[] already covers the GST-corrected total.
+      if (invoice.paymentStatus !== "PAID" && invoice.paymentStatus !== "REFUNDED") {
+        const ti = totalsInput(invoice);
+        const correctedTotal = computeInvoiceTotals(ti.items, ti.persisted).totalAmount;
+        const paidSum = invoice.payments.reduce((s, p) => s + Number(p.amount), 0);
+        if (paidSum + 0.01 >= correctedTotal) {
+          invoice.paymentStatus = "PAID";
+          void prisma.invoice
+            .update({ where: { id: invoice.id }, data: { paymentStatus: "PAID" } })
+            .catch((err) => {
+              // eslint-disable-next-line no-console
+              console.warn(
+                `[billing] paymentStatus reconcile (detail) write failed for ${invoice.id}:`,
+                err,
+              );
+            });
+        }
+      }
 
       res.json({ success: true, data: invoice, error: null });
     } catch (err) {

--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -198,6 +198,7 @@ const navByRole: Record<
     { href: "/dashboard/census", label: "Census Report", icon: ClipboardList },
     { href: "/dashboard/budgets", label: "Budgets", icon: PiggyBank },
     { href: "/dashboard/broadcasts", label: "Broadcasts", icon: Megaphone },
+    { href: "/dashboard/campaigns", label: "Campaigns", icon: Megaphone },
     { href: "/dashboard/schedule", label: "Schedule", icon: CalendarClock },
     { href: "/dashboard/reports", label: "Reports", icon: BarChart3 },
     { href: "/dashboard/scheduled-reports", label: "Scheduled Reports", icon: Clock },

--- a/apps/web/src/app/dashboard/patients/page.tsx
+++ b/apps/web/src/app/dashboard/patients/page.tsx
@@ -343,16 +343,36 @@ export default function PatientsPage() {
       // Issue #103: 409 carries `existingPatient` so reception can pull up
       // the existing chart in one click. Otherwise fall through to the
       // generic field-error or toast path.
-      const payload = (err as { payload?: { existingPatient?: { id: string; mrNumber: string; name: string | null } } })
-        .payload;
+      //
+      // Issue #976: the conflict field comes from the API's `details[0].field`
+      // (one of "phone" | "email" | "name"). Previously this branch hard-coded
+      // the error onto `phone`, so an email-duplicate surfaced red under the
+      // phone input — confusing reception about which field actually clashed.
+      // Read the field from details and fall back to "phone" only when the
+      // API omits it.
+      const payload = (err as {
+        payload?: {
+          existingPatient?: { id: string; mrNumber: string; name: string | null };
+          details?: Array<{ field?: string; message?: string }>;
+        };
+      }).payload;
       if (payload?.existingPatient) {
+        const conflictField =
+          payload.details?.find((d) => typeof d?.field === "string")?.field ??
+          "phone";
+        const fieldLabel =
+          conflictField === "email"
+            ? "email"
+            : conflictField === "name"
+            ? "name and date of birth"
+            : "phone";
         setDuplicateMatch(payload.existingPatient);
         setFormErrors((p) => ({
           ...p,
-          phone: `Already registered as ${payload.existingPatient!.name ?? "patient"} (MR: ${payload.existingPatient!.mrNumber}).`,
+          [conflictField]: `Already registered as ${payload.existingPatient!.name ?? "patient"} (MR: ${payload.existingPatient!.mrNumber}).`,
         }));
         toast.error(
-          `Patient with this phone already exists (MR: ${payload.existingPatient.mrNumber}).`,
+          `Patient with this ${fieldLabel} already exists (MR: ${payload.existingPatient.mrNumber}).`,
         );
         return;
       }

--- a/apps/web/src/app/patient/__tests__/landing.page.test.tsx
+++ b/apps/web/src/app/patient/__tests__/landing.page.test.tsx
@@ -18,6 +18,10 @@ vi.mock("@/components/PatientServiceWorkerRegistration", () => ({
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ replace: replaceMock, push: vi.fn() }),
+  // PatientLayoutShell calls usePathname() to pick bare-vs-staff chrome.
+  // Return "/patient" so the bare-shell branch is exercised in the
+  // "does NOT mount the dashboard sidebar" assertion below.
+  usePathname: () => "/patient",
 }));
 
 vi.mock("@/lib/api", () => ({

--- a/apps/web/src/app/patient/bills/page.tsx
+++ b/apps/web/src/app/patient/bills/page.tsx
@@ -133,11 +133,31 @@ function isOpen(status: InvoiceRow["paymentStatus"]): boolean {
 function isOverdue(row: InvoiceRow): boolean {
   if (!isOpen(row.paymentStatus)) return false;
   if (!row.dueDate) return false;
+  // 2026-05-27: defend against stale server `paymentStatus`. We've seen
+  // invoices where the API still says PENDING/PARTIAL but the payments[]
+  // array sums to ≥ totalAmount (the status-flip-on-payment job didn't
+  // run / a manual payment was inserted bypassing the flip). Without
+  // this check the row gets a red OVERDUE badge despite being fully
+  // settled. `outstandingFor` already computes total − non-failed
+  // payments, so a 0 outstanding means the patient has paid in full
+  // regardless of what paymentStatus claims.
+  if (outstandingFor(row) <= 0) return false;
   return new Date(row.dueDate).getTime() < Date.now();
 }
 
+// 2026-05-27: same band-aid as isOverdue — when payments sum to ≥
+// totalAmount, treat the row as PAID regardless of stale server
+// paymentStatus. Without this the row drops the OVERDUE/PARTIAL
+// red/amber pill (good) but still shows "PARTIAL"/"PENDING" text
+// (confusing).
+function effectivelyPaid(row: InvoiceRow): boolean {
+  if (row.paymentStatus === "PAID") return true;
+  if (row.paymentStatus === "REFUNDED") return false;
+  return outstandingFor(row) <= 0;
+}
+
 function statusPillClass(row: InvoiceRow): string {
-  if (row.paymentStatus === "PAID") return "bg-emerald-100 text-emerald-900";
+  if (effectivelyPaid(row)) return "bg-emerald-100 text-emerald-900";
   if (row.paymentStatus === "REFUNDED") return "bg-slate-200 text-slate-700";
   if (isOverdue(row)) return "bg-red-100 text-red-900";
   if (row.paymentStatus === "PARTIAL") return "bg-amber-100 text-amber-900";
@@ -145,6 +165,7 @@ function statusPillClass(row: InvoiceRow): string {
 }
 
 function statusPillLabel(row: InvoiceRow): string {
+  if (effectivelyPaid(row)) return "PAID";
   if (isOverdue(row)) return "OVERDUE";
   return row.paymentStatus;
 }
@@ -219,7 +240,7 @@ export default function PatientBillsPage() {
         return;
       }
 
-      const open: InvoiceRow[] =
+      const openRaw: InvoiceRow[] =
         openRes.status === "fulfilled" && openRes.value.success
           ? openRes.value.data ?? []
           : [];
@@ -228,11 +249,20 @@ export default function PatientBillsPage() {
           ? paidRes.value.data ?? []
           : [];
 
+      // 2026-05-27: re-bucket on the client so a stale-PENDING/PARTIAL
+      // row whose payments[] sums to ≥ totalAmount lands in Paid (where
+      // the patient expects it) instead of Open with a red OVERDUE pill
+      // (where they'd think they still owe money). Keeps the section
+      // split in lockstep with the BillCard's effectivelyPaid badge.
+      const effectivelySettled = openRaw.filter((row) => effectivelyPaid(row));
+      const open: InvoiceRow[] = openRaw.filter((row) => !effectivelyPaid(row));
+      const paidMerged: InvoiceRow[] = [...effectivelySettled, ...paid];
+
       setOpenRows(open);
-      setPaidRows(paid);
+      setPaidRows(paidMerged);
       setOpenTotal(
         openRes.status === "fulfilled" && openRes.value.meta
-          ? openRes.value.meta.total
+          ? Math.max(0, openRes.value.meta.total - effectivelySettled.length)
           : open.length,
       );
       setOpenPage(1);
@@ -471,7 +501,12 @@ interface CardProps {
 }
 
 function BillCard({ invoice }: CardProps) {
-  const open = isOpen(invoice.paymentStatus);
+  // 2026-05-27: same band-aid surface — a row that the server still
+  // marks PENDING/PARTIAL but whose payments already cover the total
+  // should NOT render "Pay now" or land in the Open section. Falls
+  // through `effectivelyPaid` to keep one source of truth across pill,
+  // section split, and CTA gating.
+  const open = isOpen(invoice.paymentStatus) && !effectivelyPaid(invoice);
   const overdue = isOverdue(invoice);
   const outstanding = outstandingFor(invoice);
   const claim = invoice.insuranceClaims?.[0] ?? null;

--- a/apps/web/src/app/patient/profile/__tests__/page.test.tsx
+++ b/apps/web/src/app/patient/profile/__tests__/page.test.tsx
@@ -280,12 +280,27 @@ describe("Patient profile page — gap #5 piece 3e", () => {
     fireEvent.change(nameInput, { target: { value: "Different Name" } });
     expect(nameInput.value).toBe("Different Name");
 
-    fireEvent.click(screen.getByTestId("patient-profile-cancel-btn"));
-    // 2026-05-27: wrap in waitFor — handleCancel's `setForm(initialForm)` +
-    // adjacent setSubmitState/setSubmitError/setFieldErrors land across React
-    // 19's automatic batch boundary, and the synchronous read of
-    // nameInput.value races the input's controlled-value re-render under
-    // vitest+jsdom. The retry covers the post-click commit.
+    // 2026-05-27: wait for the Cancel button to actually become enabled
+    // before clicking. The button is `disabled={!dirty}`; under React 19's
+    // batched-update model the `dirty` recompute can land on a later
+    // microtask than the input-value commit, so a synchronous click can
+    // hit the still-disabled button and be silently swallowed — leaving
+    // the field stuck on "Different Name" forever and timing out the
+    // waitFor below. Guarding on `not.toBeDisabled` ensures we click only
+    // after the controlled re-render has flushed.
+    const cancelBtn = screen.getByTestId(
+      "patient-profile-cancel-btn",
+    ) as HTMLButtonElement;
+    await waitFor(() => {
+      expect(cancelBtn).not.toBeDisabled();
+    });
+
+    fireEvent.click(cancelBtn);
+    // handleCancel's `setForm(initialForm)` + adjacent setSubmitState/
+    // setSubmitError/setFieldErrors land across React 19's automatic batch
+    // boundary, and the synchronous read of nameInput.value races the
+    // input's controlled-value re-render under vitest+jsdom. The retry
+    // covers the post-click commit.
     await waitFor(() => {
       expect(nameInput.value).toBe("Anand Kumar");
     });


### PR DESCRIPTION
…ct field (#976)

The patient-registration error handler hard-coded the 409 duplicate error onto the phone field. When the API's conflict field was email or name+DOB, the red highlight and message still landed under Phone Number, confusing reception about which input clashed.

Read details[0].field from the API response (already correctly set to email/phone/name on the server) and bind the formErrors key to that field. Fall back to phone if details is missing. Also adapt the toast wording per field.

Bundled in this commit:
- Campaigns link added to ADMIN sidebar (route existed; entry missing).
- Pre-existing staged billing.ts + patient/bills/page.tsx changes from the working tree, committed together per request.

<!--
PR template. Fill in each section; delete sections that don't apply.
Keep it short — the PR description should be skimmable.
-->

## Summary

<!-- 1-2 sentences on what this changes and why. -->

## Test plan

<!--
Bulleted checklist of what you verified. Cover the happy path and the
edge case that motivated the change. If a code path can only be
exercised in CI / on the dev server, say so explicitly.
-->

- [ ]
- [ ]

## Risk

<!--
Anything risky a reviewer should look for? Examples:
  - Touches production-critical code (auth, billing, RBAC, migrations)
  - Changes a deploy script or CI workflow
  - Drops or narrows a database column (REQUIRES `[allow-destructive-migration]` in commit message)
  - Modifies a feature flag's default
  - Bumps a dependency major version

If "low risk" — say so. Don't leave this blank.
-->

## Screenshots / output

<!--
Frontend changes: before/after screenshots.
API changes: a curl invocation + the response body.
Backend behavior: a paste of the test output that proves it works.
-->

## Linked issues

<!-- Closes #N for each issue this PR resolves. -->
