### PR TITLE
fix(web/campaigns,shared): 3 campaign UX defects (#984, #985, #987)

### DIFF
--- a/apps/web/src/app/dashboard/campaigns/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/campaigns/[id]/page.tsx
@@ -114,6 +114,109 @@ function fmtMinutes(m: number | null): string {
   return `${hh}:${mm}`;
 }
 
+// Issue #984: render the audience-rule DSL as plain English instead of
+// the raw JSON triples (e.g. `{ op: "gte", field: "age", value: 40 }`).
+// Mirrors the v1 supported predicates in
+// apps/api/src/services/audience-compiler.ts and the UI-side mapping in
+// apps/web/src/app/dashboard/campaigns/new/page.tsx::buildRulesPayload.
+// Falls back to the JSON pretty-print for any unknown shape so the
+// operator still sees SOMETHING for newer DSL fields not yet covered
+// here (defensive — keeps the panel useful as the DSL grows).
+interface AudienceFilter {
+  field?: string;
+  op?: string;
+  value?: unknown;
+}
+interface AudienceRulesV1 {
+  filters?: AudienceFilter[];
+  matchMode?: "ALL" | "ANY";
+}
+
+const FIELD_LABELS: Record<string, string> = {
+  gender: "Gender",
+  age: "Age",
+  lastVisitDays: "Days since last visit",
+  abhaLinked: "ABHA linked",
+  city: "City",
+  branchId: "Branch",
+  optedOut: "Opted out",
+};
+
+function formatFilterValue(field: string, op: string, value: unknown): string {
+  if (field === "abhaLinked" || field === "optedOut") {
+    return value === true ? "Yes" : value === false ? "No" : String(value);
+  }
+  if (field === "gender" && typeof value === "string") {
+    // Title-case MALE -> Male, FEMALE -> Female, OTHER -> Other.
+    return value.charAt(0).toUpperCase() + value.slice(1).toLowerCase();
+  }
+  if (op === "in" && Array.isArray(value)) {
+    return value.map(String).join(", ");
+  }
+  return String(value);
+}
+
+function describeFilter(f: AudienceFilter): string | null {
+  if (!f || typeof f !== "object") return null;
+  const field = typeof f.field === "string" ? f.field : null;
+  const op = typeof f.op === "string" ? f.op : null;
+  if (!field || !op) return null;
+  const label = FIELD_LABELS[field] ?? field;
+  const v = formatFilterValue(field, op, f.value);
+  switch (op) {
+    case "eq":
+      return `${label} is ${v}`;
+    case "neq":
+      return `${label} is not ${v}`;
+    case "gte":
+      return `${label} ≥ ${v}`;
+    case "lte":
+      return `${label} ≤ ${v}`;
+    case "gt":
+      return `${label} > ${v}`;
+    case "lt":
+      return `${label} < ${v}`;
+    case "in":
+      return `${label} in: ${v}`;
+    default:
+      return `${label} ${op} ${v}`;
+  }
+}
+
+// True when the rules object looks like the v1 DSL shape we know how to
+// pretty-print. Anything else falls back to JSON so we don't silently
+// hide unknown fields.
+function isV1Rules(r: unknown): r is AudienceRulesV1 {
+  if (!r || typeof r !== "object") return false;
+  const x = r as { filters?: unknown };
+  return Array.isArray(x.filters);
+}
+
+// Issue #987: render a sample-resolved preview of the campaign body so
+// operators can verify how their {{first_name}}/{{last_visit}} tokens
+// will look to a real recipient. Mirrors the dispatcher's substitution
+// surface from the new-campaign page (PERSONALISATION_TOKENS). The
+// sample values are illustrative only — the actual dispatcher fills
+// them per audience row at send time.
+const PREVIEW_SAMPLE: Record<string, string> = {
+  first_name: "Anita",
+  last_visit: "12 Mar",
+};
+
+function renderPreview(template: string | null): string {
+  if (!template) return "";
+  // {{ token }} with optional whitespace; non-greedy match on token name
+  // restricted to lowercase letters + underscore (same shape as the
+  // dispatcher's allowlist).
+  return template.replace(/\{\{\s*([a-z_]+)\s*\}\}/g, (raw, key: string) => {
+    if (key in PREVIEW_SAMPLE) return PREVIEW_SAMPLE[key];
+    // Unknown token — keep the original {{...}} so it's visibly broken
+    // in the preview instead of silently disappearing. Helps the
+    // operator catch typos.
+    return raw;
+  });
+}
+
 export default function CampaignDetailPage() {
   const router = useRouter();
   const params = useParams<{ id: string }>();
@@ -396,18 +499,67 @@ export default function CampaignDetailPage() {
             </div>
           </dl>
 
+          {/* Issue #987: render a sample-resolved Preview of subject +
+              body alongside the raw template. Operators can verify the
+              rendered output before scheduling, and still see the
+              underlying {{tokens}} via the "Raw template" details. */}
           {campaign.subject && (
             <div className="mt-4 border-t pt-3 text-sm dark:border-gray-700">
-              <div className="text-xs uppercase text-gray-500">Subject</div>
-              <p className="mt-1">{campaign.subject}</p>
+              <div className="text-xs uppercase text-gray-500">
+                Subject preview
+                <span className="ml-1 text-[10px] font-normal normal-case text-gray-400">
+                  (sample: first_name="{PREVIEW_SAMPLE.first_name}",
+                  last_visit="{PREVIEW_SAMPLE.last_visit}")
+                </span>
+              </div>
+              <p
+                data-testid="campaign-subject-preview"
+                className="mt-1"
+              >
+                {renderPreview(campaign.subject)}
+              </p>
+              {campaign.subject !== renderPreview(campaign.subject) && (
+                <details className="mt-1">
+                  <summary className="cursor-pointer text-[11px] text-gray-500 hover:text-gray-700 dark:hover:text-gray-300">
+                    Show raw template
+                  </summary>
+                  <pre
+                    data-testid="campaign-subject-raw"
+                    className="mt-1 whitespace-pre-wrap rounded bg-gray-50 p-2 font-mono text-xs dark:bg-gray-800"
+                  >
+                    {campaign.subject}
+                  </pre>
+                </details>
+              )}
             </div>
           )}
           {campaign.body && (
             <div className="mt-3 text-sm">
-              <div className="text-xs uppercase text-gray-500">Body</div>
-              <pre className="mt-1 whitespace-pre-wrap rounded bg-gray-50 p-2 font-mono text-xs dark:bg-gray-800">
-                {campaign.body}
+              <div className="text-xs uppercase text-gray-500">
+                Body preview
+                <span className="ml-1 text-[10px] font-normal normal-case text-gray-400">
+                  (sample values shown; dispatcher fills per recipient)
+                </span>
+              </div>
+              <pre
+                data-testid="campaign-body-preview"
+                className="mt-1 whitespace-pre-wrap rounded bg-gray-50 p-2 text-xs dark:bg-gray-800"
+              >
+                {renderPreview(campaign.body)}
               </pre>
+              {campaign.body !== renderPreview(campaign.body) && (
+                <details className="mt-1">
+                  <summary className="cursor-pointer text-[11px] text-gray-500 hover:text-gray-700 dark:hover:text-gray-300">
+                    Show raw template
+                  </summary>
+                  <pre
+                    data-testid="campaign-body-raw"
+                    className="mt-1 whitespace-pre-wrap rounded bg-gray-50 p-2 font-mono text-xs dark:bg-gray-800"
+                  >
+                    {campaign.body}
+                  </pre>
+                </details>
+              )}
             </div>
           )}
         </section>
@@ -443,16 +595,64 @@ export default function CampaignDetailPage() {
                   </span>
                 )}
               </p>
+              {/* Issue #984: human-readable rule summary instead of raw
+                  JSON. Falls back to a collapsible <details> with the
+                  JSON pretty-print so power users / debugging can still
+                  see the underlying DSL on demand. */}
               <div className="mt-3">
-                <div className="text-xs uppercase text-gray-500">
-                  Rules (DSL)
-                </div>
-                <pre
-                  data-testid="audience-rules-json"
-                  className="mt-1 max-h-64 overflow-auto rounded bg-gray-50 p-2 font-mono text-xs dark:bg-gray-800"
-                >
-                  {JSON.stringify(campaign.audience.rules, null, 2)}
-                </pre>
+                <div className="text-xs uppercase text-gray-500">Targeting</div>
+                {(() => {
+                  const rules = campaign.audience.rules;
+                  if (isV1Rules(rules) && (rules.filters?.length ?? 0) > 0) {
+                    const matchMode = rules.matchMode ?? "ALL";
+                    return (
+                      <div data-testid="audience-rules-human" className="mt-1">
+                        <p className="text-xs text-gray-600 dark:text-gray-400">
+                          Patients matching{" "}
+                          <strong>
+                            {matchMode === "ANY" ? "ANY" : "ALL"}
+                          </strong>{" "}
+                          of:
+                        </p>
+                        <ul className="mt-1 list-disc space-y-0.5 pl-5 text-sm text-gray-800 dark:text-gray-200">
+                          {(rules.filters ?? []).map((f, i) => {
+                            const desc = describeFilter(f);
+                            if (!desc) return null;
+                            return (
+                              <li
+                                key={i}
+                                data-testid="audience-rules-row"
+                              >
+                                {desc}
+                              </li>
+                            );
+                          })}
+                        </ul>
+                      </div>
+                    );
+                  }
+                  // Empty filters or unknown shape — keep the JSON view
+                  // as the only signal (better than blank), but flag it.
+                  return (
+                    <p
+                      data-testid="audience-rules-empty"
+                      className="mt-1 text-xs italic text-gray-500"
+                    >
+                      No filters — all patients in tenant.
+                    </p>
+                  );
+                })()}
+                <details className="mt-2">
+                  <summary className="cursor-pointer text-[11px] text-gray-500 hover:text-gray-700 dark:hover:text-gray-300">
+                    Show raw DSL
+                  </summary>
+                  <pre
+                    data-testid="audience-rules-json"
+                    className="mt-1 max-h-64 overflow-auto rounded bg-gray-50 p-2 font-mono text-xs dark:bg-gray-800"
+                  >
+                    {JSON.stringify(campaign.audience.rules, null, 2)}
+                  </pre>
+                </details>
               </div>
             </>
           )}

