### PR TITLE
fix(leads): exact-match dup detection + inline form validation (#1001…

### DIFF
--- a/apps/api/src/routes/leads.ts
+++ b/apps/api/src/routes/leads.ts
@@ -59,6 +59,45 @@ router.post(
         }
       }
 
+      // Issue #1001 — exact-match dup detection within tenant. Block
+      // when name + phone + email all match an existing lead exactly
+      // (case-insensitive on name + email, exact on phone). Per
+      // product decision the rule is intentionally strict so a typo
+      // in any of the three fields lets the new lead through — false
+      // negatives are acceptable; the goal is to stop the "same row
+      // posted 20 times" reporter case.
+      //
+      // Only runs when BOTH phone and email are present in the
+      // payload — if either is blank the operator hasn't supplied
+      // enough to claim "identical lead" and we let the row through
+      // (matches reception's intent when they record a half-known
+      // walk-in).
+      const nameIn = typeof req.body.name === "string" ? req.body.name.trim() : "";
+      const phoneIn =
+        typeof req.body.phone === "string" ? req.body.phone.trim() : "";
+      const emailIn =
+        typeof req.body.email === "string" ? req.body.email.trim() : "";
+      if (nameIn && phoneIn && emailIn) {
+        const dup = await prisma.lead.findFirst({
+          where: {
+            tenantId: req.tenantId,
+            phone: phoneIn,
+            name: { equals: nameIn, mode: "insensitive" },
+            email: { equals: emailIn, mode: "insensitive" },
+          },
+          select: { id: true },
+        });
+        if (dup) {
+          res.status(409).json({
+            success: false,
+            data: null,
+            error:
+              "A lead with this name, phone and email already exists. Open the existing lead or change one of the fields to proceed.",
+          });
+          return;
+        }
+      }
+
       const lead = await prisma.lead.create({
         data: {
           name: req.body.name,

--- a/apps/api/src/test/integration/leads.test.ts
+++ b/apps/api/src/test/integration/leads.test.ts
@@ -162,6 +162,75 @@ describeIfDB("Lead pipeline API (Pearl §3.3 — integration)", () => {
     expect(dup.status).toBe(409);
   });
 
+  // Issue #1001 — exact-match (name + phone + email all match) dup
+  // detection. Reporter saw the SAME lead row created repeatedly. Per
+  // product decision the rule is strict: only block when all three
+  // user-supplied fields are populated AND match an existing lead
+  // exactly (case-insensitive name + email, exact phone). A typo in
+  // any single field lets the new row through (false negatives are
+  // acceptable; the goal is stopping the obvious "double-click /
+  // duplicate-import" path).
+  it("#1001 POST /leads with same name + phone + email → 409 on second attempt", async () => {
+    const first = await request(app)
+      .post("/api/v1/leads")
+      .set("Authorization", `Bearer ${receptionToken}`)
+      .send({
+        name: "Dup Detect One",
+        phone: "+919876541001",
+        email: "dup1001@example.com",
+        source: "PHONE",
+      });
+    expect(first.status).toBe(201);
+
+    // Identical triple → blocked.
+    const second = await request(app)
+      .post("/api/v1/leads")
+      .set("Authorization", `Bearer ${receptionToken}`)
+      .send({
+        name: "Dup Detect One",
+        phone: "+919876541001",
+        email: "dup1001@example.com",
+        source: "PHONE",
+      });
+    expect(second.status).toBe(409);
+    expect(second.body.error).toMatch(/already exists/i);
+
+    // Case-insensitive on name + email; different casing still blocks.
+    const thirdCase = await request(app)
+      .post("/api/v1/leads")
+      .set("Authorization", `Bearer ${receptionToken}`)
+      .send({
+        name: "dup detect ONE",
+        phone: "+919876541001",
+        email: "DUP1001@example.com",
+        source: "PHONE",
+      });
+    expect(thirdCase.status).toBe(409);
+
+    // Different phone → allowed (typo escapes the gate, by design).
+    const fourthPhoneTypo = await request(app)
+      .post("/api/v1/leads")
+      .set("Authorization", `Bearer ${receptionToken}`)
+      .send({
+        name: "Dup Detect One",
+        phone: "+919876541002", // last digit changed
+        email: "dup1001@example.com",
+        source: "PHONE",
+      });
+    expect(fourthPhoneTypo.status).toBe(201);
+
+    // Missing email → falls outside the gate (only 2 of 3 fields).
+    const fifthMissingEmail = await request(app)
+      .post("/api/v1/leads")
+      .set("Authorization", `Bearer ${receptionToken}`)
+      .send({
+        name: "Dup Detect One",
+        phone: "+919876541001",
+        source: "PHONE",
+      });
+    expect(fifthMissingEmail.status).toBe(201);
+  });
+
   // Smoke: DOCTOR + ADMIN can list (just to ensure RBAC matrix is right).
   it("DOCTOR + ADMIN can list leads", async () => {
     const a = await request(app).get("/api/v1/leads").set("Authorization", `Bearer ${doctorToken}`);

--- a/apps/web/src/app/dashboard/leads/page.tsx
+++ b/apps/web/src/app/dashboard/leads/page.tsx
@@ -13,6 +13,7 @@ import Link from "next/link";
 import { api } from "@/lib/api";
 import { toast } from "@/lib/toast";
 import { useAuthStore } from "@/lib/store";
+import { extractFieldErrors, type FieldErrorMap } from "@/lib/field-errors";
 import {
   LEAD_STATUS_VALUES,
   LEAD_SOURCE_VALUES,
@@ -20,6 +21,38 @@ import {
   type LeadSource,
 } from "@medcore/shared";
 import { Plus, Search, UserCheck } from "lucide-react";
+
+// Issue #1002 — mirror the server schema (packages/shared/src/validation/leads.ts
+// createLeadSchema) on the client so users get immediate feedback before the
+// round-trip. Phone is optional, but if provided must match 10..15 digits
+// (with optional +). Email is optional, but if provided must be RFC-ish.
+const LEAD_PHONE_REGEX = /^\+?\d{10,15}$/;
+const LEAD_EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function validateLeadForm(input: {
+  name: string;
+  phone: string;
+  email: string;
+}): FieldErrorMap {
+  const errs: FieldErrorMap = {};
+  const name = input.name.trim();
+  if (!name) {
+    errs.name = "Name is required";
+  } else if (name.length < 2) {
+    errs.name = "Name must be at least 2 characters";
+  } else if (name.length > 120) {
+    errs.name = "Name must be at most 120 characters";
+  }
+  const phone = input.phone.trim();
+  if (phone && !LEAD_PHONE_REGEX.test(phone)) {
+    errs.phone = "Phone must be 10–15 digits (optional + prefix)";
+  }
+  const email = input.email.trim();
+  if (email && !LEAD_EMAIL_REGEX.test(email)) {
+    errs.email = "Enter a valid email address";
+  }
+  return errs;
+}
 
 interface Lead {
   id: string;
@@ -59,6 +92,19 @@ export default function LeadsPage() {
     source: "PHONE" as LeadSource,
     notes: "",
   });
+  // Issue #1002 — inline field errors + form-level error (server messages).
+  const [formErrors, setFormErrors] = useState<FieldErrorMap>({});
+  const [formError, setFormError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  // Live-validate so the Create button enable state updates as the user
+  // types. The validator is cheap (3 regex tests) so running it every
+  // render is fine.
+  const liveErrors = useMemo(
+    () => validateLeadForm(newLead),
+    [newLead.name, newLead.phone, newLead.email], // eslint-disable-line react-hooks/exhaustive-deps
+  );
+  const canSubmit = Object.keys(liveErrors).length === 0 && !submitting;
 
   const isStaff = !!user?.role && user.role !== "PATIENT";
 
@@ -94,10 +140,19 @@ export default function LeadsPage() {
   }, [leads]);
 
   const handleCreate = async () => {
-    if (!newLead.name.trim()) {
-      toast.error("Name is required");
+    // Issue #1002 — re-run validation on submit so the error map
+    // reflects the final state (the live one is keyed to render, but
+    // the user can click Create before React commits the latest
+    // setState in the same tick under some browsers).
+    const errs = validateLeadForm(newLead);
+    if (Object.keys(errs).length > 0) {
+      setFormErrors(errs);
+      setFormError(null);
       return;
     }
+    setFormErrors({});
+    setFormError(null);
+    setSubmitting(true);
     try {
       await api.post("/leads", {
         name: newLead.name.trim(),
@@ -111,8 +166,42 @@ export default function LeadsPage() {
       setNewLead({ name: "", phone: "", email: "", source: "PHONE", notes: "" });
       void load();
     } catch (err: any) {
-      toast.error(err?.message ?? "Failed to create lead");
+      // Issue #1001 — server returns 409 with `error` when an exact-match
+      // dup is detected (same tenant + name + phone + email). Surface
+      // that as a form-level banner instead of dropping it into a
+      // generic toast so the operator sees the actionable copy.
+      // Issue #1002 — also surface Zod field errors (phone regex, email
+      // format) inline if the schema-level rejection slips past the
+      // client-side check (different regex, edge case).
+      const status =
+        err && typeof err === "object" && "status" in err
+          ? (err as { status?: number }).status
+          : undefined;
+      const fields = extractFieldErrors(err);
+      if (fields) {
+        setFormErrors(fields);
+        setFormError(null);
+      } else if (status === 409) {
+        const payload = (err as { payload?: { error?: string } }).payload;
+        setFormError(
+          payload?.error ?? "A lead with these details already exists.",
+        );
+      } else {
+        setFormError(err?.message ?? "Failed to create lead");
+      }
+    } finally {
+      setSubmitting(false);
     }
+  };
+
+  // Helper — clear the inline error for a single field when the user
+  // edits that field. Keeps `formErrors` in sync with the value.
+  const clearFieldError = (field: keyof FieldErrorMap) => {
+    setFormErrors((prev) => {
+      if (!prev[String(field)]) return prev;
+      const { [String(field)]: _drop, ...rest } = prev;
+      return rest;
+    });
   };
 
   const handleStatusChange = async (lead: Lead, status: LeadStatus) => {
@@ -284,6 +373,18 @@ export default function LeadsPage() {
             <h2 className="mb-3 flex items-center gap-2 text-lg font-semibold">
               <UserCheck size={18} /> New lead
             </h2>
+            {/* Issue #1001 — form-level banner for 409 dup detection and
+                any other non-field server error. Field errors render
+                inline next to each input. */}
+            {formError && (
+              <div
+                role="alert"
+                data-testid="lead-create-error"
+                className="mb-3 rounded-lg border border-red-300 bg-red-50 p-3 text-xs text-red-700 dark:border-red-700 dark:bg-red-900/30 dark:text-red-200"
+              >
+                {formError}
+              </div>
+            )}
             <div className="space-y-3">
               <div>
                 <label className="text-xs text-gray-500 dark:text-gray-400">
@@ -291,33 +392,82 @@ export default function LeadsPage() {
                 </label>
                 <input
                   value={newLead.name}
-                  onChange={(e) =>
-                    setNewLead((p) => ({ ...p, name: e.target.value }))
-                  }
-                  className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-900"
+                  onChange={(e) => {
+                    setNewLead((p) => ({ ...p, name: e.target.value }));
+                    clearFieldError("name");
+                    setFormError(null);
+                  }}
+                  className={`mt-1 w-full rounded border px-3 py-2 text-sm dark:bg-gray-900 ${
+                    formErrors.name
+                      ? "border-red-500 dark:border-red-500"
+                      : "border-gray-300 dark:border-gray-600"
+                  }`}
                   data-testid="lead-create-name"
+                  aria-invalid={formErrors.name ? true : undefined}
                 />
+                {formErrors.name && (
+                  <p
+                    className="mt-1 text-xs text-red-600 dark:text-red-400"
+                    data-testid="lead-create-name-error"
+                  >
+                    {formErrors.name}
+                  </p>
+                )}
               </div>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                 <div>
                   <label className="text-xs text-gray-500 dark:text-gray-400">Phone</label>
                   <input
                     value={newLead.phone}
-                    onChange={(e) =>
-                      setNewLead((p) => ({ ...p, phone: e.target.value }))
-                    }
-                    className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-900"
+                    onChange={(e) => {
+                      setNewLead((p) => ({ ...p, phone: e.target.value }));
+                      clearFieldError("phone");
+                      setFormError(null);
+                    }}
+                    className={`mt-1 w-full rounded border px-3 py-2 text-sm dark:bg-gray-900 ${
+                      formErrors.phone
+                        ? "border-red-500 dark:border-red-500"
+                        : "border-gray-300 dark:border-gray-600"
+                    }`}
+                    data-testid="lead-create-phone"
+                    aria-invalid={formErrors.phone ? true : undefined}
+                    placeholder="10–15 digits"
                   />
+                  {formErrors.phone && (
+                    <p
+                      className="mt-1 text-xs text-red-600 dark:text-red-400"
+                      data-testid="lead-create-phone-error"
+                    >
+                      {formErrors.phone}
+                    </p>
+                  )}
                 </div>
                 <div>
                   <label className="text-xs text-gray-500 dark:text-gray-400">Email</label>
                   <input
+                    type="email"
                     value={newLead.email}
-                    onChange={(e) =>
-                      setNewLead((p) => ({ ...p, email: e.target.value }))
-                    }
-                    className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-900"
+                    onChange={(e) => {
+                      setNewLead((p) => ({ ...p, email: e.target.value }));
+                      clearFieldError("email");
+                      setFormError(null);
+                    }}
+                    className={`mt-1 w-full rounded border px-3 py-2 text-sm dark:bg-gray-900 ${
+                      formErrors.email
+                        ? "border-red-500 dark:border-red-500"
+                        : "border-gray-300 dark:border-gray-600"
+                    }`}
+                    data-testid="lead-create-email"
+                    aria-invalid={formErrors.email ? true : undefined}
                   />
+                  {formErrors.email && (
+                    <p
+                      className="mt-1 text-xs text-red-600 dark:text-red-400"
+                      data-testid="lead-create-email-error"
+                    >
+                      {formErrors.email}
+                    </p>
+                  )}
                 </div>
               </div>
               <div>
@@ -350,17 +500,22 @@ export default function LeadsPage() {
             </div>
             <div className="mt-4 flex justify-end gap-2">
               <button
-                onClick={() => setCreateOpen(false)}
+                onClick={() => {
+                  setCreateOpen(false);
+                  setFormErrors({});
+                  setFormError(null);
+                }}
                 className="rounded border border-gray-300 px-3 py-1.5 text-sm dark:border-gray-600"
               >
                 Cancel
               </button>
               <button
                 onClick={handleCreate}
-                className="rounded bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700"
+                disabled={!canSubmit}
+                className="rounded bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
                 data-testid="lead-create-submit"
               >
-                Create
+                {submitting ? "Creating…" : "Create"}
               </button>
             </div>
           </div>


### PR DESCRIPTION
…, #1002)

#1001 — Duplicate leads with identical name/phone/email
  POST /leads previously had no idempotency for direct creates
  (only MarketingEnquiry-promotion had a @unique back-ref guard).
  A double-click or repeated import created N identical rows; the
  reporter saw 'Hirosi Kimiko / +919652770456 / artist400@...'
  appear repeatedly.

  Server gate added inside the route handler at apps/api/src/routes/
  leads.ts: when ALL THREE user-supplied fields (name + phone +
  email) are present in the payload, the route does a
  prisma.lead.findFirst on (tenantId, phone exact, name + email
  case-insensitive) and returns 409 + an actionable error message
  when a match is found. Per product decision the rule is
  intentionally strict — a typo in any single field lets the new
  row through (false negatives are acceptable; goal is killing
  the obvious double-click path).

  New regression test in apps/api/src/test/integration/leads.test.ts
  pins five scenarios: exact match blocks, case-different match
  still blocks, phone typo passes, email-missing passes, first
  insert succeeds.

#1002 — No inline validation on New Lead form
  The modal previously only checked 'name not empty' and dropped
  every other error into a generic toast. Phone '78' and Email
  'test' shipped to the server, came back 400, and the user got
  no field-level feedback.

  Changes to apps/web/src/app/dashboard/leads/page.tsx:
  - validateLeadForm() mirrors createLeadSchema (10-15 digit phone regex with optional +; RFC-ish email; name 2..120 chars).
  - liveErrors recomputed on every render; Create button is disabled while any field is invalid (useMemo-gated canSubmit).
  - formErrors (visible on submit + after server response) renders inline red border + message under each offending input.
  - extractFieldErrors() consumes Zod details[] from a 400 so server-side rejections (regex edge cases the client missed) surface inline too.
  - 409 from #1001 lands in a form-level red banner above the inputs with the server's actionable copy.
  - Field-edit clears its own inline error + the form-level banner so the user sees feedback evolve as they fix things.
  - Submitting state disables the button + shows 'Creating...'.

<!--
PR template. Fill in each section; delete sections that don't apply.
Keep it short — the PR description should be skimmable.
-->

## Summary

<!-- 1-2 sentences on what this changes and why. -->

## Test plan

<!--
Bulleted checklist of what you verified. Cover the happy path and the
edge case that motivated the change. If a code path can only be
exercised in CI / on the dev server, say so explicitly.
-->

- [ ]
- [ ]

## Risk

<!--
Anything risky a reviewer should look for? Examples:
  - Touches production-critical code (auth, billing, RBAC, migrations)
  - Changes a deploy script or CI workflow
  - Drops or narrows a database column (REQUIRES `[allow-destructive-migration]` in commit message)
  - Modifies a feature flag's default
  - Bumps a dependency major version

If "low risk" — say so. Don't leave this blank.
-->

## Screenshots / output

<!--
Frontend changes: before/after screenshots.
API changes: a curl invocation + the response body.
Backend behavior: a paste of the test output that proves it works.
-->

## Linked issues

<!-- Closes #N for each issue this PR resolves. -->
