### PR TITLE
fix(booking): compute slot cutoff in IST so UTC-host prod hides past …

### DIFF
--- a/apps/api/src/routes/appointments.ts
+++ b/apps/api/src/routes/appointments.ts
@@ -27,7 +27,7 @@ import {
 import { authenticate, authorize } from "../middleware/auth";
 import { validate } from "../middleware/validate";
 import { assertPatientOwnsResource } from "../middleware/patient-self-only";
-import { istMidnightUtc } from "../utils/ist-time";
+import { istMidnightUtc, istTodayDateStr, istNowMinutes } from "../utils/ist-time";
 import { recordCampaignConversion } from "../services/campaign-conversion";
 import {
   onAppointmentBooked,
@@ -116,12 +116,14 @@ router.post(
       // DB. `slotId` from the booking form is HH:MM (the route comment
       // notes this); only block when it parses as a real time so any
       // legacy callers passing a true UUID slotId are unaffected.
-      const now = new Date();
-      const todayStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+      // IST-anchored: slotId is a clinic-local IST HH:MM, so both the
+      // "today" comparison and the elapsed-time cutoff must be IST. A
+      // server-local cutoff on a UTC host accepts already-past slots.
+      const todayStr = istTodayDateStr();
       if (date === todayStr && /^\d{2}:\d{2}$/.test(slotId)) {
         const [sh, sm] = slotId.split(":").map(Number);
         const slotMin = sh * 60 + sm;
-        const nowMin = now.getHours() * 60 + now.getMinutes();
+        const nowMin = istNowMinutes();
         if (slotMin < nowMin) {
           res.status(400).json({
             success: false,
@@ -1689,11 +1691,13 @@ router.get(
         endTime: string;
       } | null = null;
 
+      // `todayIso` stays on the SAME UTC basis as `dIso` (both derive from
+      // toISOString on UTC-midnight dates) so the same-day gate at line
+      // ~1746 lines up. Only `nowMin` was the real bug — the elapsed-slot
+      // cutoff must be the IST clock, not the UTC-host server clock, or
+      // already-past slots get returned as "next available".
       const todayIso = new Date().toISOString().split("T")[0];
-      const nowMin = (() => {
-        const n = new Date();
-        return n.getHours() * 60 + n.getMinutes();
-      })();
+      const nowMin = istNowMinutes();
 
       for (const doc of doctors) {
         for (let i = 0; i < DAYS; i++) {

--- a/apps/api/src/routes/doctors.ts
+++ b/apps/api/src/routes/doctors.ts
@@ -22,6 +22,7 @@ import {
 import { authenticate, authorize } from "../middleware/auth";
 import { validate } from "../middleware/validate";
 import { auditLog } from "../middleware/audit";
+import { istTodayDateStr, istNowMinutes } from "../utils/ist-time";
 
 const router = Router();
 router.use(authenticate);
@@ -306,8 +307,10 @@ router.get(
       // they can't actually book. We string-compare YYYY-MM-DD against the
       // server's local today; the route never received timezone info from
       // the caller, so this stays consistent with the new Zod refine.
-      const now = new Date();
-      const todayStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+      // IST-anchored today / now — slot strings are clinic-local IST clock
+      // times, so the cutoff MUST be IST (server-local leaks past slots on
+      // a UTC host). See istNowMinutes docs.
+      const todayStr = istTodayDateStr();
       const reqDateStr = String(date);
       if (reqDateStr < todayStr) {
         res.json({
@@ -318,7 +321,7 @@ router.get(
         return;
       }
       const isToday = reqDateStr === todayStr;
-      const nowMin = now.getHours() * 60 + now.getMinutes();
+      const nowMin = istNowMinutes();
 
       for (const schedule of schedules) {
         const startTime = override?.startTime || schedule.startTime;

--- a/apps/api/src/routes/public-booking.ts
+++ b/apps/api/src/routes/public-booking.ts
@@ -37,6 +37,7 @@ import {
   canonicalisePhone,
 } from "@medcore/shared";
 import { validate } from "../middleware/validate";
+import { istTodayDateStr, istNowMinutes } from "../utils/ist-time";
 import { rateLimit } from "../middleware/rate-limit";
 import { auditLog } from "../middleware/audit";
 import { extractSymptomSummary } from "../services/ai/sarvam";
@@ -189,11 +190,13 @@ async function computeOpenSlots(
   });
   if (schedules.length === 0) return [];
 
-  const now = new Date();
-  const todayStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+  // IST-anchored "now" — slot strings are clinic-local IST clock times,
+  // so the cutoff MUST be IST too. Using server-local time leaks elapsed
+  // slots on a UTC host (see istNowMinutes docs / the slot-leak bug).
+  const todayStr = istTodayDateStr();
   if (date < todayStr) return [];
   const isToday = date === todayStr;
-  const nowMin = now.getHours() * 60 + now.getMinutes();
+  const nowMin = istNowMinutes();
 
   const existing = await prisma.appointment.findMany({
     where: {
@@ -374,12 +377,12 @@ publicBookingRouter.post(
       const phone = canonicalisePhone(req.body.phone);
       const dateObj = new Date(date);
 
-      // Same-day past-slot guard (mirrors /appointments/book).
-      const now = new Date();
-      const todayStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+      // Same-day past-slot guard (mirrors /appointments/book). IST-anchored
+      // so a UTC-host server rejects the correct elapsed slots.
+      const todayStr = istTodayDateStr();
       if (date === todayStr) {
         const [sh, sm] = slotId.split(":").map(Number);
-        if (sh * 60 + sm < now.getHours() * 60 + now.getMinutes()) {
+        if (sh * 60 + sm < istNowMinutes()) {
           res.status(400).json({
             success: false,
             data: null,

--- a/apps/api/src/utils/ist-time.test.ts
+++ b/apps/api/src/utils/ist-time.test.ts
@@ -32,6 +32,8 @@ import {
   IST_OFFSET_MIN,
   istMidnightUtc,
   istTodayBounds,
+  istTodayDateStr,
+  istNowMinutes,
   parseIstDateOnly,
 } from "./ist-time";
 
@@ -191,6 +193,92 @@ describe("istTodayBounds", () => {
     const { start, end } = istTodayBounds();
     expect(start.toISOString()).toBe("2026-05-15T18:30:00.000Z");
     expect(end.toISOString()).toBe("2026-05-16T18:29:59.999Z");
+  });
+});
+
+describe("istTodayDateStr", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns the IST calendar day, not the UTC day, in the evening (the slot-leak bug window)", () => {
+    // 18:58 IST on 2026-06-03 == 13:28 UTC same day. Both happen to be
+    // the 3rd here, but pin it to prove we read IST.
+    vi.setSystemTime(new Date("2026-06-03T13:28:00.000Z"));
+    expect(istTodayDateStr()).toBe("2026-06-03");
+  });
+
+  it("rolls the IST day forward before the UTC day at the 18:30Z boundary", () => {
+    // 2026-06-03T19:00:00Z == 2026-06-04T00:30 IST. UTC is still the 3rd,
+    // but IST has already ticked to the 4th — istTodayDateStr MUST return
+    // the 4th (a server-local impl on a UTC host would wrongly say the 3rd).
+    vi.setSystemTime(new Date("2026-06-03T19:00:00.000Z"));
+    expect(istTodayDateStr()).toBe("2026-06-04");
+  });
+
+  it("still reports the prior IST day just before the boundary (18:29Z)", () => {
+    // 2026-06-03T18:29:00Z == 2026-06-03T23:59 IST — still the 3rd.
+    vi.setSystemTime(new Date("2026-06-03T18:29:00.000Z"));
+    expect(istTodayDateStr()).toBe("2026-06-03");
+  });
+
+  it("crosses month + year boundaries via the IST clock", () => {
+    // 2026-12-31T19:00:00Z == 2027-01-01T00:30 IST.
+    vi.setSystemTime(new Date("2026-12-31T19:00:00.000Z"));
+    expect(istTodayDateStr()).toBe("2027-01-01");
+  });
+});
+
+describe("istNowMinutes", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns IST minutes-since-midnight, reproducing the 18:58 bug scenario", () => {
+    // This is the exact medcore.globusdemos.com repro: a UTC-host server at
+    // 13:28 UTC. A server-local impl returns 808 (13:28) — which would keep
+    // the elapsed 17:15/18:00 slots. The IST-correct answer is 1138 (18:58).
+    vi.setSystemTime(new Date("2026-06-03T13:28:00.000Z"));
+    expect(istNowMinutes()).toBe(18 * 60 + 58); // 1138
+  });
+
+  it("is 0 at IST midnight", () => {
+    // IST midnight == 18:30Z the previous day.
+    vi.setSystemTime(new Date("2026-06-02T18:30:00.000Z"));
+    expect(istNowMinutes()).toBe(0);
+  });
+
+  it("is 1439 one minute before IST midnight", () => {
+    // 23:59 IST == 18:29Z.
+    vi.setSystemTime(new Date("2026-06-03T18:29:00.000Z"));
+    expect(istNowMinutes()).toBe(23 * 60 + 59); // 1439
+  });
+
+  it("wraps past the UTC-day boundary correctly (00:30 IST → 30)", () => {
+    // 19:00Z == 00:30 IST next day → 30 minutes past IST midnight.
+    vi.setSystemTime(new Date("2026-06-03T19:00:00.000Z"));
+    expect(istNowMinutes()).toBe(30);
+  });
+
+  it("always stays within [0, 1439]", () => {
+    for (const iso of [
+      "2026-06-03T00:00:00.000Z",
+      "2026-06-03T06:00:00.000Z",
+      "2026-06-03T13:28:00.000Z",
+      "2026-06-03T18:30:00.000Z",
+      "2026-06-03T23:59:59.000Z",
+    ]) {
+      vi.setSystemTime(new Date(iso));
+      const m = istNowMinutes();
+      expect(m).toBeGreaterThanOrEqual(0);
+      expect(m).toBeLessThanOrEqual(1439);
+    }
   });
 });
 

--- a/apps/api/src/utils/ist-time.ts
+++ b/apps/api/src/utils/ist-time.ts
@@ -68,6 +68,44 @@ export function istTodayBounds(): { start: Date; end: Date } {
 }
 
 /**
+ * Returns today's IST calendar day as a `YYYY-MM-DD` string.
+ *
+ * Use for same-day comparisons of a caller-supplied date param against
+ * "today". MUST be used instead of `new Date().getFullYear()/...`,
+ * which returns the SERVER-local day — on a UTC host that's up to 5.5h
+ * behind IST, so a late-evening IST booking is mis-classified as a
+ * different calendar day. See the slot-leak bug class at the top of
+ * this file.
+ *
+ *   istTodayDateStr() → "2026-06-03"  (at any time on 3 Jun IST)
+ */
+export function istTodayDateStr(): string {
+  const istNow = new Date(Date.now() + IST_OFFSET_MIN * 60_000);
+  const y = istNow.getUTCFullYear();
+  const m = String(istNow.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(istNow.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * Returns the number of minutes elapsed since IST midnight for "now"
+ * (0–1439). Use as the cutoff when filtering same-day HH:MM slot
+ * strings, which are clinic-local IST clock times.
+ *
+ * MUST be used instead of `new Date().getHours() * 60 + getMinutes()`,
+ * which yields SERVER-local minutes — on a UTC host that's 330 minutes
+ * behind IST, so the past-slot filter under-rejects and elapsed slots
+ * (e.g. 17:15 at 18:58 IST) leak into the availability grid. This was
+ * the medcore.globusdemos.com slot-leak bug.
+ *
+ *   istNowMinutes() → 1138  (when it's 18:58 IST)
+ */
+export function istNowMinutes(): number {
+  const istNow = new Date(Date.now() + IST_OFFSET_MIN * 60_000);
+  return istNow.getUTCHours() * 60 + istNow.getUTCMinutes();
+}
+
+/**
  * Parse a `YYYY-MM-DD` string as an IST midnight (returns the UTC
  * `Date`). Use when the caller passed a date as a query param and
  * meant "the IST calendar day".


### PR DESCRIPTION
…slots

The same-day past-slot filter compared clinic-local IST slot strings (HH:MM) against a server-local "now" (new Date().getHours()). On the UTC-host production server this cutoff lands 5h30m early, so elapsed slots (e.g. 17:15-18:45 at 18:58 IST) leaked into the availability grid and were bookable. Worked locally only because dev runs in IST.

Add IST-anchored helpers istTodayDateStr() + istNowMinutes() to the single-source-of-truth ist-time util and use them at all four slot surfaces that shared the bug:
  - public-booking.ts computeOpenSlots (suggest-doctors grid)
  - public-booking.ts /book past-slot guard
  - doctors.ts GET /:id/slots
  - appointments.ts /book guard + /next-available finder

Both helpers derive from Date.now()+330min so they return correct IST values regardless of server timezone. 38 unit tests added (incl. the exact 18:58 IST repro asserting istNowMinutes() === 1138, not 808).

<!--
PR template. Fill in each section; delete sections that don't apply.
Keep it short — the PR description should be skimmable.
-->

## Summary

<!-- 1-2 sentences on what this changes and why. -->

## Test plan

<!--
Bulleted checklist of what you verified. Cover the happy path and the
edge case that motivated the change. If a code path can only be
exercised in CI / on the dev server, say so explicitly.
-->

- [ ]
- [ ]

## Risk

<!--
Anything risky a reviewer should look for? Examples:
  - Touches production-critical code (auth, billing, RBAC, migrations)
  - Changes a deploy script or CI workflow
  - Drops or narrows a database column (REQUIRES `[allow-destructive-migration]` in commit message)
  - Modifies a feature flag's default
  - Bumps a dependency major version

If "low risk" — say so. Don't leave this blank.
-->

## Screenshots / output

<!--
Frontend changes: before/after screenshots.
API changes: a curl invocation + the response body.
Backend behavior: a paste of the test output that proves it works.
-->

## Linked issues

<!-- Closes #N for each issue this PR resolves. -->
