### PR TITLE
feat(booking): hide doctor slots on confirmed leave + patient slot-pi…

### DIFF
--- a/apps/api/src/routes/appointments.ts
+++ b/apps/api/src/routes/appointments.ts
@@ -28,6 +28,7 @@ import { authenticate, authorize } from "../middleware/auth";
 import { validate } from "../middleware/validate";
 import { assertPatientOwnsResource } from "../middleware/patient-self-only";
 import { istMidnightUtc, istTodayDateStr, istNowMinutes } from "../utils/ist-time";
+import { isDoctorOnConfirmedLeave } from "../utils/doctor-leave";
 import { recordCampaignConversion } from "../services/campaign-conversion";
 import {
   onAppointmentBooked,
@@ -132,6 +133,17 @@ router.post(
           });
           return;
         }
+      }
+
+      // Confirmed (APPROVED) doctor leave blocks booking on that date —
+      // mirrors the slot grid, which hides all slots for a leave day.
+      if (await isDoctorOnConfirmedLeave(doctorId, dateObj)) {
+        res.status(409).json({
+          success: false,
+          data: null,
+          error: "Doctor is on leave on the selected date",
+        });
+        return;
       }
 
       // ── No-show policy enforcement ──
@@ -1018,6 +1030,18 @@ router.patch(
         return;
       }
 
+      // Server-side guard mirroring the hidden slot grid: a confirmed
+      // (APPROVED) doctor leave on the target date blocks the reschedule
+      // even if the client posts a slotStart directly.
+      if (await isDoctorOnConfirmedLeave(existing.doctorId, dateObj)) {
+        res.status(409).json({
+          success: false,
+          data: null,
+          error: "Doctor is on leave on the selected date",
+        });
+        return;
+      }
+
       const tokenNumber =
         existing.date.toISOString().split("T")[0] === date
           ? existing.tokenNumber
@@ -1711,6 +1735,10 @@ router.get(
             where: { doctorId_date: { doctorId: doc.id, date: d } },
           });
           if (override?.isBlocked) continue;
