### PR TITLE
fix(api/auth): accept medcore_at cookie in resolveRegistrationRole (#…

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -318,9 +318,24 @@ function resolveRegistrationRole(req: Request, requestedRole: unknown): Role {
   // We do an in-line, best-effort token decode here (the route is otherwise
   // unauthenticated, so we can't bolt on `authenticate` middleware without
   // breaking the public flow). Any decode/role failure → coerce to PATIENT.
+  //
+  // Issue #991: read BOTH the httpOnly `medcore_at` cookie (the post-#477
+  // primary storage for the access token) AND the legacy `Authorization:
+  // Bearer ...` header. Previously this only looked at the header; the
+  // web Create-Staff form lets the browser send the cookie automatically
+  // (api.ts uses credentials:"include") and never adds the header — so
+  // every staff-creation POST got demoted to PATIENT, which then tripped
+  // the PATIENT-only address + emergencyContact gate below and returned
+  // 400 with messages for fields the staff form deliberately doesn't
+  // collect.
+  const cookieToken = (req as Request & { cookies?: Record<string, string> })
+    .cookies?.medcore_at;
   const header = req.headers.authorization;
-  if (!header?.startsWith("Bearer ")) return PUBLIC_DEFAULT;
-  const token = header.split(" ")[1];
+  const headerToken = header?.startsWith("Bearer ")
+    ? header.split(" ")[1]
+    : undefined;
+  const token = cookieToken || headerToken;
+  if (!token) return PUBLIC_DEFAULT;
   try {
     // Issue #482: algorithm-agnostic — services/jwt.ts.
     const decoded = verifyAccessToken<{ role?: string }>(token);

--- a/apps/api/src/test/integration/auth.test.ts
+++ b/apps/api/src/test/integration/auth.test.ts
@@ -530,6 +530,51 @@ describeIfDB("Auth API (integration)", () => {
     expect(errStr).toMatch(/password|12 characters/);
   });
 
+  // ─── Issue #991 (admin staff-create via cookie-only auth) ──────────────
+  //
+  // Since #477 the web client stores the access token in an httpOnly
+  // `medcore_at` cookie and never adds an Authorization: Bearer header.
+  // resolveRegistrationRole previously only consulted the header, so
+  // every staff-create POST from the web UI was demoted to PATIENT,
+  // which then tripped the PATIENT-only address + emergencyContact gate
+  // and returned 400 with messages for fields the staff form does not
+  // collect. Pin the cookie-path behaviour here so the regression is
+  // caught immediately.
+  it("#991 admin staff-create on /register accepts cookie-only auth (no Bearer header)", async () => {
+    const adminLogin = await request(app)
+      .post("/api/v1/auth/login")
+      .send({ email: "admin@test.local", password: "MedCoreT3st-2026" });
+    expect(adminLogin.status).toBe(200);
+    // Extract the medcore_at Set-Cookie header — supertest returns it as
+    // either a string or array depending on Node version.
+    const rawCookies = adminLogin.headers["set-cookie"];
+    const cookies = Array.isArray(rawCookies)
+      ? rawCookies
+      : rawCookies
+        ? [rawCookies]
+        : [];
+    const at = cookies.find((c: string) => c.startsWith("medcore_at="));
+    expect(at).toBeDefined();
+    const cookieHeader = at!.split(";")[0];
+
+    // Mirror the web form's payload exactly — only the 5 fields the
+    // Create-Staff form exposes. NO address, NO emergencyContact.
+    // NO Authorization header.
+    const res = await request(app)
+      .post("/api/v1/auth/register")
+      .set("Cookie", cookieHeader)
+      .send({
+        name: "Cookie Auth Doctor",
+        email: "cookie.doctor@test.local",
+        phone: "9123461001",
+        password: "MedCoreT3st-2026",
+        role: "DOCTOR",
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body?.data?.user?.role).toBe("DOCTOR");
+  });
+
   it("#668 admin staff-create on /register rejects denylisted 'password123'", async () => {
     const adminLogin = await request(app)
       .post("/api/v1/auth/login")


### PR DESCRIPTION
…991)

The 'Create Staff Account' form on /dashboard/users posted to /auth/register with role=DOCTOR (or NURSE / etc.) but the server returned 400 with 'Address is required (min 5 characters)' and 'Emergency contact is required' — fields the form deliberately doesn't collect for staff accounts.

Root cause: resolveRegistrationRole inspected only the Authorization: Bearer header to confirm the caller is an admin. Since #477 the web client stores the access token in an httpOnly medcore_at cookie and never adds the Bearer header on /register — so the resolver silently demoted the requested DOCTOR role back to PATIENT, which then tripped the PATIENT-only address + emergencyContact gate at the route handler.

Fix: read BOTH the medcore_at cookie AND the legacy Authorization header (mirroring the authenticate middleware). The same admin session that lets the staff form load now also identifies the caller for the staff-create POST, the requested role is honoured, and the patient-only address/emergencyContact gate is skipped.

Test: new #991 integration test in auth.test.ts uses ONLY the cookie (no Bearer header) to mirror the web client exactly, sends the 5-field staff payload, and asserts 201 + role=DOCTOR. Pins the regression so a future refactor that drops the cookie path fails immediately.

<!--
PR template. Fill in each section; delete sections that don't apply.
Keep it short — the PR description should be skimmable.
-->

## Summary

<!-- 1-2 sentences on what this changes and why. -->

## Test plan

<!--
Bulleted checklist of what you verified. Cover the happy path and the
edge case that motivated the change. If a code path can only be
exercised in CI / on the dev server, say so explicitly.
-->

- [ ]
- [ ]

## Risk

<!--
Anything risky a reviewer should look for? Examples:
  - Touches production-critical code (auth, billing, RBAC, migrations)
  - Changes a deploy script or CI workflow
  - Drops or narrows a database column (REQUIRES `[allow-destructive-migration]` in commit message)
  - Modifies a feature flag's default
  - Bumps a dependency major version

If "low risk" — say so. Don't leave this blank.
-->

## Screenshots / output

<!--
Frontend changes: before/after screenshots.
API changes: a curl invocation + the response body.
Backend behavior: a paste of the test output that proves it works.
-->

## Linked issues

<!-- Closes #N for each issue this PR resolves. -->