--- a/apps/web/src/app/dashboard/campaigns/new/page.tsx
+++ b/apps/web/src/app/dashboard/campaigns/new/page.tsx
@@ -26,6 +26,7 @@ import { useRouter } from "next/navigation";
 import { api } from "@/lib/api";
 import { useAuthStore } from "@/lib/store";
 import { toast } from "@/lib/toast";
+import { CAMPAIGN_SEND_WINDOW_POLICY } from "@medcore/shared";
 import {
   Megaphone,
   Save,
@@ -112,6 +113,30 @@ function timeToMinutes(t: string): number | null {
   return hh * 60 + mm;
 }
 
+// Issue #985 — quiet-hour policy: campaigns must dispatch within
+// 09:00..21:00 IST. Mirror the server schema's
+// CAMPAIGN_SEND_WINDOW_POLICY so the client surfaces the error before
+// the round-trip. Returns null when valid; otherwise the message to
+// show under the offending input.
+function checkSendWindowPolicy(
+  start: string,
+  end: string,
+): string | null {
+  const s = timeToMinutes(start);
+  const e = timeToMinutes(end);
+  if (s == null || e == null) return null;
+  if (s >= e) {
+    return "Start must be before end.";
+  }
+  if (s < CAMPAIGN_SEND_WINDOW_POLICY.minStart) {
+    return CAMPAIGN_SEND_WINDOW_POLICY.label;
+  }
+  if (e > CAMPAIGN_SEND_WINDOW_POLICY.maxEnd) {
+    return CAMPAIGN_SEND_WINDOW_POLICY.label;
+  }
+  return null;
+}
+
 export default function NewCampaignPage() {
   const router = useRouter();
   const { user, isLoading } = useAuthStore();
@@ -184,6 +209,13 @@ export default function NewCampaignPage() {
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
+  // Issue #985 — derived send-window-policy error, recomputed on every
+  // input change. Pushes the inline message and gates `canSubmit`.
+  const sendWindowError = useMemo(
+    () => checkSendWindowPolicy(sendWindowStart, sendWindowEnd),
+    [sendWindowStart, sendWindowEnd],
+  );
+
   function toggleChannel(c: CampaignChannel) {
     setChannels((prev) =>
       prev.includes(c) ? prev.filter((x) => x !== c) : [...prev, c],
@@ -255,7 +287,11 @@ export default function NewCampaignPage() {
     name.trim().length >= 2 &&
     channels.length > 0 &&
     !!audienceId &&
-    !submitting;
+    !submitting &&
+    // Issue #985 — block submit when the send window violates the
+    // quiet-hour policy. The server schema also rejects this, but
+    // catching it client-side prevents a confusing round-trip + toast.
+    !sendWindowError;
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -459,6 +495,15 @@ export default function NewCampaignPage() {
             </div>
           </div>
 
+          {/* Issue #985: enforce 09:00..21:00 quiet-hour policy on
+              both inputs + show an inline error when violated. The
+              type=time pickers respect the min/max hint on most
+              browsers, but we ALSO compute checkSendWindowPolicy()
+              and block submit because (a) Safari ignores the time-
+              input clamp on mobile and (b) typed-in values can
+              bypass the spinner. The server-side schema refinement
+              in packages/shared/src/validation/campaign.ts is the
+              defence-in-depth check. */}
           <div className="mt-4 grid gap-3 md:grid-cols-2">
             <div>
               <label
@@ -470,9 +515,16 @@ export default function NewCampaignPage() {
               <input
                 id="campaign-window-start"
                 type="time"
+                min="09:00"
+                max="21:00"
                 value={sendWindowStart}
                 onChange={(e) => setSendWindowStart(e.target.value)}
-                className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-800"
+                aria-invalid={!!sendWindowError}
+                className={`mt-1 w-full rounded-lg border px-3 py-2 text-sm dark:bg-gray-800 ${
+                  sendWindowError
+                    ? "border-red-400 dark:border-red-500"
+                    : "border-gray-300 dark:border-gray-700"
+                }`}
               />
             </div>
             <div>
@@ -485,11 +537,30 @@ export default function NewCampaignPage() {
               <input
                 id="campaign-window-end"
                 type="time"
+                min="09:00"
+                max="21:00"
                 value={sendWindowEnd}
                 onChange={(e) => setSendWindowEnd(e.target.value)}
-                className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-800"
+                aria-invalid={!!sendWindowError}
+                className={`mt-1 w-full rounded-lg border px-3 py-2 text-sm dark:bg-gray-800 ${
+                  sendWindowError
+                    ? "border-red-400 dark:border-red-500"
+                    : "border-gray-300 dark:border-gray-700"
+                }`}
               />
             </div>
+            {sendWindowError && (
+              <p
+                role="alert"
+                data-testid="campaign-window-error"
+                className="text-xs text-red-600 dark:text-red-400 md:col-span-2"
+              >
+                {sendWindowError}
+              </p>
+            )}
+            <p className="text-[11px] text-gray-500 md:col-span-2">
+              Send window must be within 09:00–21:00 IST (quiet hours after 21:00).
+            </p>
           </div>
         </section>
 

--- a/packages/shared/src/validation/__tests__/campaign.test.ts
+++ b/packages/shared/src/validation/__tests__/campaign.test.ts
@@ -315,33 +315,64 @@ describe("createCampaignSchema", () => {
 
   // minuteOfDay bounds (0..1439)
   it("rejects sendWindowStart below 0", () => {
+    // Both negative AND below the 540 policy floor — schema rejects.
     expect(
       createCampaignSchema.safeParse({
         ...minimal,
         sendWindowStart: -1,
-        sendWindowEnd: 100,
+        sendWindowEnd: 1140,
       }).success,
     ).toBe(false);
   });
 
   it("rejects sendWindowEnd above 1439", () => {
+    // Above the minuteOfDay max AND above the 1260 policy ceiling.
     expect(
       createCampaignSchema.safeParse({
         ...minimal,
-        sendWindowStart: 0,
+        sendWindowStart: 540,
         sendWindowEnd: 1440,
       }).success,
     ).toBe(false);
   });
 
-  it("accepts sendWindow at the 0..1439 boundary", () => {
+  // Issue #985 — quiet-hour policy locks the accepted window to
+  // 09:00..21:00 (540..1260). Prior tests treated 0..1439 as accepted;
+  // those values would now violate the policy refinement.
+  it("accepts sendWindow at the 540..1260 (09:00..21:00) policy boundary", () => {
     expect(
       createCampaignSchema.safeParse({
         ...minimal,
-        sendWindowStart: 0,
-        sendWindowEnd: 1439,
+        sendWindowStart: 540,
+        sendWindowEnd: 1260,
       }).success,
     ).toBe(true);
+  });
+
+  it("rejects sendWindowEnd at 22:00 (#985 — out-of-policy)", () => {
+    const r = createCampaignSchema.safeParse({
+      ...minimal,
+      sendWindowStart: 540, // 09:00
+      sendWindowEnd: 1320, // 22:00
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(
+        r.error.issues.some((i) =>
+          /09:00.*21:00|Send window must be within/.test(i.message),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it("rejects sendWindowStart at 08:00 (#985 — before policy floor)", () => {
+    expect(
+      createCampaignSchema.safeParse({
+        ...minimal,
+        sendWindowStart: 480, // 08:00
+        sendWindowEnd: 1260,
+      }).success,
+    ).toBe(false);
   });
 
   it("rejects non-integer minuteOfDay", () => {

--- a/packages/shared/src/validation/campaign.ts
+++ b/packages/shared/src/validation/campaign.ts
@@ -36,6 +36,19 @@ const abVariantSchema = z.object({
 // Minute-of-day window: 0..1439 inclusive. Used for IST quiet-hour clamp.
 const minuteOfDay = z.number().int().min(0).max(1439);
 
+// Issue #985 — quiet-hour policy. Campaigns must dispatch within
+// 09:00..21:00 IST so we don't push WhatsApp/SMS to patients in the
+// middle of the night. Exported so the web form can share the same
+// bounds + the same human-readable copy.
+export const CAMPAIGN_SEND_WINDOW_POLICY = {
+  /** Earliest minute-of-day a campaign send window may START at. 09:00 = 540. */
+  minStart: 9 * 60,
+  /** Latest minute-of-day a campaign send window may END at. 21:00 = 1260. */
+  maxEnd: 21 * 60,
+  /** Human-readable copy for client + API error messages. Keep in sync. */
+  label: "Send window must be within 09:00–21:00 (quiet hours after 21:00)",
+} as const;
+
 // Operator-side state-machine. The dispatcher (piece 2) is responsible
 // for SCHEDULED → RUNNING; operators can DRAFT → SCHEDULED, RUNNING ↔
 // PAUSED, and any → CANCELLED. Direct jumps to COMPLETED are rejected by
@@ -91,6 +104,24 @@ export const createCampaignSchema = z
     },
     {
       message: "sendWindowStart must be strictly less than sendWindowEnd",
+      path: ["sendWindowEnd"],
+    },
+  )
+  // Issue #985 — quiet-hour policy: the send window must lie within
+  // 09:00..21:00 IST. A previous client-side bug let users save a
+  // 22:00 end-time silently; this refinement is the defence-in-depth
+  // server-side guard so the same payload is rejected from any
+  // client (web, mobile, CLI, automation).
+  .refine(
+    (v) => {
+      if (v.sendWindowStart == null || v.sendWindowEnd == null) return true;
+      return (
+        v.sendWindowStart >= CAMPAIGN_SEND_WINDOW_POLICY.minStart &&
+        v.sendWindowEnd <= CAMPAIGN_SEND_WINDOW_POLICY.maxEnd
+      );
+    },
+    {
+      message: CAMPAIGN_SEND_WINDOW_POLICY.label,
       path: ["sendWindowEnd"],
     },
   );
@@ -152,6 +183,22 @@ export const updateCampaignSchema = z
     },
     {
       message: "sendWindowStart must be strictly less than sendWindowEnd",
+      path: ["sendWindowEnd"],
+    },
+  )
+  // Issue #985 — same quiet-hour policy as createCampaignSchema. Also
+  // applies on PATCH so an operator can't widen the window outside
+  // 09:00..21:00 after the campaign exists.
+  .refine(
+    (v) => {
+      if (v.sendWindowStart == null || v.sendWindowEnd == null) return true;
+      return (
+        v.sendWindowStart >= CAMPAIGN_SEND_WINDOW_POLICY.minStart &&
+        v.sendWindowEnd <= CAMPAIGN_SEND_WINDOW_POLICY.maxEnd
+      );
+    },
+    {
+      message: CAMPAIGN_SEND_WINDOW_POLICY.label,
       path: ["sendWindowEnd"],
     },
   );


### PR DESCRIPTION
#984 — Raw DSL/JSON exposed in audience section
  The audience panel on /dashboard/campaigns/[id] rendered the rules
  triples as JSON.stringify pretty-print (e.g. { op: 'gte', field:
  'age', value: 40 }). Non-technical staff couldn't read it, and the
  raw schema details didn't need to be in the operator surface.
  Translate filter triples to human sentences via a describeFilter()
  helper covering the v1 DSL (gender/age/lastVisitDays/abhaLinked/
  city/branch/optedOut). Keep the JSON inside a collapsible <details>
  so power users / debugging can still see the underlying payload.
  Unknown rule shapes fall back to the JSON view (defensive).

#985 — Quiet-hour clamp not enforced on send window
  The new-campaign form documented '09:00-21:00 (quiet hours after
  21:00)' but the time picker accepted 22:00 and the API persisted it.
  Defence in depth:
   - packages/shared/src/validation/campaign.ts: new CAMPAIGN_SEND_WINDOW_POLICY constant (minStart=540, maxEnd=1260)
     + a third refine() on both createCampaignSchema and updateCampaignSchema rejecting out-of-policy values from any client (web, mobile, CLI).
   - apps/web/src/app/dashboard/campaigns/new/page.tsx: import the constant, add min='09:00' / max='21:00' to the time inputs, compute a derived sendWindowError, surface it inline with aria-invalid + red border, and gate canSubmit on it.
   - Schema tests updated: the boundary-tests at lines 317-345 of campaign.test.ts that asserted 0..1439 as the acceptance range now correctly assert 540..1260 (with a 22:00 rejection case pinned to issue #985).

#987 — No personalisation token preview
  The body field on the detail page rendered the raw template
  ('Hi {{first_name}}…'), giving operators no way to verify how the
  message will look to a recipient. Add a sample-resolved preview
  using illustrative values (first_name=Anita, last_visit=12 Mar),
  with a Show raw template <details> below for the canonical form.
  Subject gets the same treatment. Unknown tokens are intentionally
  left as {{...}} in the preview so typos stay visible.

<!--
PR template. Fill in each section; delete sections that don't apply.
Keep it short — the PR description should be skimmable.
-->

## Summary

<!-- 1-2 sentences on what this changes and why. -->

## Test plan

<!--
Bulleted checklist of what you verified. Cover the happy path and the
edge case that motivated the change. If a code path can only be
exercised in CI / on the dev server, say so explicitly.
-->

- [ ]
- [ ]

## Risk

<!--
Anything risky a reviewer should look for? Examples:
  - Touches production-critical code (auth, billing, RBAC, migrations)
  - Changes a deploy script or CI workflow
  - Drops or narrows a database column (REQUIRES `[allow-destructive-migration]` in commit message)
  - Modifies a feature flag's default
  - Bumps a dependency major version

If "low risk" — say so. Don't leave this blank.
-->

## Screenshots / output

<!--
Frontend changes: before/after screenshots.
API changes: a curl invocation + the response body.
Backend behavior: a paste of the test output that proves it works.
-->

## Linked issues

<!-- Closes #N for each issue this PR resolves. -->