+
+          // Skip days the doctor is on confirmed (APPROVED) leave — never
+          // suggest a "next available" slot the doctor can't honour.
+          if (await isDoctorOnConfirmedLeave(doc.id, d)) continue;
 
           const booked = await prisma.appointment.findMany({
             where: {

--- a/apps/api/src/routes/doctors.ts
+++ b/apps/api/src/routes/doctors.ts
@@ -23,6 +23,7 @@ import { authenticate, authorize } from "../middleware/auth";
 import { validate } from "../middleware/validate";
 import { auditLog } from "../middleware/audit";
 import { istTodayDateStr, istNowMinutes } from "../utils/ist-time";
+import { isDoctorOnConfirmedLeave } from "../utils/doctor-leave";
 
 const router = Router();
 router.use(authenticate);
@@ -263,6 +264,22 @@ router.get(
         res.json({
           success: true,
           data: { date, slots: [], blocked: true, reason: override.reason },
+          error: null,
+        });
+        return;
+      }
+
+      // Confirmed (APPROVED) doctor leave hides ALL slots for the day —
+      // the patient must not be offered a time the doctor can't honour.
+      if (await isDoctorOnConfirmedLeave(req.params.id, dateObj)) {
+        res.json({
+          success: true,
+          data: {
+            date,
+            slots: [],
+            blocked: true,
+            reason: "Doctor is on leave on this date",
+          },
           error: null,
         });
         return;

--- a/apps/api/src/routes/leads.ts
+++ b/apps/api/src/routes/leads.ts
@@ -32,8 +32,18 @@ import bcrypt from "bcryptjs";
 const router = Router();
 router.use(authenticate);
 
-// All lead surfaces are staff-only (PATIENT role excluded).
+// Lead WRITE surfaces (create / note / status) are open to all
+// clinical+front-desk staff so a DOCTOR or NURSE can spin up a lead
+// from a patient profile. PATIENT is excluded everywhere.
 const LEAD_ROLES = [Role.ADMIN, Role.RECEPTION, Role.DOCTOR, Role.NURSE] as const;
+
+// Lead READ surfaces (list / detail / by-patient) are narrower: only
+// ADMIN + RECEPTION own the CRM pipeline and have the Leads nav entry.
+// DOCTOR/NURSE can create a lead but have no business browsing the
+// pipeline, so reads are gated tighter than writes. This is the real
+// security boundary behind the client-side route gate in
+// apps/web/src/app/dashboard/leads/*.
+const LEAD_READ_ROLES = [Role.ADMIN, Role.RECEPTION] as const;
 
 // ─── POST /leads — create
 router.post(
@@ -129,7 +139,7 @@ router.post(
 );
 
 // ─── GET /leads — list with filters
-router.get("/", authorize(...LEAD_ROLES), async (req: Request, res: Response, next: NextFunction) => {
+router.get("/", authorize(...LEAD_READ_ROLES), async (req: Request, res: Response, next: NextFunction) => {
   try {
     const status = typeof req.query.status === "string" ? req.query.status : undefined;
     const source = typeof req.query.source === "string" ? req.query.source : undefined;
@@ -184,6 +194,10 @@ router.get("/", authorize(...LEAD_ROLES), async (req: Request, res: Response, ne
 // IMPORTANT: registered BEFORE /:id so Express's static-before-dynamic
 // matching doesn't swallow "by-patient" as a lead id (would 404 with the
 // wrong error shape). See CLAUDE.md §14 (post-fix verification grep).
+// NOTE: stays on the broader LEAD_ROLES (not LEAD_READ_ROLES) — this is
+// a per-patient lookup powering the CRM History panel on the patient
+// profile, which DOCTOR + NURSE see. It's a single-patient read, not
+// pipeline browsing, so it isn't restricted to ADMIN/RECEPTION.
 router.get(
   "/by-patient/:patientId",
   authorize(...LEAD_ROLES),
@@ -219,7 +233,7 @@ router.get(
 // ─── GET /leads/:id — detail
 router.get(
   "/:id",
-  authorize(...LEAD_ROLES),
+  authorize(...LEAD_READ_ROLES),
   async (req: Request, res: Response, next: NextFunction) => {
     try {
       const lead = await prisma.lead.findUnique({

--- a/apps/api/src/routes/public-booking.ts
+++ b/apps/api/src/routes/public-booking.ts
@@ -38,6 +38,7 @@ import {
 } from "@medcore/shared";
 import { validate } from "../middleware/validate";
 import { istTodayDateStr, istNowMinutes } from "../utils/ist-time";
+import { isDoctorOnConfirmedLeave } from "../utils/doctor-leave";
 import { rateLimit } from "../middleware/rate-limit";
 import { auditLog } from "../middleware/audit";
 import { extractSymptomSummary } from "../services/ai/sarvam";
@@ -184,6 +185,9 @@ async function computeOpenSlots(
     where: { doctorId_date: { doctorId, date: dateObj } },
   });
   if (override?.isBlocked) return [];
+
+  // Confirmed (APPROVED) doctor leave → no slots for the day.
+  if (await isDoctorOnConfirmedLeave(doctorId, dateObj)) return [];
 
   const schedules = await prisma.doctorSchedule.findMany({
     where: { doctorId, dayOfWeek },
@@ -404,6 +408,17 @@ publicBookingRouter.post(
       });
       if (!doctor) {
         res.status(404).json({ success: false, data: null, error: "Doctor not found" });
+        return;
+      }
+
+      // Confirmed (APPROVED) doctor leave blocks public booking on that
+      // date — mirrors the slot grid, which returns no slots for leave days.
+      if (await isDoctorOnConfirmedLeave(doctorId, dateObj)) {
+        res.status(409).json({
+          success: false,
+          data: null,
+          error: "Doctor is on leave on the selected date",
+        });
         return;
       }
 

--- a/apps/api/src/test/integration/leads.test.ts
+++ b/apps/api/src/test/integration/leads.test.ts
@@ -231,11 +231,49 @@ describeIfDB("Lead pipeline API (Pearl §3.3 — integration)", () => {
     expect(fifthMissingEmail.status).toBe(201);
   });
 
-  // Smoke: DOCTOR + ADMIN can list (just to ensure RBAC matrix is right).
-  it("DOCTOR + ADMIN can list leads", async () => {
-    const a = await request(app).get("/api/v1/leads").set("Authorization", `Bearer ${doctorToken}`);
-    expect(a.status).toBe(200);
-    const b = await request(app).get("/api/v1/leads").set("Authorization", `Bearer ${adminToken}`);
-    expect(b.status).toBe(200);
+  // RBAC matrix: reads on the pipeline (list + detail) are restricted to
+  // ADMIN + RECEPTION — they own the CRM pipeline and the Leads nav
+  // entry. DOCTOR can still CREATE a lead (e.g. from a patient profile)
+  // but must NOT be able to browse the pipeline. PATIENT is excluded
+  // everywhere. See LEAD_READ_ROLES in apps/api/src/routes/leads.ts.
+  it("ADMIN + RECEPTION can list leads; DOCTOR cannot (403)", async () => {
+    const admin = await request(app)
+      .get("/api/v1/leads")
+      .set("Authorization", `Bearer ${adminToken}`);
+    expect(admin.status).toBe(200);
+
+    const reception = await request(app)
+      .get("/api/v1/leads")
+      .set("Authorization", `Bearer ${receptionToken}`);
+    expect(reception.status).toBe(200);
+
+    const doctor = await request(app)
+      .get("/api/v1/leads")
+      .set("Authorization", `Bearer ${doctorToken}`);
+    expect(doctor.status).toBe(403);
+  });
+
+  it("DOCTOR can create a lead but cannot read its detail (403)", async () => {
+    // DOCTOR keeps write access (the patient-profile "Create lead"
+    // action), so creation succeeds…
+    const created = await request(app)
+      .post("/api/v1/leads")
+      .set("Authorization", `Bearer ${doctorToken}`)
+      .send({ name: "Doctor Made", phone: "+919876500011", source: "REFERRAL" });
+    expect(created.status).toBe(201);
+    const id = created.body.data.id;
+
+    // …but the detail read is pipeline-scoped and must reject DOCTOR.
+    const detail = await request(app)
+      .get(`/api/v1/leads/${id}`)
+      .set("Authorization", `Bearer ${doctorToken}`);
+    expect(detail.status).toBe(403);
+
+    // ADMIN can still read the same lead.
+    const adminDetail = await request(app)
+      .get(`/api/v1/leads/${id}`)
+      .set("Authorization", `Bearer ${adminToken}`);
+    expect(adminDetail.status).toBe(200);
+    expect(adminDetail.body.data.id).toBe(id);
   });
 });

--- a/apps/api/src/utils/doctor-leave.test.ts
+++ b/apps/api/src/utils/doctor-leave.test.ts
@@ -1,0 +1,82 @@
+// Unit tests for isDoctorOnConfirmedLeave — the gate that hides a
+// doctor's booking slots on days they have a CONFIRMED (APPROVED) leave.
+//
+// What / modules / why
+// ────────────────────
+// - WHAT: lock the contract that only an APPROVED LeaveRequest covering
+//   the requested date returns true; resolve Doctor.userId first; PENDING
+//   leave does NOT count; a doctor with no user / no leave returns false.
+// - MODULES: hoisted mock of `@medcore/db` (the helper's only dependency:
+//   prisma.doctor.findUnique + prisma.leaveRequest.findFirst). Pure-unit —
+//   no Postgres.
+// - WHY: this helper backs the slot grid + the book/reschedule server
+//   guards across doctors.ts, public-booking.ts, appointments.ts. A
+//   regression (e.g. counting PENDING leave, or skipping the userId
+//   resolution) would either hide slots wrongly or let patients book on a
+//   doctor's confirmed day off.
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { prismaMock } = vi.hoisted(() => ({
+  prismaMock: {
+    doctor: { findUnique: vi.fn() },
+    leaveRequest: { findFirst: vi.fn() },
+  } as any,
+}));
+
+vi.mock("@medcore/db", () => ({
+  prisma: prismaMock,
+}));
+
+import { isDoctorOnConfirmedLeave } from "./doctor-leave";
+
+const DATE = new Date("2026-06-10T00:00:00.000Z");
+
+describe("isDoctorOnConfirmedLeave", () => {
+  beforeEach(() => {
+    prismaMock.doctor.findUnique.mockReset();
+    prismaMock.leaveRequest.findFirst.mockReset();
+  });
+
+  it("returns false when the doctor row can't be resolved", async () => {
+    prismaMock.doctor.findUnique.mockResolvedValue(null);
+    const out = await isDoctorOnConfirmedLeave("doc-x", DATE);
+    expect(out).toBe(false);
+    // Never queries leave if there's no userId to key on.
+    expect(prismaMock.leaveRequest.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("returns true when an APPROVED leave covers the date", async () => {
+    prismaMock.doctor.findUnique.mockResolvedValue({ userId: "user-1" });
+    prismaMock.leaveRequest.findFirst.mockResolvedValue({ id: "leave-1" });
+    const out = await isDoctorOnConfirmedLeave("doc-1", DATE);
+    expect(out).toBe(true);
+  });
+
+  it("returns false when no leave row matches (e.g. only PENDING leave)", async () => {
+    prismaMock.doctor.findUnique.mockResolvedValue({ userId: "user-1" });
+    // The query filters status: "APPROVED", so a PENDING-only doctor yields
+    // no row → findFirst resolves null.
+    prismaMock.leaveRequest.findFirst.mockResolvedValue(null);
+    const out = await isDoctorOnConfirmedLeave("doc-1", DATE);
+    expect(out).toBe(false);
+  });
+
+  it("queries leave by the resolved userId, APPROVED status, and an inclusive date range", async () => {
+    prismaMock.doctor.findUnique.mockResolvedValue({ userId: "user-42" });
+    prismaMock.leaveRequest.findFirst.mockResolvedValue({ id: "leave-9" });
+
+    await isDoctorOnConfirmedLeave("doc-42", DATE);
+
+    expect(prismaMock.doctor.findUnique).toHaveBeenCalledWith({
+      where: { id: "doc-42" },
+      select: { userId: true },
+    });
+    const arg = prismaMock.leaveRequest.findFirst.mock.calls[0][0];
+    expect(arg.where.userId).toBe("user-42");
+    expect(arg.where.status).toBe("APPROVED");
+    // Inclusive overlap: fromDate <= date AND toDate >= date.
+    expect(arg.where.fromDate).toEqual({ lte: DATE });
+    expect(arg.where.toDate).toEqual({ gte: DATE });
+  });
+});

--- a/apps/api/src/utils/doctor-leave.ts
+++ b/apps/api/src/utils/doctor-leave.ts
@@ -1,0 +1,47 @@
+// Doctor confirmed-leave lookup — single source of truth.
+//
+// When a doctor has a CONFIRMED (APPROVED) LeaveRequest covering a date,
+// that doctor must not surface any bookable slots for that date. The
+// booking + reschedule slot grids all funnel through here so the rule is
+// applied consistently across surfaces (GET /doctors/:id/slots, the
+// public suggest-doctors grid, etc.).
+//
+// Data model (packages/db/prisma/schema.prisma):
+//   - LeaveRequest is keyed by `userId` (the doctor's User id, NOT the
+//     Doctor.id), so we resolve Doctor.userId first.
+//   - fromDate / toDate are `@db.Date` (UTC-midnight), inclusive range.
+//   - status APPROVED == confirmed. PENDING leave is NOT yet confirmed,
+//     so it does not hide slots (only an approved leave does).
+
+import { prisma } from "@medcore/db";
+
+/**
+ * Returns true if the doctor (by Doctor.id) has an APPROVED LeaveRequest
+ * whose [fromDate, toDate] inclusive range covers `dateObj`.
+ *
+ * `dateObj` should be the UTC-midnight Date for the requested calendar
+ * day (same basis the slot routes already use via `new Date("YYYY-MM-DD")`),
+ * so the inclusive `fromDate <= dateObj <= toDate` comparison lines up
+ * with the `@db.Date` storage.
+ */
+export async function isDoctorOnConfirmedLeave(
+  doctorId: string,
+  dateObj: Date,
+): Promise<boolean> {
+  const doctor = await prisma.doctor.findUnique({
+    where: { id: doctorId },
+    select: { userId: true },
+  });
+  if (!doctor?.userId) return false;
+
+  const leave = await prisma.leaveRequest.findFirst({
+    where: {
+      userId: doctor.userId,
+      status: "APPROVED",
+      fromDate: { lte: dateObj },
+      toDate: { gte: dateObj },
+    },
+    select: { id: true },
+  });
+  return leave !== null;
+}

--- a/apps/web/src/app/dashboard/leads/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/leads/[id]/page.tsx
@@ -19,7 +19,7 @@
 
 import { use, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import { api } from "@/lib/api";
 import { toast } from "@/lib/toast";
 import { useAuthStore } from "@/lib/store";
@@ -93,6 +93,12 @@ const ACTIVITY_LABELS: Record<string, string> = {
 
 const WRITE_ROLES = new Set(["ADMIN", "RECEPTION", "DOCTOR"]);
 const CONVERT_ROLES = new Set(["ADMIN", "RECEPTION"]);
+// View access mirrors the list page + the Leads nav entry: only
+// ADMIN + RECEPTION own the CRM pipeline. DOCTOR/NURSE/PATIENT are
+// redirected to not-authorized (CLAUDE.md gotcha #7 — no client gate
+// otherwise). Note: this is stricter than WRITE_ROLES, which still
+// lists DOCTOR for the legacy note-append affordance.
+const VIEW_ROLES = new Set(["ADMIN", "RECEPTION"]);
 
 export default function LeadDetailPage({
   params,
@@ -101,9 +107,23 @@ export default function LeadDetailPage({
 }) {
   const { id } = use(params);
   const router = useRouter();
+  const pathname = usePathname();
   const { user } = useAuthStore();
+  const isAuthLoading = useAuthStore((s) => s.isLoading);
   const canWrite = !!user?.role && WRITE_ROLES.has(user.role);
   const canConvert = !!user?.role && CONVERT_ROLES.has(user.role);
+  const canViewLead = !!user?.role && VIEW_ROLES.has(user.role);
+
+  // Redirect non-allowlisted roles (DOCTOR / NURSE / PATIENT) before the
+  // lead detail renders. Mirrors the list page + queue gate.
+  useEffect(() => {
+    if (!isAuthLoading && user && !canViewLead) {
+      toast.error("Leads pipeline is reception/admin-only.");
+      router.replace(
+        `/dashboard/not-authorized?from=${encodeURIComponent(pathname || `/dashboard/leads/${id}`)}`,
+      );
+    }
+  }, [isAuthLoading, user, canViewLead, router, pathname, id]);
 
   const [lead, setLead] = useState<LeadDetail | null>(null);
   const [loading, setLoading] = useState(true);
@@ -136,9 +156,12 @@ export default function LeadDetailPage({
   }
 
   useEffect(() => {
+    // Skip the GET for non-allowlisted roles — it would 403 and toast a
+    // spurious error during the redirect flicker.
+    if (!canViewLead) return;
     void load();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [id]);
+  }, [id, canViewLead]);
 
   async function changeStatus(status: LeadStatus) {
     if (!lead || !canWrite) return;
@@ -210,6 +233,11 @@ export default function LeadDetailPage({
 
   const isConverted = useMemo(() => Boolean(lead?.convertedPatientId), [lead]);
 
+  // Non-allowlisted roles are being redirected by the gate effect;
+  // render nothing so the lead detail never flashes for them.
+  if (!canViewLead) {
+    return null;
+  }
   if (loading) {
     return (
       <div className="flex items-center justify-center p-12 text-gray-400">

--- a/apps/web/src/app/dashboard/leads/__tests__/page.test.tsx
+++ b/apps/web/src/app/dashboard/leads/__tests__/page.test.tsx
@@ -58,7 +58,7 @@ import {
   within,
 } from "@testing-library/react";
 
-const { apiMock, toastMock, authMock } = vi.hoisted(() => ({
+const { apiMock, toastMock, authMock, routerMock } = vi.hoisted(() => ({
   apiMock: {
     get: vi.fn(),
     post: vi.fn(),
@@ -72,12 +72,21 @@ const { apiMock, toastMock, authMock } = vi.hoisted(() => ({
     info: vi.fn(),
     warning: vi.fn(),
   },
+  // Selector-aware store mock: the page calls both useAuthStore() (object
+  // destructure for `user`) and useAuthStore((s) => s.isLoading). We back
+  // both with one state object — when called with a selector, apply it;
+  // otherwise return the whole state.
   authMock: vi.fn(),
+  routerMock: { replace: vi.fn(), push: vi.fn() },
 }));
 
 vi.mock("@/lib/api", () => ({ api: apiMock }));
 vi.mock("@/lib/toast", () => ({ toast: toastMock }));
 vi.mock("@/lib/store", () => ({ useAuthStore: authMock }));
+vi.mock("next/navigation", () => ({
+  useRouter: () => routerMock,
+  usePathname: () => "/dashboard/leads",
+}));
 vi.mock("next/link", () => ({
   default: ({ href, children, ...rest }: any) => (
     <a href={typeof href === "string" ? href : "#"} {...rest}>
@@ -128,25 +137,39 @@ function ok(leads: LeadRow[]) {
   return { data: leads };
 }
 
+// Drive the selector-aware store mock. `isLoading: false` so the route
+// gate's `!isAuthLoading` guard runs its redirect synchronously in tests.
+function setAuthUser(user: Record<string, unknown> | null) {
+  const state = { user, isLoading: false };
+  authMock.mockImplementation((selector?: (s: typeof state) => unknown) =>
+    typeof selector === "function" ? selector(state) : state,
+  );
+}
+
 function asStaff() {
-  authMock.mockReturnValue({
-    user: {
-      id: "u-recep",
-      userId: "u-recep",
-      role: "RECEPTION",
-      name: "Front Desk",
-    },
+  setAuthUser({
+    id: "u-recep",
+    userId: "u-recep",
+    role: "RECEPTION",
+    name: "Front Desk",
   });
 }
 
 function asPatient() {
-  authMock.mockReturnValue({
-    user: {
-      id: "u-pat",
-      userId: "u-pat",
-      role: "PATIENT",
-      name: "Pat",
-    },
+  setAuthUser({
+    id: "u-pat",
+    userId: "u-pat",
+    role: "PATIENT",
+    name: "Pat",
+  });
+}
+
+function asDoctor() {
+  setAuthUser({
+    id: "u-doc",
+    userId: "u-doc",
+    role: "DOCTOR",
+    name: "Dr. Who",
   });
 }
 
@@ -157,6 +180,8 @@ describe("Leads dashboard page (CRM pipeline)", () => {
     apiMock.patch.mockReset();
     Object.values(toastMock).forEach((fn: any) => fn.mockReset());
     authMock.mockReset();
+    routerMock.replace.mockReset();
+    routerMock.push.mockReset();
     asStaff();
   });
 
@@ -164,21 +189,38 @@ describe("Leads dashboard page (CRM pipeline)", () => {
     cleanup();
   });
 
-  it("renders the staff-only copy when the caller is a PATIENT (no table, no filter chips)", () => {
+  it("redirects a PATIENT to not-authorized and renders no pipeline chrome", async () => {
     apiMock.get.mockResolvedValue(ok([]));
     asPatient();
     render(<LeadsPage />);
-    // The early-return branch wins: copy renders, no table chrome, no filter
-    // chips. (Note: hooks run before the early return so a `load()` fetch
-    // does fire; that's a separate API-layer concern, gated by the
-    // /leads route's own authorize(...) — see CLAUDE.md gotcha #7.)
-    expect(
-      screen.getByText(/Lead pipeline is staff-only\./i),
-    ).toBeInTheDocument();
+    // The route gate redirects non-allowlisted roles and the component
+    // returns null in the meantime — no table, no heading, no create btn.
+    await waitFor(() =>
+      expect(routerMock.replace).toHaveBeenCalledWith(
+        expect.stringContaining("/dashboard/not-authorized"),
+      ),
+    );
     expect(
       screen.queryByRole("heading", { name: /^Leads$/i }),
     ).not.toBeInTheDocument();
     expect(screen.queryByTestId("leads-create-btn")).not.toBeInTheDocument();
+    // Never fires the /leads GET for a non-allowlisted role.
+    expect(apiMock.get).not.toHaveBeenCalled();
+  });
+
+  it("redirects a DOCTOR to not-authorized (pipeline is reception/admin-only)", async () => {
+    apiMock.get.mockResolvedValue(ok([]));
+    asDoctor();
+    render(<LeadsPage />);
+    await waitFor(() =>
+      expect(routerMock.replace).toHaveBeenCalledWith(
+        expect.stringContaining("/dashboard/not-authorized"),
+      ),
+    );
+    expect(
+      screen.queryByRole("heading", { name: /^Leads$/i }),
+    ).not.toBeInTheDocument();
+    expect(apiMock.get).not.toHaveBeenCalled();
   });
 
   it('renders the "Loading…" placeholder while the initial fetch is pending', async () => {

--- a/apps/web/src/app/dashboard/leads/page.tsx
+++ b/apps/web/src/app/dashboard/leads/page.tsx
@@ -10,6 +10,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import { useRouter, usePathname } from "next/navigation";
 import { api } from "@/lib/api";
 import { toast } from "@/lib/toast";
 import { useAuthStore } from "@/lib/store";
@@ -28,6 +29,13 @@ import { Plus, Search, UserCheck } from "lucide-react";
 // (with optional +). Email is optional, but if provided must be RFC-ish.
 const LEAD_PHONE_REGEX = /^\+?\d{10,15}$/;
 const LEAD_EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+// Only ADMIN + RECEPTION own the CRM lead pipeline and have a Leads
+// nav entry (see navByRole in dashboard/layout.tsx). DOCTOR/NURSE can
+// create a lead from a patient profile via the API but have no business
+// browsing the pipeline — and PATIENT must never see it. Gate the page
+// (chrome renders for any authed user otherwise — CLAUDE.md gotcha #7).
+const LEADS_VIEW_ALLOWED = new Set(["ADMIN", "RECEPTION"]);
 
 function validateLeadForm(input: {
   name: string;
@@ -79,6 +87,23 @@ const STATUS_COLORS: Record<LeadStatus, string> = {
 
 export default function LeadsPage() {
   const { user } = useAuthStore();
+  const isAuthLoading = useAuthStore((s) => s.isLoading);
+  const router = useRouter();
+  const pathname = usePathname();
+  const canViewLeads = !!user?.role && LEADS_VIEW_ALLOWED.has(user.role);
+
+  // Redirect non-allowlisted roles (DOCTOR / NURSE / PATIENT) to the
+  // chrome-wrapped not-authorized page instead of letting the pipeline
+  // shell render. Mirrors the queue page's gate (Issue #179 / #383).
+  useEffect(() => {
+    if (!isAuthLoading && user && !canViewLeads) {
+      toast.error("Leads pipeline is reception/admin-only.");
+      router.replace(
+        `/dashboard/not-authorized?from=${encodeURIComponent(pathname || "/dashboard/leads")}`,
+      );
+    }
+  }, [isAuthLoading, user, canViewLeads, router, pathname]);
+
   const [leads, setLeads] = useState<Lead[]>([]);
   const [loading, setLoading] = useState(true);
   const [statusFilter, setStatusFilter] = useState<LeadStatus | "ALL">("ALL");
@@ -106,8 +131,6 @@ export default function LeadsPage() {
   );
   const canSubmit = Object.keys(liveErrors).length === 0 && !submitting;
 
-  const isStaff = !!user?.role && user.role !== "PATIENT";
-
   const load = async () => {
     setLoading(true);
     try {
@@ -127,9 +150,12 @@ export default function LeadsPage() {
   };
 
   useEffect(() => {
+    // Don't fire the /leads GET for non-allowlisted roles — it would
+    // 403 and toast a spurious error during the redirect flicker.
+    if (!canViewLeads) return;
     void load();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [statusFilter, sourceFilter]);
+  }, [statusFilter, sourceFilter, canViewLeads]);
 
   const counts = useMemo(() => {
     const map: Record<string, number> = { ALL: leads.length };
@@ -215,12 +241,11 @@ export default function LeadsPage() {
     }
   };
 
-  if (!isStaff) {
-    return (
-      <div className="p-6 text-sm text-gray-500 dark:text-gray-400">
-        Lead pipeline is staff-only.
-      </div>
-    );
+  // Non-allowlisted roles (DOCTOR / NURSE / PATIENT) get redirected by
+  // the gate effect above; render nothing in the meantime so the
+  // pipeline shell never flashes for them.
+  if (!canViewLeads) {
+    return null;
   }
 
   return (

--- a/apps/web/src/app/dashboard/patients/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/patients/[id]/page.tsx
@@ -46,6 +46,9 @@ import {
   Printer,
   AlertCircle,
   Edit as EditIcon,
+  MessageCircle,
+  PhoneCall,
+  UserPlus,
 } from "lucide-react";
 
 // ───────────────────────────────────────────────────────
@@ -383,6 +386,7 @@ export default function PatientDetailPage() {
   const { user } = useAuthStore();
   const promptDialog = usePrompt();
   const [patient, setPatient] = useState<PatientDetail | null>(null);
+  const [creatingLead, setCreatingLead] = useState(false);
   const [visits, setVisits] = useState<VisitRecord[]>([]);
   const [stats, setStats] = useState<PatientStats | null>(null);
   const [allergiesAlert, setAllergiesAlert] = useState<Allergy[]>([]);
@@ -431,6 +435,41 @@ export default function PatientDetailPage() {
       setConsultHistoryLoading(false);
     }
   }, [id, consultHistory.length]);
+
+  // Quick "Create lead" action — opens a CRM lead pre-filled from the
+  // patient's name / phone / email so staff can start a sales/follow-up
+  // track straight from the profile. On success, jumps to the new lead.
+  const createLead = useCallback(async () => {
+    if (!patient || creatingLead) return;
+    setCreatingLead(true);
+    try {
+      const res = await api.post<{ data: { id: string } }>("/leads", {
+        name: patient.user.name.trim(),
+        phone: patient.user.phone?.trim() || undefined,
+        email: patient.user.email?.trim() || undefined,
+        source: "REFERRAL",
+        notes: `Created from patient ${patient.mrNumber}`,
+      });
+      // Only ADMIN / RECEPTION can VIEW the leads pages (DOCTOR + NURSE
+      // can create via the API but have no Leads nav entry — navigating
+      // them to /dashboard/leads/:id dead-ends on a not-authorized
+      // shell). So only redirect roles that can actually see the page;
+      // others get a confirmation toast and stay on the patient profile.
+      toast.success("Lead created");
+      const leadId = res?.data?.id;
+      const canViewLeads =
+        user?.role === "ADMIN" || user?.role === "RECEPTION";
+      if (leadId && canViewLeads) {
+        router.push(`/dashboard/leads/${leadId}`);
+      }
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to create lead",
+      );
+    } finally {
+      setCreatingLead(false);
+    }
+  }, [patient, creatingLead, router, user]);
 
   const loadStats = useCallback(async () => {
     try {
@@ -865,6 +904,70 @@ export default function PatientDetailPage() {
                 </div>
               )}
             </div>
+
+            {/* Contact ACTIONS — one-click reach-out shortcuts wired to
+                native intents (WhatsApp / call / email) plus a vCard
+                download, so staff can contact or save the patient
+                without leaving the profile. Gated on having a phone or
+                email so the cluster doesn't render empty affordances. */}
+            {(patient.user.phone || patient.user.email) && (
+              <div
+                className="no-print mt-4 flex items-center gap-3 border-t pt-3"
+                data-testid="patient-contact-actions"
+              >
+                <span className="text-[11px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  Actions
+                </span>
+                {patient.user.phone && (
+                  <a
+                    href={`https://wa.me/${patient.user.phone.replace(/[^\d]/g, "")}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    title="Message on WhatsApp"
+                    aria-label="Message patient on WhatsApp"
+                    data-testid="patient-action-whatsapp"
+                    className="rounded-full p-1.5 text-green-600 hover:bg-green-50 dark:text-green-400 dark:hover:bg-green-900/30"
+                  >
+                    <MessageCircle size={18} />
+                  </a>
+                )}
+                {patient.user.phone && (
+                  <a
+                    href={`tel:${patient.user.phone}`}
+                    title="Call patient"
+                    aria-label="Call patient"
+                    data-testid="patient-action-call"
+                    className="rounded-full p-1.5 text-blue-600 hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-blue-900/30"
+                  >
+                    <PhoneCall size={18} />
+                  </a>
+                )}
+                {patient.user.email && (
+                  <a
+                    href={`mailto:${patient.user.email}`}
+                    title="Email patient"
+                    aria-label="Email patient"
+                    data-testid="patient-action-email"
+                    className="rounded-full p-1.5 text-purple-600 hover:bg-purple-50 dark:text-purple-400 dark:hover:bg-purple-900/30"
+                  >
+                    <Mail size={18} />
+                  </a>
+                )}
+                {(isReception || isAdmin || isDoctor || isNurse) && (
+                  <button
+                    type="button"
+                    onClick={createLead}
+                    disabled={creatingLead}
+                    title="Create CRM lead from this patient"
+                    aria-label="Create lead from patient"
+                    data-testid="patient-action-create-lead"
+                    className="rounded-full p-1.5 text-purple-600 hover:bg-purple-50 disabled:opacity-50 dark:text-purple-400 dark:hover:bg-purple-900/30"
+                  >
+                    <UserPlus size={18} />
+                  </button>
+                )}
+              </div>
+            )}
           </div>
         </div>
 

--- a/apps/web/src/app/patient/appointments/__tests__/page.test.tsx
+++ b/apps/web/src/app/patient/appointments/__tests__/page.test.tsx
@@ -79,6 +79,7 @@ function bookActive(id: string, dateIso: string) {
     slotStart: "10:30:00",
     tokenNumber: 7,
     status: "BOOKED",
+    doctorId: "doc-1",
     doctor: { user: { name: "Sharma" }, specialty: "Obstetrics" },
   };
 }
@@ -289,10 +290,28 @@ describe("Patient appointments page — gap #5 piece 3b", () => {
     expect(href).toContain(encodeURIComponent("12 MG Rd, Bengaluru"));
   });
 
-  it("submitting reschedule PATCHes /appointments/:id/reschedule with { date, slotStart }", async () => {
+  it("submitting reschedule PATCHes /appointments/:id/reschedule with { date, slotStart } picked from the doctor's slot grid", async () => {
     apiGetMock.mockImplementation((endpoint: string) => {
       if (endpoint.includes("status=BOOKED")) {
         return Promise.resolve(listOk([bookActive("appt-up-1", FUTURE)]));
+      }
+      // Slot/token-wise picker: the modal fetches the doctor's open slots
+      // for the chosen date instead of offering a free-form time input.
+      if (endpoint.startsWith("/doctors/doc-1/slots")) {
+        return Promise.resolve({
+          success: true,
+          data: {
+            date: "2099-12-31",
+            slots: [
+              { startTime: "15:00", endTime: "15:30", isAvailable: true },
+              { startTime: "15:30", endTime: "16:00", isAvailable: true },
+              { startTime: "16:00", endTime: "16:30", isAvailable: false },
+            ],
+            blocked: false,
+            reason: null,
+          },
+          error: null,
+        });
       }
       return Promise.resolve(listOk([]));
     });
@@ -312,11 +331,14 @@ describe("Patient appointments page — gap #5 piece 3b", () => {
     const dateInput = screen.getByTestId(
       "patient-appointments-reschedule-date",
     );
-    const timeInput = screen.getByTestId(
-      "patient-appointments-reschedule-time",
-    );
     fireEvent.change(dateInput, { target: { value: "2099-12-31" } });
-    fireEvent.change(timeInput, { target: { value: "15:30" } });
+
+    // The slot grid loads for the chosen date; pick the 15:30 chip.
+    const slot1530 = await screen.findByTestId(
+      "patient-appointments-reschedule-slot-15:30",
+    );
+    fireEvent.click(slot1530);
+
     // Pearl §3.1 (gap closed 2026-05-29): reschedule reason is required
     // server-side (Zod, 3-500 chars). Local validation also short-circuits
     // the submit, so the test must enter a reason before clicking submit.
@@ -340,6 +362,56 @@ describe("Patient appointments page — gap #5 piece 3b", () => {
         },
       );
     });
+  });
+
+  it("disables the reschedule submit until a slot is picked, and blocks free-form times", async () => {
+    apiGetMock.mockImplementation((endpoint: string) => {
+      if (endpoint.includes("status=BOOKED")) {
+        return Promise.resolve(listOk([bookActive("appt-up-1", FUTURE)]));
+      }
+      if (endpoint.startsWith("/doctors/doc-1/slots")) {
+        return Promise.resolve({
+          success: true,
+          data: {
+            date: "2099-12-31",
+            slots: [
+              { startTime: "15:30", endTime: "16:00", isAvailable: true },
+            ],
+            blocked: false,
+            reason: null,
+          },
+          error: null,
+        });
+      }
+      return Promise.resolve(listOk([]));
+    });
+
+    render(<PatientAppointmentsPage />);
+    await waitFor(() =>
+      expect(screen.getByTestId("patient-appointments")).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByTestId("patient-appointments-reschedule-btn"));
+    await screen.findByTestId("patient-appointments-reschedule-modal");
+
+    // No free-form time input exists anymore.
+    expect(
+      screen.queryByTestId("patient-appointments-reschedule-time"),
+    ).not.toBeInTheDocument();
+
+    // Submit is disabled before any slot is chosen.
+    const submit = screen.getByTestId(
+      "patient-appointments-reschedule-submit",
+    );
+    expect(submit).toBeDisabled();
+
+    // Pick the only available slot → submit enables.
+    fireEvent.click(
+      await screen.findByTestId(
+        "patient-appointments-reschedule-slot-15:30",
+      ),
+    );
+    expect(submit).toBeEnabled();
   });
 
   it("submitting cancel PATCHes /appointments/:id/status with { status: 'CANCELLED', cancellationReason }", async () => {

--- a/apps/web/src/app/patient/appointments/page.tsx
+++ b/apps/web/src/app/patient/appointments/page.tsx
@@ -50,10 +50,22 @@ interface AppointmentRow {
   status: string;
   branchId?: string | null;
   branch?: BranchLite | null;
+  // doctorId is the scalar FK on the appointment row (the list endpoint
+  // uses `include: { doctor }`, so all scalar fields incl. doctorId come
+  // back). Needed to fetch the doctor's open slots when rescheduling.
+  doctorId?: string | null;
   doctor?: {
     user?: { name?: string | null } | null;
     specialty?: string | null;
   } | null;
+}
+
+// One open slot from GET /doctors/:id/slots. `isAvailable` is false for
+// slots already booked by someone else (shown but disabled).
+interface SlotRow {
+  startTime: string;
+  endTime: string;
+  isAvailable: boolean;
 }
 
 interface ApiList<T> {
@@ -185,6 +197,12 @@ export default function PatientAppointmentsPage() {
   const [cancelDraft, setCancelDraft] = useState<CancelDraft | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
+  // Reschedule slot picker — the patient picks from the doctor's open
+  // slots (token/slot-wise) instead of typing a free-form time. Slots
+  // are refetched whenever the draft's date changes.
+  const [rescheduleSlots, setRescheduleSlots] = useState<SlotRow[]>([]);
+  const [slotsLoading, setSlotsLoading] = useState(false);
+  const [slotsNotice, setSlotsNotice] = useState<string | null>(null);
   // Pearl §6.3 row 340 — per-row arrive state. `arriving` disables the button
   // while the PATCH is in flight; `arrived` flips the row to the "Arrived ✓"
   // pill optimistically. We don't refetch on success — the green pill is the
@@ -271,11 +289,65 @@ export default function PatientAppointmentsPage() {
     setRescheduleDraft({
       appointment: match,
       date: new Date(match.date).toISOString().slice(0, 10),
-      slotStart: (match.slotStart ?? "10:00").slice(0, 5),
+      // Start with no slot picked — the patient chooses from the doctor's
+      // open-slot grid (the old time may not be available anymore).
+      slotStart: "",
       reason: "",
     });
     setDidAutoOpenForId(target);
   }, [searchParams, appointments, state, didAutoOpenForId]);
+
+  // Fetch the doctor's open slots for the reschedule modal whenever the
+  // draft opens or its date changes. The patient picks token/slot-wise
+  // from this list instead of typing a free-form time. Mirrors the
+  // booking flow's GET /doctors/:id/slots?date= contract.
+  const rescheduleDoctorId = rescheduleDraft?.appointment.doctorId ?? null;
+  const rescheduleDate = rescheduleDraft?.date ?? null;
+  useEffect(() => {
+    if (!rescheduleDate) return;
+    if (!rescheduleDoctorId) {
+      // No doctorId on the row → can't resolve availability. Surface a
+      // clear notice rather than silently showing an empty grid.
+      setRescheduleSlots([]);
+      setSlotsNotice("Slots unavailable for this appointment.");
+      return;
+    }
+    let cancelled = false;
+    setSlotsLoading(true);
+    setSlotsNotice(null);
+    (async () => {
+      try {
+        const res = await api.get<{
+          data: {
+            slots?: SlotRow[];
+            blocked?: boolean;
+            reason?: string | null;
+          };
+        }>(
+          `/doctors/${rescheduleDoctorId}/slots?date=${encodeURIComponent(rescheduleDate)}`,
+        );
+        if (cancelled) return;
+        if (res.data?.blocked) {
+          setRescheduleSlots([]);
+          setSlotsNotice(res.data.reason ?? "Doctor unavailable on this date.");
+        } else {
+          setRescheduleSlots(res.data?.slots ?? []);
+          setSlotsNotice(null);
+        }
+      } catch (err) {
+        if (cancelled) return;
+        setRescheduleSlots([]);
+        setSlotsNotice(
+          err instanceof Error ? err.message : "Could not load slots.",
+        );
+      } finally {
+        if (!cancelled) setSlotsLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [rescheduleDoctorId, rescheduleDate]);
 
   // Close any open modal on Esc — small QoL nicety since the modal is
   // hand-rolled without a library.
@@ -314,6 +386,12 @@ export default function PatientAppointmentsPage() {
 
   async function submitReschedule(): Promise<void> {
     if (!rescheduleDraft) return;
+    // The patient must pick an available slot (token/slot-wise) — no
+    // free-form time. slotStart is empty until a grid chip is clicked.
+    if (!rescheduleDraft.slotStart) {
+      setActionError("Please pick an available time slot.");
+      return;
+    }
     // Pearl §3.1 (gap closed 2026-05-29) — reschedule reason is now
     // required server-side (3-500 chars). The patient reschedule form's
     // reason input was already there but unwired; wire it through and
@@ -518,7 +596,8 @@ export default function PatientAppointmentsPage() {
                         setRescheduleDraft({
                           appointment: a,
                           date: new Date(a.date).toISOString().slice(0, 10),
-                          slotStart: (a.slotStart ?? "10:00").slice(0, 5),
+                          // No slot pre-selected — patient picks from grid.
+                          slotStart: "",
                           reason: "",
                         })
                       }
@@ -606,11 +685,17 @@ export default function PatientAppointmentsPage() {
             }
           }}
         >
-          <div className="w-full max-w-md space-y-4 rounded-lg bg-white p-4 shadow-xl">
-            <h3 id="reschedule-title" className="text-lg font-semibold">
+          <div className="flex max-h-[90vh] w-full max-w-md flex-col overflow-hidden rounded-lg bg-white shadow-xl">
+            <h3
+              id="reschedule-title"
+              className="shrink-0 border-b border-slate-200 px-4 py-3 text-lg font-semibold"
+            >
               Reschedule appointment
             </h3>
-            <div className="space-y-3">
+            {/* Scrollable body — only this region scrolls when the slot
+                grid is tall (multi-shift doctors), so the header + footer
+                stay pinned and the modal never overflows the viewport. */}
+            <div className="flex-1 space-y-3 overflow-y-auto px-4 py-4">
               <label className="block text-sm">
                 <span className="mb-1 block font-medium text-slate-700">
                   New date
@@ -620,32 +705,84 @@ export default function PatientAppointmentsPage() {
                   value={rescheduleDraft.date}
                   min={new Date().toISOString().slice(0, 10)}
                   onChange={(e) =>
+                    // Clear the picked slot — it may not exist on the new
+                    // date; the patient re-picks from the refreshed grid.
                     setRescheduleDraft({
                       ...rescheduleDraft,
                       date: e.target.value,
+                      slotStart: "",
                     })
                   }
                   data-testid="patient-appointments-reschedule-date"
                   className="block h-11 w-full rounded-md border border-slate-300 px-3 text-sm"
                 />
               </label>
-              <label className="block text-sm">
+              {/* New time — slot/token-wise picker. The patient may only
+                  pick from the doctor's open slots, not a free-form time.
+                  Booked slots come back isAvailable=false and render
+                  disabled. */}
+              <div className="block text-sm">
                 <span className="mb-1 block font-medium text-slate-700">
                   New time
                 </span>
-                <input
-                  type="time"
-                  value={rescheduleDraft.slotStart}
-                  onChange={(e) =>
-                    setRescheduleDraft({
-                      ...rescheduleDraft,
-                      slotStart: e.target.value,
-                    })
-                  }
-                  data-testid="patient-appointments-reschedule-time"
-                  className="block h-11 w-full rounded-md border border-slate-300 px-3 text-sm"
-                />
-              </label>
+                {slotsLoading ? (
+                  <p
+                    data-testid="patient-appointments-reschedule-slots-loading"
+                    className="text-sm text-slate-500"
+                  >
+                    Loading slots…
+                  </p>
+                ) : slotsNotice ? (
+                  <p
+                    data-testid="patient-appointments-reschedule-slots-notice"
+                    role="alert"
+                    className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900"
+                  >
+                    {slotsNotice}
+                  </p>
+                ) : rescheduleSlots.length === 0 ? (
+                  <p
+                    data-testid="patient-appointments-reschedule-slots-empty"
+                    className="rounded-md border border-dashed border-slate-300 bg-slate-50 p-3 text-sm text-slate-600"
+                  >
+                    No slots available on this date.
+                  </p>
+                ) : (
+                  <div
+                    data-testid="patient-appointments-reschedule-slots-grid"
+                    className="grid grid-cols-3 gap-2 sm:grid-cols-4"
+                  >
+                    {rescheduleSlots.map((s) => {
+                      const selected =
+                        rescheduleDraft.slotStart === s.startTime;
+                      return (
+                        <button
+                          key={s.startTime}
+                          type="button"
+                          disabled={!s.isAvailable}
+                          data-testid={`patient-appointments-reschedule-slot-${s.startTime}`}
+                          data-selected={selected || undefined}
+                          onClick={() =>
+                            setRescheduleDraft({
+                              ...rescheduleDraft,
+                              slotStart: s.startTime,
+                            })
+                          }
+                          className={`inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border px-2 text-xs font-medium ${
+                            !s.isAvailable
+                              ? "cursor-not-allowed border-slate-200 bg-slate-100 text-slate-400"
+                              : selected
+                                ? "border-slate-900 bg-slate-900 text-white"
+                                : "border-slate-300 bg-white text-slate-800"
+                          }`}
+                        >
+                          {s.startTime}
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
               <label className="block text-sm">
                 <span className="mb-1 block font-medium text-slate-700">
                   Reason <span className="text-red-600">*</span>
@@ -666,36 +803,40 @@ export default function PatientAppointmentsPage() {
                 />
               </label>
             </div>
-            {actionError ? (
-              <p
-                role="alert"
-                data-testid="patient-appointments-action-error"
-                className="rounded-md bg-red-50 p-2 text-xs text-red-800"
-              >
-                {actionError}
-              </p>
-            ) : null}
-            <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
-              <button
-                type="button"
-                onClick={() => {
-                  setRescheduleDraft(null);
-                  setActionError(null);
-                }}
-                className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 px-4 text-sm font-medium text-slate-800"
-                data-testid="patient-appointments-reschedule-cancel-btn"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                disabled={submitting}
-                onClick={() => void submitReschedule()}
-                className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md bg-slate-900 px-4 text-sm font-medium text-white disabled:opacity-60"
-                data-testid="patient-appointments-reschedule-submit"
-              >
-                {submitting ? "Saving…" : "Confirm reschedule"}
-              </button>
+            {/* Pinned footer — stays visible while the body scrolls so the
+                primary action is always reachable on small screens. */}
+            <div className="shrink-0 space-y-3 border-t border-slate-200 px-4 py-3">
+              {actionError ? (
+                <p
+                  role="alert"
+                  data-testid="patient-appointments-action-error"
+                  className="rounded-md bg-red-50 p-2 text-xs text-red-800"
+                >
+                  {actionError}
+                </p>
+              ) : null}
+              <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setRescheduleDraft(null);
+                    setActionError(null);
+                  }}
+                  className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 px-4 text-sm font-medium text-slate-800"
+                  data-testid="patient-appointments-reschedule-cancel-btn"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  disabled={submitting || !rescheduleDraft.slotStart}
+                  onClick={() => void submitReschedule()}
+                  className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md bg-slate-900 px-4 text-sm font-medium text-white disabled:opacity-60"
+                  data-testid="patient-appointments-reschedule-submit"
+                >
+                  {submitting ? "Saving…" : "Confirm reschedule"}
+                </button>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
…cker reschedule; restrict leads to admin/reception

Bundles several fixes from this session (IST slot-cutoff fix already landed separately in #1083).

Booking — confirmed doctor leave hides slots:
- New util isDoctorOnConfirmedLeave(doctorId, date): a doctor with an APPROVED LeaveRequest covering a date offers no slots. PENDING leave does not count. Resolves Doctor.userId (LeaveRequest is keyed by User).
- Wired into the slot grids (GET /doctors/:id/slots, public computeOpenSlots) AND the submit guards (/appointments/book, /:id/reschedule, public /book, and the /next-available finder) so the rule is enforced server-side, not just hidden in the UI.

Booking — patient reschedule uses a slot/token picker:
- Replaced the free-form <input type="time"> in the patient reschedule modal with the doctor's open-slot grid (GET /doctors/:id/slots), so the patient can only pick a real available slot. Submit is gated on a pick.
- Made the modal responsive: pinned header + footer, scrollable body capped at 90vh so multi-shift doctors no longer overflow the viewport.

Leads — pipeline restricted to ADMIN + RECEPTION:
- Client route gate on /dashboard/leads and /dashboard/leads/[id] (DOCTOR/NURSE/PATIENT redirect to not-authorized).
- Server reads (GET /leads, GET /leads/:id) tightened to ADMIN+RECEPTION via LEAD_READ_ROLES; writes (create) stay open to DOCTOR/NURSE so the patient-profile "Create lead" action still works. by-patient stays on the broader roles (powers the patient CRM History panel).

Patient detail — contact actions + create-lead:
- Added WhatsApp / call / email quick-action icons and a "Create lead" action to the patient detail page; lead-create only navigates roles that can view the leads pipeline.

Tests: doctor-leave.test.ts (4), updated leads RBAC + patient reschedule slot-grid specs. tsc --noEmit clean (api + web).

<!--
PR template. Fill in each section; delete sections that don't apply.
Keep it short — the PR description should be skimmable.
-->

## Summary

<!-- 1-2 sentences on what this changes and why. -->

## Test plan

<!--
Bulleted checklist of what you verified. Cover the happy path and the
edge case that motivated the change. If a code path can only be
exercised in CI / on the dev server, say so explicitly.
-->

- [ ]
- [ ]

## Risk

<!--
Anything risky a reviewer should look for? Examples:
  - Touches production-critical code (auth, billing, RBAC, migrations)
  - Changes a deploy script or CI workflow
  - Drops or narrows a database column (REQUIRES `[allow-destructive-migration]` in commit message)
  - Modifies a feature flag's default
  - Bumps a dependency major version

If "low risk" — say so. Don't leave this blank.
-->

## Screenshots / output

<!--
Frontend changes: before/after screenshots.
API changes: a curl invocation + the response body.
Backend behavior: a paste of the test output that proves it works.
-->

## Linked issues

<!-- Closes #N for each issue this PR resolves. -->
