### PR TITLE
fix(patient-ui): add dark-mode variants across the patient PWA

### DIFF
--- a/apps/web/src/app/patient/appointments/page.tsx
+++ b/apps/web/src/app/patient/appointments/page.tsx
@@ -160,13 +160,13 @@ function formatApptWhen(a: AppointmentRow): string {
 }
 
 function statusPillClass(status: string): string {
-  if (status === "BOOKED") return "bg-blue-100 text-blue-900";
-  if (status === "CHECKED_IN") return "bg-amber-100 text-amber-900";
-  if (status === "IN_CONSULTATION") return "bg-violet-100 text-violet-900";
-  if (status === "COMPLETED") return "bg-emerald-100 text-emerald-900";
-  if (status === "CANCELLED") return "bg-slate-200 text-slate-700";
-  if (status === "NO_SHOW") return "bg-red-100 text-red-900";
-  return "bg-slate-100 text-slate-700";
+  if (status === "BOOKED") return "bg-blue-100 dark:bg-blue-900/40 text-blue-900 dark:text-blue-200";
+  if (status === "CHECKED_IN") return "bg-amber-100 dark:bg-amber-900/40 text-amber-900 dark:text-amber-200";
+  if (status === "IN_CONSULTATION") return "bg-violet-100 dark:bg-violet-900/40 text-violet-900 dark:text-violet-200";
+  if (status === "COMPLETED") return "bg-emerald-100 dark:bg-emerald-900/40 text-emerald-900 dark:text-emerald-200";
+  if (status === "CANCELLED") return "bg-slate-200 dark:bg-gray-700 text-slate-700 dark:text-gray-200";
+  if (status === "NO_SHOW") return "bg-red-100 dark:bg-red-900/40 text-red-900 dark:text-red-200";
+  return "bg-slate-100 dark:bg-gray-800 text-slate-700 dark:text-gray-200";
 }
 
 // ─── Modal helpers ──────────────────────────────────────────────────────
@@ -490,7 +490,7 @@ export default function PatientAppointmentsPage() {
     return (
       <section
         data-testid="patient-appointments-loading"
-        className="flex min-h-[40vh] items-center justify-center text-sm text-slate-500"
+        className="flex min-h-[40vh] items-center justify-center text-sm text-slate-500 dark:text-gray-400"
       >
         Loading your appointments…
       </section>
@@ -504,7 +504,7 @@ export default function PatientAppointmentsPage() {
         className="space-y-4 py-6"
       >
         <h1 className="text-2xl font-semibold tracking-tight">Sign in</h1>
-        <p className="text-base text-slate-600">
+        <p className="text-base text-slate-600 dark:text-gray-300">
           Please sign in to view your appointments.
         </p>
         <Link
@@ -523,7 +523,7 @@ export default function PatientAppointmentsPage() {
       <section
         data-testid="patient-appointments-error"
         role="alert"
-        className="rounded-md border border-red-300 bg-red-50 p-4 text-sm text-red-800"
+        className="rounded-md border border-red-300 dark:border-red-800 bg-red-50 dark:bg-red-900/30 p-4 text-sm text-red-800 dark:text-red-200"
       >
         Something went wrong loading your appointments. Please refresh.
       </section>
@@ -553,9 +553,9 @@ export default function PatientAppointmentsPage() {
       {isEmpty ? (
         <div
           data-testid="patient-appointments-empty"
-          className="space-y-3 rounded-lg border border-slate-200 bg-white p-6 text-center shadow-sm"
+          className="space-y-3 rounded-lg border border-slate-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6 text-center shadow-sm"
         >
-          <p className="text-base text-slate-700">No appointments yet.</p>
+          <p className="text-base text-slate-700 dark:text-gray-200">No appointments yet.</p>
           <Link
             href="/patient/book"
             className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md bg-slate-900 px-6 text-sm font-medium text-white"
@@ -574,14 +574,14 @@ export default function PatientAppointmentsPage() {
           >
             <h2
               id="upcoming-heading"
-              className="text-sm font-medium uppercase tracking-wide text-slate-500"
+              className="text-sm font-medium uppercase tracking-wide text-slate-500 dark:text-gray-400"
             >
               Upcoming
             </h2>
             {upcoming.length === 0 ? (
               <p
                 data-testid="patient-appointments-upcoming-empty"
-                className="rounded-md border border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-600"
+                className="rounded-md border border-dashed border-slate-300 dark:border-gray-600 bg-slate-50 dark:bg-gray-900 p-4 text-sm text-slate-600 dark:text-gray-300"
               >
                 No upcoming appointments.
               </p>
@@ -614,7 +614,7 @@ export default function PatientAppointmentsPage() {
                   <p
                     role="alert"
                     data-testid="patient-appointments-arrive-error"
-                    className="rounded-md bg-red-50 p-2 text-xs text-red-800"
+                    className="rounded-md bg-red-50 dark:bg-red-900/30 p-2 text-xs text-red-800 dark:text-red-200"
                   >
                     {arriveError}
                   </p>
@@ -633,7 +633,7 @@ export default function PatientAppointmentsPage() {
               <div className="flex items-center justify-between">
                 <h2
                   id="past-heading"
-                  className="text-sm font-medium uppercase tracking-wide text-slate-500"
+                  className="text-sm font-medium uppercase tracking-wide text-slate-500 dark:text-gray-400"
                 >
                   Past
                 </h2>
@@ -642,7 +642,7 @@ export default function PatientAppointmentsPage() {
                   onClick={() => setShowPast((v) => !v)}
                   data-testid="patient-appointments-past-toggle"
                   aria-expanded={showPast}
-                  className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 px-3 text-xs font-medium text-slate-800"
+                  className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 dark:border-gray-600 px-3 text-xs font-medium text-slate-800 dark:text-gray-100"
                 >
                   {showPast ? "Hide past appointments" : "Show past appointments"}
                 </button>
@@ -685,10 +685,10 @@ export default function PatientAppointmentsPage() {
             }
           }}
         >
-          <div className="flex max-h-[90vh] w-full max-w-md flex-col overflow-hidden rounded-lg bg-white shadow-xl">
+          <div className="flex max-h-[90vh] w-full max-w-md flex-col overflow-hidden rounded-lg bg-white dark:bg-gray-800 shadow-xl">
             <h3
               id="reschedule-title"
-              className="shrink-0 border-b border-slate-200 px-4 py-3 text-lg font-semibold"
+              className="shrink-0 border-b border-slate-200 dark:border-gray-700 px-4 py-3 text-lg font-semibold"
             >
               Reschedule appointment
             </h3>
@@ -697,7 +697,7 @@ export default function PatientAppointmentsPage() {
                 stay pinned and the modal never overflows the viewport. */}
             <div className="flex-1 space-y-3 overflow-y-auto px-4 py-4">
               <label className="block text-sm">
-                <span className="mb-1 block font-medium text-slate-700">
+                <span className="mb-1 block font-medium text-slate-700 dark:text-gray-200">
                   New date
                 </span>
                 <input
@@ -714,7 +714,7 @@ export default function PatientAppointmentsPage() {
                     })
                   }
                   data-testid="patient-appointments-reschedule-date"
-                  className="block h-11 w-full rounded-md border border-slate-300 px-3 text-sm"
+                  className="block h-11 w-full rounded-md border border-slate-300 dark:border-gray-600 px-3 text-sm"
                 />
               </label>
               {/* New time — slot/token-wise picker. The patient may only
@@ -722,13 +722,13 @@ export default function PatientAppointmentsPage() {
                   Booked slots come back isAvailable=false and render
                   disabled. */}
               <div className="block text-sm">
-                <span className="mb-1 block font-medium text-slate-700">
+                <span className="mb-1 block font-medium text-slate-700 dark:text-gray-200">
                   New time
                 </span>
                 {slotsLoading ? (
                   <p
                     data-testid="patient-appointments-reschedule-slots-loading"
-                    className="text-sm text-slate-500"
+                    className="text-sm text-slate-500 dark:text-gray-400"
                   >
                     Loading slots…
                   </p>
@@ -736,14 +736,14 @@ export default function PatientAppointmentsPage() {
                   <p
                     data-testid="patient-appointments-reschedule-slots-notice"
                     role="alert"
-                    className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900"
+                    className="rounded-md border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/30 p-3 text-sm text-amber-900 dark:text-amber-200"
                   >
                     {slotsNotice}
                   </p>
                 ) : rescheduleSlots.length === 0 ? (
                   <p
                     data-testid="patient-appointments-reschedule-slots-empty"
-                    className="rounded-md border border-dashed border-slate-300 bg-slate-50 p-3 text-sm text-slate-600"
+                    className="rounded-md border border-dashed border-slate-300 dark:border-gray-600 bg-slate-50 dark:bg-gray-900 p-3 text-sm text-slate-600 dark:text-gray-300"
                   >
                     No slots available on this date.
                   </p>
@@ -770,10 +770,10 @@ export default function PatientAppointmentsPage() {
                           }
                           className={`inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border px-2 text-xs font-medium ${
                             !s.isAvailable
-                              ? "cursor-not-allowed border-slate-200 bg-slate-100 text-slate-400"
+                              ? "cursor-not-allowed border-slate-200 dark:border-gray-700 bg-slate-100 dark:bg-gray-800 text-slate-400 dark:text-gray-500"
                               : selected
-                                ? "border-slate-900 bg-slate-900 text-white"
-                                : "border-slate-300 bg-white text-slate-800"
+                                ? "border-slate-900 dark:border-gray-300 bg-slate-900 text-white"
+                                : "border-slate-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-slate-800 dark:text-gray-100"
                           }`}
                         >
                           {s.startTime}
@@ -784,8 +784,8 @@ export default function PatientAppointmentsPage() {
                 )}
               </div>
               <label className="block text-sm">
-                <span className="mb-1 block font-medium text-slate-700">
-                  Reason <span className="text-red-600">*</span>
+                <span className="mb-1 block font-medium text-slate-700 dark:text-gray-200">
+                  Reason <span className="text-red-600 dark:text-red-300">*</span>
                 </span>
                 <textarea
                   value={rescheduleDraft.reason}
@@ -799,18 +799,18 @@ export default function PatientAppointmentsPage() {
                   maxLength={500}
                   placeholder="e.g. Schedule conflict; need a different time"
                   data-testid="patient-appointments-reschedule-reason"
-                  className="block w-full rounded-md border border-slate-300 p-2 text-sm"
+                  className="block w-full rounded-md border border-slate-300 dark:border-gray-600 p-2 text-sm"
                 />
               </label>
             </div>
             {/* Pinned footer — stays visible while the body scrolls so the
                 primary action is always reachable on small screens. */}
-            <div className="shrink-0 space-y-3 border-t border-slate-200 px-4 py-3">
+            <div className="shrink-0 space-y-3 border-t border-slate-200 dark:border-gray-700 px-4 py-3">
               {actionError ? (
                 <p
                   role="alert"
                   data-testid="patient-appointments-action-error"
-                  className="rounded-md bg-red-50 p-2 text-xs text-red-800"
+                  className="rounded-md bg-red-50 dark:bg-red-900/30 p-2 text-xs text-red-800 dark:text-red-200"
                 >
                   {actionError}
                 </p>
@@ -822,7 +822,7 @@ export default function PatientAppointmentsPage() {
                     setRescheduleDraft(null);
                     setActionError(null);
                   }}
-                  className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 px-4 text-sm font-medium text-slate-800"
+                  className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 dark:border-gray-600 px-4 text-sm font-medium text-slate-800 dark:text-gray-100"
                   data-testid="patient-appointments-reschedule-cancel-btn"
                 >
                   Cancel
@@ -857,16 +857,16 @@ export default function PatientAppointmentsPage() {
             }
           }}
         >
-          <div className="w-full max-w-md space-y-4 rounded-lg bg-white p-4 shadow-xl">
+          <div className="w-full max-w-md space-y-4 rounded-lg bg-white dark:bg-gray-800 p-4 shadow-xl">
             <h3 id="cancel-title" className="text-lg font-semibold">
               Cancel appointment
             </h3>
-            <p className="text-sm text-slate-700">
+            <p className="text-sm text-slate-700 dark:text-gray-200">
               Are you sure you want to cancel this appointment?
             </p>
             <label className="block text-sm">
-              <span className="mb-1 block font-medium text-slate-700">
-                Reason <span className="text-red-600">*</span>
+              <span className="mb-1 block font-medium text-slate-700 dark:text-gray-200">
+                Reason <span className="text-red-600 dark:text-red-300">*</span>
               </span>
               <textarea
                 value={cancelDraft.reason}
@@ -877,9 +877,9 @@ export default function PatientAppointmentsPage() {
                 maxLength={500}
                 placeholder="e.g. Schedule conflict; feeling better"
                 data-testid="patient-appointments-cancel-reason"
-                className="block w-full rounded-md border border-slate-300 p-2 text-sm"
+                className="block w-full rounded-md border border-slate-300 dark:border-gray-600 p-2 text-sm"
               />
-              <span className="mt-1 block text-xs text-slate-500">
+              <span className="mt-1 block text-xs text-slate-500 dark:text-gray-400">
                 {cancelDraft.reason.trim().length} / 500 characters (min 3)
               </span>
             </label>
@@ -887,7 +887,7 @@ export default function PatientAppointmentsPage() {
               <p
                 role="alert"
                 data-testid="patient-appointments-action-error"
-                className="rounded-md bg-red-50 p-2 text-xs text-red-800"
+                className="rounded-md bg-red-50 dark:bg-red-900/30 p-2 text-xs text-red-800 dark:text-red-200"
               >
                 {actionError}
               </p>
@@ -899,7 +899,7 @@ export default function PatientAppointmentsPage() {
                   setCancelDraft(null);
                   setActionError(null);
                 }}
-                className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 px-4 text-sm font-medium text-slate-800"
+                className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 dark:border-gray-600 px-4 text-sm font-medium text-slate-800 dark:text-gray-100"
                 data-testid="patient-appointments-cancel-keep-btn"
               >
                 Keep appointment
@@ -963,33 +963,33 @@ function AppointmentCard({
     <li
       data-testid="patient-appointments-row"
       data-appointment-id={appointment.id}
-      className="space-y-2 rounded-lg border border-slate-200 bg-white p-4 shadow-sm"
+      className="space-y-2 rounded-lg border border-slate-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 shadow-sm"
     >
       <div className="flex flex-wrap items-start justify-between gap-2">
         <div className="space-y-1">
-          <p className="text-base font-semibold text-slate-900">
+          <p className="text-base font-semibold text-slate-900 dark:text-gray-100">
             {appointment.doctor?.user?.name
               ? `Dr. ${appointment.doctor.user.name}`
               : "Doctor TBA"}
           </p>
           {appointment.doctor?.specialty ? (
-            <p className="text-sm text-slate-600">
+            <p className="text-sm text-slate-600 dark:text-gray-300">
               {appointment.doctor.specialty}
             </p>
           ) : null}
           <p
             data-testid="patient-appointments-row-when"
-            className="text-sm text-slate-700"
+            className="text-sm text-slate-700 dark:text-gray-200"
           >
             {when}
           </p>
           {appointment.tokenNumber ? (
-            <p className="text-xs text-slate-600">
+            <p className="text-xs text-slate-600 dark:text-gray-300">
               Token #{appointment.tokenNumber}
             </p>
           ) : null}
           {appointment.branch?.name ? (
-            <p className="text-xs text-slate-600">
+            <p className="text-xs text-slate-600 dark:text-gray-300">
               {appointment.branch.name}
             </p>
           ) : null}
@@ -1009,7 +1009,7 @@ function AppointmentCard({
           {arrived ? (
             <span
               data-testid={`patient-arrived-pill-${appointment.id}`}
-              className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md bg-emerald-100 px-4 text-sm font-medium text-emerald-900"
+              className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md bg-emerald-100 dark:bg-emerald-900/40 px-4 text-sm font-medium text-emerald-900 dark:text-emerald-200"
               aria-live="polite"
             >
               Arrived ✓
@@ -1040,7 +1040,7 @@ function AppointmentCard({
               type="button"
               onClick={onCancel ?? undefined}
               data-testid="patient-appointments-cancel-btn"
-              className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-red-300 px-4 text-sm font-medium text-red-800"
+              className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-red-300 dark:border-red-800 px-4 text-sm font-medium text-red-800 dark:text-red-200"
             >
               Cancel
             </button>
@@ -1051,7 +1051,7 @@ function AppointmentCard({
               target="_blank"
               rel="noopener noreferrer"
               data-testid="patient-appointments-share-location"
-              className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 px-4 text-sm font-medium text-slate-800"
+              className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 dark:border-gray-600 px-4 text-sm font-medium text-slate-800 dark:text-gray-100"
             >
               Share location
             </a>

--- a/apps/web/src/app/patient/bills/[id]/page.tsx
+++ b/apps/web/src/app/patient/bills/[id]/page.tsx
@@ -171,11 +171,11 @@ function isOverdue(inv: InvoiceDetail): boolean {
 }
 
 function statusPillClass(inv: InvoiceDetail): string {
-  if (inv.paymentStatus === "PAID") return "bg-emerald-100 text-emerald-900";
-  if (inv.paymentStatus === "REFUNDED") return "bg-slate-200 text-slate-700";
-  if (isOverdue(inv)) return "bg-red-100 text-red-900";
-  if (inv.paymentStatus === "PARTIAL") return "bg-amber-100 text-amber-900";
-  return "bg-blue-100 text-blue-900";
+  if (inv.paymentStatus === "PAID") return "bg-emerald-100 dark:bg-emerald-900/40 text-emerald-900 dark:text-emerald-200";
+  if (inv.paymentStatus === "REFUNDED") return "bg-slate-200 dark:bg-gray-700 text-slate-700 dark:text-gray-200";
+  if (isOverdue(inv)) return "bg-red-100 dark:bg-red-900/40 text-red-900 dark:text-red-200";
+  if (inv.paymentStatus === "PARTIAL") return "bg-amber-100 dark:bg-amber-900/40 text-amber-900 dark:text-amber-200";
+  return "bg-blue-100 dark:bg-blue-900/40 text-blue-900 dark:text-blue-200";
 }
 
 function statusPillLabel(inv: InvoiceDetail): string {
@@ -187,17 +187,17 @@ function statusPillLabel(inv: InvoiceDetail): string {
 function paymentModePillClass(mode: string): string {
   switch (mode) {
     case "CASH":
-      return "bg-emerald-100 text-emerald-900";
+      return "bg-emerald-100 dark:bg-emerald-900/40 text-emerald-900 dark:text-emerald-200";
     case "CARD":
       return "bg-indigo-100 text-indigo-900";
     case "UPI":
-      return "bg-violet-100 text-violet-900";
+      return "bg-violet-100 dark:bg-violet-900/40 text-violet-900 dark:text-violet-200";
     case "ONLINE":
-      return "bg-sky-100 text-sky-900";
+      return "bg-sky-100 dark:bg-sky-900/40 text-sky-900 dark:text-sky-200";
     case "INSURANCE":
-      return "bg-amber-100 text-amber-900";
+      return "bg-amber-100 dark:bg-amber-900/40 text-amber-900 dark:text-amber-200";
     default:
-      return "bg-slate-100 text-slate-700";
+      return "bg-slate-100 dark:bg-gray-800 text-slate-700 dark:text-gray-200";
   }
 }
 
@@ -316,7 +316,7 @@ export default function PatientBillDetailPage() {
     return (
       <section
         data-testid="patient-bill-detail-loading"
-        className="flex min-h-[40vh] items-center justify-center text-sm text-slate-500"
+        className="flex min-h-[40vh] items-center justify-center text-sm text-slate-500 dark:text-gray-400"
       >
         Loading invoice…
       </section>
@@ -330,7 +330,7 @@ export default function PatientBillDetailPage() {
         className="space-y-4 py-6"
       >
         <h1 className="text-2xl font-semibold tracking-tight">Sign in</h1>
-        <p className="text-base text-slate-600">
+        <p className="text-base text-slate-600 dark:text-gray-300">
           Please sign in to view this invoice.
         </p>
         <Link
@@ -353,7 +353,7 @@ export default function PatientBillDetailPage() {
         <h1 className="text-2xl font-semibold tracking-tight">
           Invoice not found
         </h1>
-        <p className="text-base text-slate-600">
+        <p className="text-base text-slate-600 dark:text-gray-300">
           We couldn&apos;t find this invoice. It may have been removed, or
           you may not have access to it.
         </p>
@@ -373,7 +373,7 @@ export default function PatientBillDetailPage() {
       <section
         data-testid="patient-bill-detail-error"
         role="alert"
-        className="rounded-md border border-red-300 bg-red-50 p-4 text-sm text-red-800"
+        className="rounded-md border border-red-300 dark:border-red-800 bg-red-50 dark:bg-red-900/30 p-4 text-sm text-red-800 dark:text-red-200"
       >
         Something went wrong loading this invoice. Please refresh.
       </section>
@@ -399,7 +399,7 @@ export default function PatientBillDetailPage() {
         <Link
           href="/patient/bills"
           data-testid="patient-bill-detail-back"
-          className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 px-4 text-sm font-medium text-slate-800"
+          className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 dark:border-gray-600 px-4 text-sm font-medium text-slate-800 dark:text-gray-100"
         >
           ← Back to bills
         </Link>
@@ -408,30 +408,30 @@ export default function PatientBillDetailPage() {
       {/* ─── Header ────────────────────────────────────────────────────── */}
       <header
         data-testid="patient-bill-detail-header"
-        className="space-y-3 rounded-lg border border-slate-200 bg-white p-4 shadow-sm"
+        className="space-y-3 rounded-lg border border-slate-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 shadow-sm"
       >
         <div className="flex flex-wrap items-start justify-between gap-2">
           <div className="space-y-1">
             <p
               data-testid="patient-bill-detail-number"
-              className="text-xs font-medium uppercase tracking-wide text-slate-500"
+              className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-gray-400"
             >
               Invoice #{invoice.invoiceNumber}
             </p>
             <p
               data-testid="patient-bill-detail-total"
-              className="text-2xl font-semibold text-slate-900"
+              className="text-2xl font-semibold text-slate-900 dark:text-gray-100"
             >
               {formatRupees(Number(invoice.totalAmount))}
             </p>
-            <p className="text-xs text-slate-600">
+            <p className="text-xs text-slate-600 dark:text-gray-300">
               Issued {formatDate(invoice.createdAt)}
             </p>
             {invoice.dueDate ? (
               <p
                 data-testid="patient-bill-detail-due"
                 className={`text-xs font-medium ${
-                  overdue ? "text-red-700" : "text-slate-600"
+                  overdue ? "text-red-700 dark:text-red-300" : "text-slate-600 dark:text-gray-300"
                 }`}
               >
                 Due {formatDate(invoice.dueDate)}
@@ -454,18 +454,18 @@ export default function PatientBillDetailPage() {
       <section
         data-testid="patient-bill-detail-items"
         aria-labelledby="items-heading"
-        className="space-y-3 rounded-lg border border-slate-200 bg-white p-4 shadow-sm"
+        className="space-y-3 rounded-lg border border-slate-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 shadow-sm"
       >
         <h2
           id="items-heading"
-          className="text-sm font-medium uppercase tracking-wide text-slate-500"
+          className="text-sm font-medium uppercase tracking-wide text-slate-500 dark:text-gray-400"
         >
           Line items
         </h2>
         {items.length === 0 ? (
           <p
             data-testid="patient-bill-detail-items-empty"
-            className="rounded-md border border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-600"
+            className="rounded-md border border-dashed border-slate-300 dark:border-gray-600 bg-slate-50 dark:bg-gray-900 p-4 text-sm text-slate-600 dark:text-gray-300"
           >
             No line items on this invoice.
           </p>
@@ -473,7 +473,7 @@ export default function PatientBillDetailPage() {
           <div className="overflow-x-auto">
             <table className="w-full min-w-[640px] text-left text-sm">
               <thead>
-                <tr className="border-b border-slate-200 text-xs uppercase tracking-wide text-slate-500">
+                <tr className="border-b border-slate-200 dark:border-gray-700 text-xs uppercase tracking-wide text-slate-500 dark:text-gray-400">
                   <th className="py-2 pr-3 font-medium">Description</th>
                   <th className="py-2 pr-3 font-medium">HSN/SAC</th>
                   <th className="py-2 pr-3 text-right font-medium">Qty</th>
@@ -495,21 +495,21 @@ export default function PatientBillDetailPage() {
                       key={it.id}
                       data-testid="patient-bill-detail-item-row"
                       data-item-id={it.id}
-                      className="border-b border-slate-100 last:border-b-0 text-slate-800"
+                      className="border-b border-slate-100 dark:border-gray-800 last:border-b-0 text-slate-800 dark:text-gray-100"
                     >
                       <td className="py-2 pr-3">
-                        <div className="font-medium text-slate-900">
+                        <div className="font-medium text-slate-900 dark:text-gray-100">
                           {it.description}
                         </div>
                         {it.category ? (
-                          <div className="text-xs text-slate-500">
+                          <div className="text-xs text-slate-500 dark:text-gray-400">
                             {it.category}
                           </div>
                         ) : null}
                       </td>
                       <td
                         data-testid="patient-bill-detail-item-hsn"
-                        className="py-2 pr-3 text-xs text-slate-600"
+                        className="py-2 pr-3 text-xs text-slate-600 dark:text-gray-300"
                       >
                         {it.hsnSac || "—"}
                       </td>
@@ -533,8 +533,8 @@ export default function PatientBillDetailPage() {
                 })}
               </tbody>
               <tfoot>
-                <tr className="text-slate-700">
-                  <td colSpan={6} className="pt-3 pr-3 text-right text-xs uppercase tracking-wide text-slate-500">
+                <tr className="text-slate-700 dark:text-gray-200">
+                  <td colSpan={6} className="pt-3 pr-3 text-right text-xs uppercase tracking-wide text-slate-500 dark:text-gray-400">
                     Subtotal
                   </td>
                   <td
@@ -545,33 +545,33 @@ export default function PatientBillDetailPage() {
                   </td>
                 </tr>
                 {headerDiscount > 0 ? (
-                  <tr className="text-slate-700">
-                    <td colSpan={6} className="pr-3 text-right text-xs uppercase tracking-wide text-slate-500">
+                  <tr className="text-slate-700 dark:text-gray-200">
+                    <td colSpan={6} className="pr-3 text-right text-xs uppercase tracking-wide text-slate-500 dark:text-gray-400">
                       Discount
                     </td>
                     <td
                       data-testid="patient-bill-detail-discount"
-                      className="text-right tabular-nums text-emerald-700"
+                      className="text-right tabular-nums text-emerald-700 dark:text-emerald-300"
                     >
                       − {formatRupees(headerDiscount)}
                     </td>
                   </tr>
                 ) : null}
                 {headerAdvance > 0 ? (
-                  <tr className="text-slate-700">
-                    <td colSpan={6} className="pr-3 text-right text-xs uppercase tracking-wide text-slate-500">
+                  <tr className="text-slate-700 dark:text-gray-200">
+                    <td colSpan={6} className="pr-3 text-right text-xs uppercase tracking-wide text-slate-500 dark:text-gray-400">
                       Advance applied
                     </td>
                     <td
                       data-testid="patient-bill-detail-advance"
-                      className="text-right tabular-nums text-emerald-700"
+                      className="text-right tabular-nums text-emerald-700 dark:text-emerald-300"
                     >
                       − {formatRupees(headerAdvance)}
                     </td>
                   </tr>
                 ) : null}
-                <tr className="text-slate-700">
-                  <td colSpan={6} className="pr-3 text-right text-xs uppercase tracking-wide text-slate-500">
+                <tr className="text-slate-700 dark:text-gray-200">
+                  <td colSpan={6} className="pr-3 text-right text-xs uppercase tracking-wide text-slate-500 dark:text-gray-400">
                     Total tax (CGST + SGST)
                   </td>
                   <td
@@ -581,7 +581,7 @@ export default function PatientBillDetailPage() {
                     {formatRupees(headerTax)}
                   </td>
                 </tr>
-                <tr className="border-t border-slate-200 text-slate-900">
+                <tr className="border-t border-slate-200 dark:border-gray-700 text-slate-900 dark:text-gray-100">
                   <td colSpan={6} className="pt-2 pr-3 text-right text-sm font-semibold uppercase tracking-wide">
                     Grand total
                   </td>
@@ -602,18 +602,18 @@ export default function PatientBillDetailPage() {
       <section
         data-testid="patient-bill-detail-payments"
         aria-labelledby="payments-heading"
-        className="space-y-3 rounded-lg border border-slate-200 bg-white p-4 shadow-sm"
+        className="space-y-3 rounded-lg border border-slate-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 shadow-sm"
       >
         <h2
           id="payments-heading"
-          className="text-sm font-medium uppercase tracking-wide text-slate-500"
+          className="text-sm font-medium uppercase tracking-wide text-slate-500 dark:text-gray-400"
         >
           Payments
         </h2>
         {payments.length === 0 ? (
           <p
             data-testid="patient-bill-detail-payments-empty"
-            className="rounded-md border border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-600"
+            className="rounded-md border border-dashed border-slate-300 dark:border-gray-600 bg-slate-50 dark:bg-gray-900 p-4 text-sm text-slate-600 dark:text-gray-300"
           >
             No payments recorded yet.
           </p>
@@ -626,14 +626,14 @@ export default function PatientBillDetailPage() {
                   key={p.id}
                   data-testid="patient-bill-detail-payment-row"
                   data-payment-id={p.id}
-                  className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-2"
+                  className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-slate-200 dark:border-gray-700 bg-slate-50 dark:bg-gray-900 px-3 py-2"
                 >
                   <div className="space-y-0.5">
-                    <p className="text-sm font-medium text-slate-900">
+                    <p className="text-sm font-medium text-slate-900 dark:text-gray-100">
                       {refund ? "Refund " : ""}
                       {formatRupees(Number(p.amount))}
                     </p>
-                    <p className="text-xs text-slate-600">
+                    <p className="text-xs text-slate-600 dark:text-gray-300">
                       {formatDateTime(p.paidAt)}
                       {p.transactionId ? ` · Ref ${p.transactionId}` : ""}
                     </p>
@@ -658,34 +658,34 @@ export default function PatientBillDetailPage() {
       <section
         data-testid="patient-bill-detail-outstanding"
         aria-labelledby="outstanding-heading"
-        className="space-y-3 rounded-lg border border-slate-200 bg-white p-4 shadow-sm"
+        className="space-y-3 rounded-lg border border-slate-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 shadow-sm"
       >
         <h2
           id="outstanding-heading"
-          className="text-sm font-medium uppercase tracking-wide text-slate-500"
+          className="text-sm font-medium uppercase tracking-wide text-slate-500 dark:text-gray-400"
         >
           Outstanding
         </h2>
         <div className="grid grid-cols-2 gap-3 text-sm">
           <div>
-            <p className="text-xs uppercase tracking-wide text-slate-500">
+            <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-gray-400">
               Paid to date
             </p>
             <p
               data-testid="patient-bill-detail-paid"
-              className="text-base font-semibold text-slate-900 tabular-nums"
+              className="text-base font-semibold text-slate-900 dark:text-gray-100 tabular-nums"
             >
               {formatRupees(paid)}
             </p>
           </div>
           <div>
-            <p className="text-xs uppercase tracking-wide text-slate-500">
+            <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-gray-400">
               Due
             </p>
             <p
               data-testid="patient-bill-detail-due-amount"
               className={`text-base font-semibold tabular-nums ${
-                due > 0 ? "text-red-700" : "text-slate-700"
+                due > 0 ? "text-red-700 dark:text-red-300" : "text-slate-700 dark:text-gray-200"
               }`}
             >
               {formatRupees(due)}
@@ -708,18 +708,18 @@ export default function PatientBillDetailPage() {
         <section
           data-testid="patient-bill-detail-stepper"
           aria-labelledby="nhcx-heading"
-          className="space-y-3 rounded-lg border border-slate-200 bg-white p-4 shadow-sm"
+          className="space-y-3 rounded-lg border border-slate-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 shadow-sm"
         >
           <h2
             id="nhcx-heading"
-            className="text-sm font-medium uppercase tracking-wide text-slate-500"
+            className="text-sm font-medium uppercase tracking-wide text-slate-500 dark:text-gray-400"
           >
             Cashless claim status
           </h2>
           {claim?.insuranceProvider ? (
             <p
               data-testid="patient-bill-detail-stepper-provider"
-              className="text-xs text-slate-600"
+              className="text-xs text-slate-600 dark:text-gray-300"
             >
               {claim.insuranceProvider}
               {claim?.claimAmount != null
@@ -740,8 +740,8 @@ export default function PatientBillDetailPage() {
               const cls = active
                 ? "bg-slate-900 text-white"
                 : done
-                  ? "bg-emerald-100 text-emerald-900"
-                  : "bg-slate-100 text-slate-600";
+                  ? "bg-emerald-100 dark:bg-emerald-900/40 text-emerald-900 dark:text-emerald-200"
+                  : "bg-slate-100 dark:bg-gray-800 text-slate-600 dark:text-gray-300";
               return (
                 <span
                   key={stage.key}
@@ -755,7 +755,7 @@ export default function PatientBillDetailPage() {
               );
             })}
           </div>
-          <p className="text-xs text-slate-500">
+          <p className="text-xs text-slate-500 dark:text-gray-400">
             Stage 1 displays a stub stepper; live insurer integration is
             Stage 3.
           </p>
@@ -766,15 +766,15 @@ export default function PatientBillDetailPage() {
       <section
         data-testid="patient-bill-detail-gst"
         aria-labelledby="gst-heading"
-        className="space-y-3 rounded-lg border border-slate-200 bg-white p-4 shadow-sm"
+        className="space-y-3 rounded-lg border border-slate-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 shadow-sm"
       >
         <h2
           id="gst-heading"
-          className="text-sm font-medium uppercase tracking-wide text-slate-500"
+          className="text-sm font-medium uppercase tracking-wide text-slate-500 dark:text-gray-400"
         >
           GST invoice
         </h2>
-        <p className="text-xs text-slate-600">
+        <p className="text-xs text-slate-600 dark:text-gray-300">
           A printable GST-format invoice is available for your records.
         </p>
         <a
@@ -782,7 +782,7 @@ export default function PatientBillDetailPage() {
           target="_blank"
           rel="noopener noreferrer"
           data-testid="patient-bill-detail-gst-btn"
-          className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 px-4 text-sm font-medium text-slate-800"
+          className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 dark:border-gray-600 px-4 text-sm font-medium text-slate-800 dark:text-gray-100"
         >
           Download GST invoice PDF
         </a>

--- a/apps/web/src/app/patient/bills/[id]/pay/page.tsx
+++ b/apps/web/src/app/patient/bills/[id]/pay/page.tsx
@@ -266,7 +266,7 @@ export default function PatientBillPayPage() {
     return (
       <section
         data-testid="patient-bill-pay-loading"
-        className="flex min-h-[40vh] items-center justify-center text-sm text-slate-500"
+        className="flex min-h-[40vh] items-center justify-center text-sm text-slate-500 dark:text-gray-400"
       >
         Loading payment…
       </section>
@@ -280,7 +280,7 @@ export default function PatientBillPayPage() {
         className="space-y-4 py-6"
       >
         <h1 className="text-2xl font-semibold tracking-tight">Sign in</h1>
-        <p className="text-base text-slate-600">
+        <p className="text-base text-slate-600 dark:text-gray-300">
           Please sign in to pay this bill.
         </p>
         <Link
@@ -303,7 +303,7 @@ export default function PatientBillPayPage() {
         <h1 className="text-2xl font-semibold tracking-tight">
           Invoice not found
         </h1>
-        <p className="text-base text-slate-600">
+        <p className="text-base text-slate-600 dark:text-gray-300">
           We couldn&apos;t find this invoice. It may have been removed, or you
           may not have access to it.
         </p>
@@ -330,7 +330,7 @@ export default function PatientBillPayPage() {
         <h1 className="text-2xl font-semibold tracking-tight">
           {fullyPaid ? "Invoice already paid" : "Online payment unavailable"}
         </h1>
-        <p className="text-base text-slate-600">
+        <p className="text-base text-slate-600 dark:text-gray-300">
           {fullyPaid
             ? `Invoice #${invoice.invoiceNumber} has no outstanding balance.`
             : "Online payment is not configured for this hospital right now. Please pay at the reception desk."}
@@ -351,7 +351,7 @@ export default function PatientBillPayPage() {
       <section
         data-testid="patient-bill-pay-error"
         role="alert"
-        className="space-y-3 rounded-md border border-red-300 bg-red-50 p-4 text-sm text-red-800"
+        className="space-y-3 rounded-md border border-red-300 dark:border-red-800 bg-red-50 dark:bg-red-900/30 p-4 text-sm text-red-800 dark:text-red-200"
       >
         <p>{errorMessage ?? "Something went wrong. Please refresh."}</p>
         <button
@@ -393,7 +393,7 @@ export default function PatientBillPayPage() {
         <Link
           href={`/patient/bills/${invoice.id}`}
           data-testid="patient-bill-pay-back"
-          className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 px-4 text-sm font-medium text-slate-800"
+          className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 dark:border-gray-600 px-4 text-sm font-medium text-slate-800 dark:text-gray-100"
         >
           ← Back to invoice
         </Link>
@@ -402,21 +402,21 @@ export default function PatientBillPayPage() {
       {/* ─── Summary card ─────────────────────────────────────────────── */}
       <header
         data-testid="patient-bill-pay-summary"
-        className="space-y-2 rounded-lg border border-slate-200 bg-white p-4 shadow-sm"
+        className="space-y-2 rounded-lg border border-slate-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 shadow-sm"
       >
         <p
           data-testid="patient-bill-pay-number"
-          className="text-xs font-medium uppercase tracking-wide text-slate-500"
+          className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-gray-400"
         >
           Invoice #{invoice.invoiceNumber}
         </p>
         <p
           data-testid="patient-bill-pay-due"
-          className="text-3xl font-semibold text-slate-900 tabular-nums"
+          className="text-3xl font-semibold text-slate-900 dark:text-gray-100 tabular-nums"
         >
           {formatRupees(due)}
         </p>
-        <p className="text-xs text-slate-600">
+        <p className="text-xs text-slate-600 dark:text-gray-300">
           Pay via UPI, card, or netbanking — secured by Razorpay.
         </p>
       </header>
@@ -426,7 +426,7 @@ export default function PatientBillPayPage() {
         <section
           data-testid="patient-bill-pay-success"
           role="status"
-          className="space-y-3 rounded-md border border-emerald-300 bg-emerald-50 p-4 text-sm text-emerald-900"
+          className="space-y-3 rounded-md border border-emerald-300 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-900/30 p-4 text-sm text-emerald-900 dark:text-emerald-200"
         >
           <p className="text-base font-medium">Payment received.</p>
           <p>
@@ -447,7 +447,7 @@ export default function PatientBillPayPage() {
         <section
           data-testid="patient-bill-pay-cancelled"
           role="status"
-          className="space-y-2 rounded-md border border-amber-300 bg-amber-50 p-4 text-sm text-amber-900"
+          className="space-y-2 rounded-md border border-amber-300 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/30 p-4 text-sm text-amber-900 dark:text-amber-200"
         >
           <p className="font-medium">Payment cancelled.</p>
           <p>
@@ -460,7 +460,7 @@ export default function PatientBillPayPage() {
         <section
           data-testid="patient-bill-pay-error-banner"
           role="alert"
-          className="space-y-2 rounded-md border border-red-300 bg-red-50 p-4 text-sm text-red-800"
+          className="space-y-2 rounded-md border border-red-300 dark:border-red-800 bg-red-50 dark:bg-red-900/30 p-4 text-sm text-red-800 dark:text-red-200"
         >
           <p className="font-medium">Payment didn&apos;t go through.</p>
           <p>{errorMessage}</p>
@@ -489,7 +489,7 @@ export default function PatientBillPayPage() {
         </button>
       ) : null}
 
-      <p className="text-xs text-slate-500">
+      <p className="text-xs text-slate-500 dark:text-gray-400">
         You&apos;ll be charged exactly the amount above. Razorpay confirms
         within seconds; this page will update automatically.
       </p>

--- a/apps/web/src/app/patient/bills/page.tsx
+++ b/apps/web/src/app/patient/bills/page.tsx
@@ -157,11 +157,11 @@ function effectivelyPaid(row: InvoiceRow): boolean {
 }
 
 function statusPillClass(row: InvoiceRow): string {
-  if (effectivelyPaid(row)) return "bg-emerald-100 text-emerald-900";
-  if (row.paymentStatus === "REFUNDED") return "bg-slate-200 text-slate-700";
-  if (isOverdue(row)) return "bg-red-100 text-red-900";
-  if (row.paymentStatus === "PARTIAL") return "bg-amber-100 text-amber-900";
-  return "bg-blue-100 text-blue-900";
+  if (effectivelyPaid(row)) return "bg-emerald-100 dark:bg-emerald-900/40 text-emerald-900 dark:text-emerald-200";
+  if (row.paymentStatus === "REFUNDED") return "bg-slate-200 dark:bg-gray-700 text-slate-700 dark:text-gray-200";
+  if (isOverdue(row)) return "bg-red-100 dark:bg-red-900/40 text-red-900 dark:text-red-200";
+  if (row.paymentStatus === "PARTIAL") return "bg-amber-100 dark:bg-amber-900/40 text-amber-900 dark:text-amber-200";
+  return "bg-blue-100 dark:bg-blue-900/40 text-blue-900 dark:text-blue-200";
 }
 
 function statusPillLabel(row: InvoiceRow): string {
@@ -328,7 +328,7 @@ export default function PatientBillsPage() {
     return (
       <section
         data-testid="patient-bills-loading"
-        className="flex min-h-[40vh] items-center justify-center text-sm text-slate-500"
+        className="flex min-h-[40vh] items-center justify-center text-sm text-slate-500 dark:text-gray-400"
       >
         Loading your bills…
       </section>
@@ -339,7 +339,7 @@ export default function PatientBillsPage() {
     return (
       <section data-testid="patient-bills-unauth" className="space-y-4 py-6">
         <h1 className="text-2xl font-semibold tracking-tight">Sign in</h1>
-        <p className="text-base text-slate-600">
+        <p className="text-base text-slate-600 dark:text-gray-300">
           Please sign in to view your bills.
         </p>
         <Link
@@ -358,7 +358,7 @@ export default function PatientBillsPage() {
       <section
         data-testid="patient-bills-error"
         role="alert"
-        className="rounded-md border border-red-300 bg-red-50 p-4 text-sm text-red-800"
+        className="rounded-md border border-red-300 dark:border-red-800 bg-red-50 dark:bg-red-900/30 p-4 text-sm text-red-800 dark:text-red-200"
       >
         Something went wrong loading your bills. Please refresh.
       </section>
@@ -376,7 +376,7 @@ export default function PatientBillsPage() {
           {sortedOpen.length > 0 ? (
             <span
               data-testid="patient-bills-open-count"
-              className="rounded-full bg-slate-100 px-2 py-1 text-xs font-medium text-slate-700"
+              className="rounded-full bg-slate-100 dark:bg-gray-800 px-2 py-1 text-xs font-medium text-slate-700 dark:text-gray-200"
             >
               {sortedOpen.length} open
             </span>
@@ -385,7 +385,7 @@ export default function PatientBillsPage() {
         {totalOutstanding > 0 ? (
           <div
             data-testid="patient-bills-outstanding-total"
-            className="rounded-md bg-red-50 px-3 py-2 text-sm font-semibold text-red-900"
+            className="rounded-md bg-red-50 dark:bg-red-900/30 px-3 py-2 text-sm font-semibold text-red-900 dark:text-red-200"
           >
             Outstanding {formatRupees(totalOutstanding)}
           </div>
@@ -395,9 +395,9 @@ export default function PatientBillsPage() {
       {isEmpty ? (
         <div
           data-testid="patient-bills-empty"
-          className="space-y-3 rounded-lg border border-slate-200 bg-white p-6 text-center shadow-sm"
+          className="space-y-3 rounded-lg border border-slate-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6 text-center shadow-sm"
         >
-          <p className="text-base text-slate-700">
+          <p className="text-base text-slate-700 dark:text-gray-200">
             No bills yet. Invoices raised after a visit will appear here.
           </p>
         </div>
@@ -411,14 +411,14 @@ export default function PatientBillsPage() {
           >
             <h2
               id="open-heading"
-              className="text-sm font-medium uppercase tracking-wide text-slate-500"
+              className="text-sm font-medium uppercase tracking-wide text-slate-500 dark:text-gray-400"
             >
               Open
             </h2>
             {sortedOpen.length === 0 ? (
               <p
                 data-testid="patient-bills-open-empty"
-                className="rounded-md border border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-600"
+                className="rounded-md border border-dashed border-slate-300 dark:border-gray-600 bg-slate-50 dark:bg-gray-900 p-4 text-sm text-slate-600 dark:text-gray-300"
               >
                 No open bills. You&apos;re all caught up!
               </p>
@@ -437,7 +437,7 @@ export default function PatientBillsPage() {
                   disabled={loadingMore}
                   onClick={() => void fetchMoreOpen()}
                   data-testid="patient-bills-load-more"
-                  className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 px-6 text-sm font-medium text-slate-800 disabled:opacity-60"
+                  className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 dark:border-gray-600 px-6 text-sm font-medium text-slate-800 dark:text-gray-100 disabled:opacity-60"
                 >
                   {loadingMore ? "Loading…" : "Load more"}
                 </button>
@@ -455,7 +455,7 @@ export default function PatientBillsPage() {
               <div className="flex items-center justify-between">
                 <h2
                   id="paid-heading"
-                  className="text-sm font-medium uppercase tracking-wide text-slate-500"
+                  className="text-sm font-medium uppercase tracking-wide text-slate-500 dark:text-gray-400"
                 >
                   Paid
                 </h2>
@@ -464,7 +464,7 @@ export default function PatientBillsPage() {
                   onClick={() => setShowPaid((v) => !v)}
                   aria-expanded={showPaid}
                   data-testid="patient-bills-paid-toggle"
-                  className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 px-3 text-xs font-medium text-slate-800"
+                  className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 dark:border-gray-600 px-3 text-xs font-medium text-slate-800 dark:text-gray-100"
                 >
                   {showPaid ? "Hide paid bills" : "Show paid bills"}
                 </button>
@@ -473,7 +473,7 @@ export default function PatientBillsPage() {
                 sortedPaid.length === 0 ? (
                   <p
                     data-testid="patient-bills-paid-empty"
-                    className="rounded-md border border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-600"
+                    className="rounded-md border border-dashed border-slate-300 dark:border-gray-600 bg-slate-50 dark:bg-gray-900 p-4 text-sm text-slate-600 dark:text-gray-300"
                   >
                     No past bills yet.
                   </p>
@@ -518,27 +518,27 @@ function BillCard({ invoice }: CardProps) {
     <li
       data-testid="patient-bills-row"
       data-invoice-id={invoice.id}
-      className="space-y-3 rounded-lg border border-slate-200 bg-white p-4 shadow-sm"
+      className="space-y-3 rounded-lg border border-slate-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 shadow-sm"
     >
       <div className="flex flex-wrap items-start justify-between gap-2">
         <div className="space-y-1">
           <p
             data-testid="patient-bills-row-number"
-            className="text-xs font-medium uppercase tracking-wide text-slate-500"
+            className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-gray-400"
           >
             #{invoice.invoiceNumber}
           </p>
-          <p className="text-base font-semibold text-slate-900">
+          <p className="text-base font-semibold text-slate-900 dark:text-gray-100">
             {formatRupees(Number(invoice.totalAmount))}
           </p>
-          <p className="text-xs text-slate-600">
+          <p className="text-xs text-slate-600 dark:text-gray-300">
             Issued {formatDate(invoice.createdAt)}
           </p>
           {open && invoice.dueDate ? (
             <p
               data-testid="patient-bills-row-due"
               className={`text-xs font-medium ${
-                overdue ? "text-red-700" : "text-slate-600"
+                overdue ? "text-red-700 dark:text-red-300" : "text-slate-600 dark:text-gray-300"
               }`}
             >
               Due {formatDate(invoice.dueDate)}
@@ -548,7 +548,7 @@ function BillCard({ invoice }: CardProps) {
           {open && outstanding > 0 && outstanding !== Number(invoice.totalAmount) ? (
             <p
               data-testid="patient-bills-row-outstanding"
-              className="text-xs text-slate-700"
+              className="text-xs text-slate-700 dark:text-gray-200"
             >
               Outstanding {formatRupees(outstanding)}
             </p>
@@ -576,8 +576,8 @@ function BillCard({ invoice }: CardProps) {
             const cls = active
               ? "bg-slate-900 text-white"
               : done
-                ? "bg-emerald-100 text-emerald-900"
-                : "bg-slate-100 text-slate-600";
+                ? "bg-emerald-100 dark:bg-emerald-900/40 text-emerald-900 dark:text-emerald-200"
+                : "bg-slate-100 dark:bg-gray-800 text-slate-600 dark:text-gray-300";
             return (
               <span
                 key={stage.key}
@@ -606,7 +606,7 @@ function BillCard({ invoice }: CardProps) {
         <Link
           href={`/patient/bills/${invoice.id}`}
           data-testid="patient-bills-view-btn"
-          className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 px-4 text-sm font-medium text-slate-800"
+          className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 dark:border-gray-600 px-4 text-sm font-medium text-slate-800 dark:text-gray-100"
         >
           View detail
         </Link>
@@ -615,7 +615,7 @@ function BillCard({ invoice }: CardProps) {
           target="_blank"
           rel="noopener noreferrer"
           data-testid="patient-bills-gst-btn"
-          className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 px-4 text-sm font-medium text-slate-800"
+          className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 dark:border-gray-600 px-4 text-sm font-medium text-slate-800 dark:text-gray-100"
         >
           Download GST invoice
         </a>

--- a/apps/web/src/app/patient/book/page.tsx
+++ b/apps/web/src/app/patient/book/page.tsx
@@ -133,9 +133,9 @@ function modeBadge(mode: AppointmentMode | null | undefined): string {
 }
 
 function modeBadgeClass(mode: AppointmentMode | null | undefined): string {
-  if (mode === "SLOT") return "bg-violet-100 text-violet-900";
-  if (mode === "CALLING") return "bg-amber-100 text-amber-900";
-  return "bg-blue-100 text-blue-900"; // TOKEN + default
+  if (mode === "SLOT") return "bg-violet-100 dark:bg-violet-900/40 text-violet-900 dark:text-violet-200";
+  if (mode === "CALLING") return "bg-amber-100 dark:bg-amber-900/40 text-amber-900 dark:text-amber-200";
+  return "bg-blue-100 dark:bg-blue-900/40 text-blue-900 dark:text-blue-200"; // TOKEN + default
 }
 
 export default function PatientBookAppointmentPage() {
@@ -296,7 +296,7 @@ export default function PatientBookAppointmentPage() {
       <section
         data-testid="pwa-book-loading"
         aria-busy="true"
-        className="flex min-h-[40vh] items-center justify-center text-sm text-slate-500"
+        className="flex min-h-[40vh] items-center justify-center text-sm text-slate-500 dark:text-gray-400"
       >
         Loading…
       </section>
@@ -310,7 +310,7 @@ export default function PatientBookAppointmentPage() {
         className="space-y-4 py-6"
       >
         <h1 className="text-2xl font-semibold tracking-tight">Sign in</h1>
-        <p className="text-base text-slate-600">
+        <p className="text-base text-slate-600 dark:text-gray-300">
           Please sign in to book an appointment.
         </p>
         <Link
@@ -329,7 +329,7 @@ export default function PatientBookAppointmentPage() {
       <section
         data-testid="pwa-book-error"
         role="alert"
-        className="rounded-md border border-red-300 bg-red-50 p-4 text-sm text-red-800"
+        className="rounded-md border border-red-300 dark:border-red-800 bg-red-50 dark:bg-red-900/30 p-4 text-sm text-red-800 dark:text-red-200"
       >
         Something went wrong loading the booking page. Please refresh.
       </section>
@@ -342,7 +342,7 @@ export default function PatientBookAppointmentPage() {
         <h1 className="text-2xl font-semibold tracking-tight">
           Book an appointment
         </h1>
-        <p className="text-sm text-slate-600">
+        <p className="text-sm text-slate-600 dark:text-gray-300">
           {step === "pick-doctor"
             ? "Step 1 of 3 — pick your doctor"
             : step === "pick-date"
@@ -357,7 +357,7 @@ export default function PatientBookAppointmentPage() {
           {doctors.length === 0 ? (
             <p
               data-testid="pwa-book-doctors-empty"
-              className="rounded-md border border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-600"
+              className="rounded-md border border-dashed border-slate-300 dark:border-gray-600 bg-slate-50 dark:bg-gray-900 p-4 text-sm text-slate-600 dark:text-gray-300"
             >
               No doctors available right now. Please check back later.
             </p>
@@ -373,15 +373,15 @@ export default function PatientBookAppointmentPage() {
                       setSelectedSlot(null);
                       setStep("pick-date");
                     }}
-                    className="block w-full rounded-lg border border-slate-200 bg-white p-4 text-left shadow-sm hover:border-slate-400"
+                    className="block w-full rounded-lg border border-slate-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 text-left shadow-sm hover:border-slate-400"
                   >
                     <div className="flex items-start justify-between gap-3">
                       <div className="space-y-1">
-                        <p className="text-base font-semibold text-slate-900">
+                        <p className="text-base font-semibold text-slate-900 dark:text-gray-100">
                           {d.user?.name ? `Dr. ${d.user.name}` : "Doctor"}
                         </p>
                         {d.specialty ? (
-                          <p className="text-sm text-slate-600">
+                          <p className="text-sm text-slate-600 dark:text-gray-300">
                             {d.specialty}
                           </p>
                         ) : null}
@@ -404,15 +404,15 @@ export default function PatientBookAppointmentPage() {
       {/* ─── Step 2: date + mode-specific input ────────────────────────── */}
       {step === "pick-date" && selectedDoctor ? (
         <div className="space-y-4">
-          <div className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
-            <p className="text-sm text-slate-600">Booking with</p>
-            <p className="text-base font-semibold text-slate-900">
+          <div className="rounded-lg border border-slate-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 shadow-sm">
+            <p className="text-sm text-slate-600 dark:text-gray-300">Booking with</p>
+            <p className="text-base font-semibold text-slate-900 dark:text-gray-100">
               {selectedDoctor.user?.name
                 ? `Dr. ${selectedDoctor.user.name}`
                 : "Doctor"}
             </p>
             {selectedDoctor.specialty ? (
-              <p className="text-sm text-slate-600">
+              <p className="text-sm text-slate-600 dark:text-gray-300">
                 {selectedDoctor.specialty}
               </p>
             ) : null}
@@ -424,7 +424,7 @@ export default function PatientBookAppointmentPage() {
           </div>
 
           <label className="block text-sm">
-            <span className="mb-1 block font-medium text-slate-700">
+            <span className="mb-1 block font-medium text-slate-700 dark:text-gray-200">
               Pick a date
             </span>
             <input
@@ -433,20 +433,20 @@ export default function PatientBookAppointmentPage() {
               min={todayYmd()}
               onChange={(e) => setDate(e.target.value)}
               data-testid="pwa-book-date-input"
-              className="block h-11 w-full rounded-md border border-slate-300 px-3 text-sm"
+              className="block h-11 w-full rounded-md border border-slate-300 dark:border-gray-600 px-3 text-sm"
             />
           </label>
 
           {/* SLOT mode — availability grid */}
           {selectedDoctor.appointmentMode === "SLOT" ? (
             <div className="space-y-2">
-              <p className="text-sm font-medium text-slate-700">
+              <p className="text-sm font-medium text-slate-700 dark:text-gray-200">
                 Pick a time slot
               </p>
               {slotsLoading ? (
                 <p
                   data-testid="pwa-book-slots-loading"
-                  className="text-sm text-slate-500"
+                  className="text-sm text-slate-500 dark:text-gray-400"
                 >
                   Loading slots…
                 </p>
@@ -454,14 +454,14 @@ export default function PatientBookAppointmentPage() {
                 <p
                   data-testid="pwa-book-slots-blocked"
                   role="alert"
-                  className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900"
+                  className="rounded-md border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/30 p-3 text-sm text-amber-900 dark:text-amber-200"
                 >
                   {slotsBlocked.reason ?? "No slots on this date"}
                 </p>
               ) : slots.length === 0 ? (
                 <p
                   data-testid="pwa-book-slots-empty"
-                  className="rounded-md border border-dashed border-slate-300 bg-slate-50 p-3 text-sm text-slate-600"
+                  className="rounded-md border border-dashed border-slate-300 dark:border-gray-600 bg-slate-50 dark:bg-gray-900 p-3 text-sm text-slate-600 dark:text-gray-300"
                 >
                   No slots available on this date.
                 </p>
@@ -480,10 +480,10 @@ export default function PatientBookAppointmentPage() {
                       onClick={() => setSelectedSlot(s.startTime)}
                       className={`inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border px-2 text-xs font-medium ${
                         !s.isAvailable
-                          ? "cursor-not-allowed border-slate-200 bg-slate-100 text-slate-400"
+                          ? "cursor-not-allowed border-slate-200 dark:border-gray-700 bg-slate-100 dark:bg-gray-800 text-slate-400 dark:text-gray-500"
                           : selectedSlot === s.startTime
-                            ? "border-slate-900 bg-slate-900 text-white"
-                            : "border-slate-300 bg-white text-slate-800"
+                            ? "border-slate-900 dark:border-gray-300 bg-slate-900 text-white"
+                            : "border-slate-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-slate-800 dark:text-gray-100"
                       }`}
                     >
                       {s.startTime}
@@ -498,10 +498,10 @@ export default function PatientBookAppointmentPage() {
           {selectedDoctor.appointmentMode === "TOKEN" ? (
             <div
               data-testid="pwa-book-token-info"
-              className="rounded-md border border-blue-200 bg-blue-50 p-3 text-sm text-blue-900"
+              className="rounded-md border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-900/30 p-3 text-sm text-blue-900 dark:text-blue-200"
             >
               <p className="font-medium">Token mode</p>
-              <p className="text-blue-800">
+              <p className="text-blue-800 dark:text-blue-300">
                 You'll be issued the next available token when you confirm.
                 Your token number will appear on your appointments page.
               </p>
@@ -512,10 +512,10 @@ export default function PatientBookAppointmentPage() {
           {selectedDoctor.appointmentMode === "CALLING" ? (
             <div
               data-testid="pwa-book-calling-info"
-              className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900"
+              className="rounded-md border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/30 p-3 text-sm text-amber-900 dark:text-amber-200"
             >
               <p className="font-medium">Calling mode</p>
-              <p className="text-amber-800">
+              <p className="text-amber-800 dark:text-amber-300">
                 This doctor sees patients in arrival order. Confirm to join
                 the queue — you'll be called in turn on the clinic display.
               </p>
@@ -531,7 +531,7 @@ export default function PatientBookAppointmentPage() {
                 setSlots([]);
               }}
               data-testid="pwa-book-back-to-doctors"
-              className="inline-flex h-11 min-w-[44px] flex-1 items-center justify-center rounded-md border border-slate-300 px-4 text-sm font-medium text-slate-800"
+              className="inline-flex h-11 min-w-[44px] flex-1 items-center justify-center rounded-md border border-slate-300 dark:border-gray-600 px-4 text-sm font-medium text-slate-800 dark:text-gray-100"
             >
               Back
             </button>
@@ -557,15 +557,15 @@ export default function PatientBookAppointmentPage() {
         <div className="space-y-4">
           <div
             data-testid="pwa-book-summary"
-            className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm"
+            className="rounded-lg border border-slate-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 shadow-sm"
           >
-            <p className="text-sm font-medium uppercase tracking-wide text-slate-500">
+            <p className="text-sm font-medium uppercase tracking-wide text-slate-500 dark:text-gray-400">
               Review your booking
             </p>
             <dl className="mt-3 space-y-2 text-sm">
               <div className="flex justify-between gap-3">
-                <dt className="text-slate-600">Doctor</dt>
-                <dd className="font-medium text-slate-900">
+                <dt className="text-slate-600 dark:text-gray-300">Doctor</dt>
+                <dd className="font-medium text-slate-900 dark:text-gray-100">
                   {selectedDoctor.user?.name
                     ? `Dr. ${selectedDoctor.user.name}`
                     : "Doctor"}
@@ -573,12 +573,12 @@ export default function PatientBookAppointmentPage() {
               </div>
               {selectedDoctor.specialty ? (
                 <div className="flex justify-between gap-3">
-                  <dt className="text-slate-600">Specialty</dt>
-                  <dd className="text-slate-900">{selectedDoctor.specialty}</dd>
+                  <dt className="text-slate-600 dark:text-gray-300">Specialty</dt>
+                  <dd className="text-slate-900 dark:text-gray-100">{selectedDoctor.specialty}</dd>
                 </div>
               ) : null}
               <div className="flex justify-between gap-3">
-                <dt className="text-slate-600">Mode</dt>
+                <dt className="text-slate-600 dark:text-gray-300">Mode</dt>
                 <dd>
                   <span
                     className={`rounded-full px-2 py-1 text-xs font-medium ${modeBadgeClass(selectedDoctor.appointmentMode)}`}
@@ -588,15 +588,15 @@ export default function PatientBookAppointmentPage() {
                 </dd>
               </div>
               <div className="flex justify-between gap-3">
-                <dt className="text-slate-600">Date</dt>
-                <dd className="font-medium text-slate-900">{date}</dd>
+                <dt className="text-slate-600 dark:text-gray-300">Date</dt>
+                <dd className="font-medium text-slate-900 dark:text-gray-100">{date}</dd>
               </div>
               {selectedDoctor.appointmentMode === "SLOT" && selectedSlot ? (
                 <div className="flex justify-between gap-3">
-                  <dt className="text-slate-600">Time</dt>
+                  <dt className="text-slate-600 dark:text-gray-300">Time</dt>
                   <dd
                     data-testid="pwa-book-summary-slot"
-                    className="font-medium text-slate-900"
+                    className="font-medium text-slate-900 dark:text-gray-100"
                   >
                     {selectedSlot}
                   </dd>
@@ -604,16 +604,16 @@ export default function PatientBookAppointmentPage() {
               ) : null}
               {selectedDoctor.appointmentMode === "TOKEN" ? (
                 <div className="flex justify-between gap-3">
-                  <dt className="text-slate-600">Token</dt>
-                  <dd className="text-slate-700">
+                  <dt className="text-slate-600 dark:text-gray-300">Token</dt>
+                  <dd className="text-slate-700 dark:text-gray-200">
                     Issued at confirmation
                   </dd>
                 </div>
               ) : null}
               {selectedDoctor.appointmentMode === "CALLING" ? (
                 <div className="flex justify-between gap-3">
-                  <dt className="text-slate-600">Queue</dt>
-                  <dd className="text-slate-700">
+                  <dt className="text-slate-600 dark:text-gray-300">Queue</dt>
+                  <dd className="text-slate-700 dark:text-gray-200">
                     Joined on confirmation
                   </dd>
                 </div>
@@ -625,7 +625,7 @@ export default function PatientBookAppointmentPage() {
             <p
               role="alert"
               data-testid="pwa-book-submit-error"
-              className="rounded-md bg-red-50 p-2 text-sm text-red-800"
+              className="rounded-md bg-red-50 dark:bg-red-900/30 p-2 text-sm text-red-800 dark:text-red-200"
             >
               {submitError}
             </p>
@@ -637,7 +637,7 @@ export default function PatientBookAppointmentPage() {
               onClick={() => setStep("pick-date")}
               disabled={submitting}
               data-testid="pwa-book-back-to-date"
-              className="inline-flex h-11 min-w-[44px] flex-1 items-center justify-center rounded-md border border-slate-300 px-4 text-sm font-medium text-slate-800 disabled:opacity-60"
+              className="inline-flex h-11 min-w-[44px] flex-1 items-center justify-center rounded-md border border-slate-300 dark:border-gray-600 px-4 text-sm font-medium text-slate-800 dark:text-gray-100 disabled:opacity-60"
             >
               Back
             </button>

--- a/apps/web/src/app/patient/dashboard/page.tsx
+++ b/apps/web/src/app/patient/dashboard/page.tsx
@@ -398,7 +398,7 @@ export default function PatientDashboardPage() {
     return (
       <section
         data-testid="patient-dashboard-loading"
-        className="flex min-h-[40vh] items-center justify-center text-sm text-slate-500"
+        className="flex min-h-[40vh] items-center justify-center text-sm text-slate-500 dark:text-gray-400"
       >
         Loading your portal…
       </section>
@@ -412,7 +412,7 @@ export default function PatientDashboardPage() {
         className="space-y-4 py-6"
       >
         <h1 className="text-2xl font-semibold tracking-tight">Sign in</h1>
-        <p className="text-base text-slate-600">
+        <p className="text-base text-slate-600 dark:text-gray-300">
           Please sign in to view your appointments, prescriptions, and bills.
         </p>
         <Link
@@ -431,7 +431,7 @@ export default function PatientDashboardPage() {
       <section
         data-testid="patient-dashboard-error"
         role="alert"
-        className="rounded-md border border-red-300 bg-red-50 p-4 text-sm text-red-800"
+        className="rounded-md border border-red-300 bg-red-50 p-4 text-sm text-red-800 dark:border-red-800 dark:bg-red-900/30 dark:text-red-200"
       >
         Something went wrong loading your dashboard. Please refresh.
       </section>
@@ -446,13 +446,13 @@ export default function PatientDashboardPage() {
           data-testid="patient-abha-prompt-banner"
           role="region"
           aria-label="Link your ABHA Health ID"
-          className="flex flex-col gap-3 rounded-lg border border-sky-200 bg-sky-50 p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between"
+          className="flex flex-col gap-3 rounded-lg border border-sky-200 bg-sky-50 p-4 shadow-sm dark:border-sky-800 dark:bg-sky-900/30 sm:flex-row sm:items-center sm:justify-between"
         >
           <div className="space-y-1">
-            <p className="text-sm font-semibold text-sky-900">
+            <p className="text-sm font-semibold text-sky-900 dark:text-sky-200">
               Link your ABHA Health ID for portable medical records.
             </p>
-            <p className="text-xs text-sky-800">
+            <p className="text-xs text-sky-800 dark:text-sky-300">
               Skip for now if you don't have one — you can link it any time
               from your profile.
             </p>
@@ -468,7 +468,7 @@ export default function PatientDashboardPage() {
             <button
               type="button"
               onClick={dismissAbhaPrompt}
-              className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-sky-300 bg-white px-4 text-sm font-medium text-sky-900"
+              className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-sky-300 bg-white px-4 text-sm font-medium text-sky-900 dark:border-sky-700 dark:bg-gray-800 dark:text-sky-200"
               data-testid="patient-abha-prompt-skip"
             >
               Skip for now
@@ -484,33 +484,33 @@ export default function PatientDashboardPage() {
       {/* ─── Next Appointment ───────────────────────────────────────── */}
       <article
         data-testid="patient-dashboard-next-appointment"
-        className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm"
+        className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800"
       >
         <header className="mb-3">
-          <h2 className="text-sm font-medium uppercase tracking-wide text-slate-500">
+          <h2 className="text-sm font-medium uppercase tracking-wide text-slate-500 dark:text-gray-400">
             Next appointment
           </h2>
         </header>
         {nextAppointment ? (
           <div className="space-y-2">
-            <p className="text-base font-semibold text-slate-900">
+            <p className="text-base font-semibold text-slate-900 dark:text-gray-100">
               {nextAppointment.doctor?.user?.name
                 ? `Dr. ${nextAppointment.doctor.user.name}`
                 : "Doctor TBA"}
             </p>
             {nextAppointment.doctor?.specialty ? (
-              <p className="text-sm text-slate-600">
+              <p className="text-sm text-slate-600 dark:text-gray-300">
                 {nextAppointment.doctor.specialty}
               </p>
             ) : null}
             <p
               data-testid="patient-dashboard-next-appointment-when"
-              className="text-sm text-slate-700"
+              className="text-sm text-slate-700 dark:text-gray-200"
             >
               {formatApptWhen(nextAppointment)}
             </p>
             {nextAppointment.tokenNumber ? (
-              <p className="text-sm text-slate-600">
+              <p className="text-sm text-slate-600 dark:text-gray-300">
                 Token #{nextAppointment.tokenNumber}
               </p>
             ) : null}
@@ -526,7 +526,7 @@ export default function PatientDashboardPage() {
                 <span
                   data-testid="patient-dashboard-next-appointment-arrived-pill"
                   aria-live="polite"
-                  className="inline-flex h-11 min-w-[44px] flex-1 items-center justify-center rounded-md bg-emerald-100 px-4 text-sm font-medium text-emerald-900"
+                  className="inline-flex h-11 min-w-[44px] flex-1 items-center justify-center rounded-md bg-emerald-100 px-4 text-sm font-medium text-emerald-900 dark:bg-emerald-900/40 dark:text-emerald-200"
                 >
                   Arrived ✓
                 </span>
@@ -545,7 +545,7 @@ export default function PatientDashboardPage() {
                 <button
                   type="button"
                   disabled
-                  className="inline-flex h-11 min-w-[44px] flex-1 items-center justify-center rounded-md border border-slate-300 px-4 text-sm font-medium text-slate-400 disabled:cursor-not-allowed"
+                  className="inline-flex h-11 min-w-[44px] flex-1 items-center justify-center rounded-md border border-slate-300 dark:border-gray-600 px-4 text-sm font-medium text-slate-400 dark:text-gray-500 disabled:cursor-not-allowed"
                   data-testid="patient-dashboard-next-appointment-arrived"
                   title="Available on the day of your appointment"
                 >
@@ -557,7 +557,7 @@ export default function PatientDashboardPage() {
               <p
                 role="alert"
                 data-testid="patient-dashboard-arrive-error"
-                className="rounded-md bg-red-50 p-2 text-xs text-red-800"
+                className="rounded-md bg-red-50 p-2 text-xs text-red-800 dark:bg-red-900/30 dark:text-red-200"
               >
                 {arriveError}
               </p>
@@ -568,7 +568,7 @@ export default function PatientDashboardPage() {
             data-testid="patient-dashboard-next-appointment-empty"
             className="space-y-3"
           >
-            <p className="text-sm text-slate-600">
+            <p className="text-sm text-slate-600 dark:text-gray-300">
               You don't have any upcoming appointments.
             </p>
             <Link
@@ -585,16 +585,16 @@ export default function PatientDashboardPage() {
       {/* ─── Recent Prescriptions ───────────────────────────────────── */}
       <article
         data-testid="patient-dashboard-prescriptions"
-        className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm"
+        className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800"
       >
         <header className="mb-3 flex items-center justify-between">
-          <h2 className="text-sm font-medium uppercase tracking-wide text-slate-500">
+          <h2 className="text-sm font-medium uppercase tracking-wide text-slate-500 dark:text-gray-400">
             Recent prescriptions
           </h2>
           {prescriptions.length > 0 ? (
             <Link
               href="/patient/prescriptions"
-              className="text-xs font-medium text-slate-700 underline-offset-2 hover:underline"
+              className="text-xs font-medium text-slate-700 dark:text-gray-200 underline-offset-2 hover:underline"
               data-testid="patient-dashboard-prescriptions-all"
             >
               See all
@@ -602,7 +602,7 @@ export default function PatientDashboardPage() {
           ) : null}
         </header>
         {prescriptions.length > 0 ? (
-          <ul className="divide-y divide-slate-100">
+          <ul className="divide-y divide-slate-100 dark:divide-gray-700">
             {prescriptions.map((rx) => {
               const first = rx.items?.[0]?.medicineName ?? "Prescription";
               const more = Math.max(0, (rx.items?.length ?? 0) - 1);
@@ -612,13 +612,13 @@ export default function PatientDashboardPage() {
                   data-testid="patient-dashboard-prescription-row"
                   className="space-y-1 py-3 first:pt-0 last:pb-0"
                 >
-                  <p className="text-sm font-medium text-slate-900">
+                  <p className="text-sm font-medium text-slate-900 dark:text-gray-100">
                     {first}
                     {more > 0 ? (
-                      <span className="text-slate-500"> + {more} more</span>
+                      <span className="text-slate-500 dark:text-gray-400"> + {more} more</span>
                     ) : null}
                   </p>
-                  <p className="text-xs text-slate-600">
+                  <p className="text-xs text-slate-600 dark:text-gray-300">
                     {new Date(rx.createdAt).toLocaleDateString("en-IN", {
                       day: "2-digit",
                       month: "short",
@@ -631,7 +631,7 @@ export default function PatientDashboardPage() {
                   <div className="flex gap-2 pt-1">
                     <a
                       href={buildPdfUrl(rx.id)}
-                      className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 px-3 text-xs font-medium text-slate-800"
+                      className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 dark:border-gray-600 px-3 text-xs font-medium text-slate-800 dark:text-gray-100"
                       data-testid="patient-dashboard-prescription-download"
                       target="_blank"
                       rel="noopener noreferrer"
@@ -654,7 +654,7 @@ export default function PatientDashboardPage() {
                       type="button"
                       onClick={() => shareViaWhatsApp(rx.id)}
                       disabled={sharingRxId === rx.id}
-                      className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 px-3 text-xs font-medium text-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
+                      className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 dark:border-gray-600 px-3 text-xs font-medium text-slate-800 dark:text-gray-100 disabled:cursor-not-allowed disabled:opacity-60"
                       data-testid="patient-dashboard-prescription-share"
                     >
                       {sharingRxId === rx.id ? "Sharing…" : "Share on WhatsApp"}
@@ -667,7 +667,7 @@ export default function PatientDashboardPage() {
         ) : (
           <p
             data-testid="patient-dashboard-prescriptions-empty"
-            className="text-sm text-slate-600"
+            className="text-sm text-slate-600 dark:text-gray-300"
           >
             No prescriptions yet — they'll appear here after your next visit.
           </p>
@@ -677,16 +677,16 @@ export default function PatientDashboardPage() {
       {/* ─── Open Bills ─────────────────────────────────────────────── */}
       <article
         data-testid="patient-dashboard-bills"
-        className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm"
+        className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800"
       >
         <header className="mb-3 flex items-center justify-between">
-          <h2 className="text-sm font-medium uppercase tracking-wide text-slate-500">
+          <h2 className="text-sm font-medium uppercase tracking-wide text-slate-500 dark:text-gray-400">
             Open bills
           </h2>
           {invoices.length > 0 ? (
             <Link
               href="/patient/bills"
-              className="text-xs font-medium text-slate-700 underline-offset-2 hover:underline"
+              className="text-xs font-medium text-slate-700 dark:text-gray-200 underline-offset-2 hover:underline"
               data-testid="patient-dashboard-bills-all"
             >
               See all
@@ -697,16 +697,16 @@ export default function PatientDashboardPage() {
           <div className="space-y-3">
             <div
               data-testid="patient-dashboard-bills-total"
-              className="rounded-md bg-amber-50 p-3 text-sm"
+              className="rounded-md bg-amber-50 p-3 text-sm dark:bg-amber-900/30"
             >
-              <p className="font-semibold text-amber-900">
+              <p className="font-semibold text-amber-900 dark:text-amber-200">
                 {formatINR(openBillsTotal)} outstanding
               </p>
-              <p className="text-xs text-amber-800">
+              <p className="text-xs text-amber-800 dark:text-amber-300">
                 {invoices.length} open bill{invoices.length === 1 ? "" : "s"}
               </p>
             </div>
-            <ul className="divide-y divide-slate-100">
+            <ul className="divide-y divide-slate-100 dark:divide-gray-700">
               {invoices.map((inv) => {
                 const due =
                   toNumber(inv.totalAmount) - toNumber(inv.paidAmount);
@@ -727,10 +727,10 @@ export default function PatientDashboardPage() {
                     data-testid="patient-dashboard-bill-row"
                     className="space-y-1 py-3 first:pt-0 last:pb-0"
                   >
-                    <p className="text-sm font-medium text-slate-900">
+                    <p className="text-sm font-medium text-slate-900 dark:text-gray-100">
                       {inv.invoiceNumber}
                     </p>
-                    <p className="text-xs text-slate-600">
+                    <p className="text-xs text-slate-600 dark:text-gray-300">
                       {new Date(inv.createdAt).toLocaleDateString("en-IN", {
                         day: "2-digit",
                         month: "short",
@@ -741,7 +741,7 @@ export default function PatientDashboardPage() {
                     {isSettled ? (
                       <Link
                         href={`/patient/bills/${inv.id}`}
-                        className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 px-4 text-xs font-medium text-slate-800"
+                        className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 dark:border-gray-600 px-4 text-xs font-medium text-slate-800 dark:text-gray-100"
                         data-testid="patient-dashboard-bill-view"
                       >
                         View detail
@@ -763,7 +763,7 @@ export default function PatientDashboardPage() {
         ) : (
           <p
             data-testid="patient-dashboard-bills-empty"
-            className="text-sm text-slate-600"
+            className="text-sm text-slate-600 dark:text-gray-300"
           >
             No open bills — you're all paid up.
           </p>

--- a/apps/web/src/app/patient/prescriptions/page.tsx
+++ b/apps/web/src/app/patient/prescriptions/page.tsx
@@ -81,13 +81,13 @@ function formatDate(iso: string): string {
 }
 
 function statusPillClass(status: string | null | undefined): string {
-  if (!status) return "bg-slate-100 text-slate-700";
+  if (!status) return "bg-slate-100 dark:bg-gray-800 text-slate-700 dark:text-gray-200";
   if (status === "ACTIVE" || status === "ISSUED" || status === "SIGNED")
-    return "bg-emerald-100 text-emerald-900";
-  if (status === "DRAFT") return "bg-amber-100 text-amber-900";
+    return "bg-emerald-100 dark:bg-emerald-900/40 text-emerald-900 dark:text-emerald-200";
+  if (status === "DRAFT") return "bg-amber-100 dark:bg-amber-900/40 text-amber-900 dark:text-amber-200";
   if (status === "CANCELLED" || status === "REJECTED")
-    return "bg-slate-200 text-slate-700";
-  return "bg-slate-100 text-slate-700";
+    return "bg-slate-200 dark:bg-gray-700 text-slate-700 dark:text-gray-200";
+  return "bg-slate-100 dark:bg-gray-800 text-slate-700 dark:text-gray-200";
 }
 
 // Build the verify URL the public `/verify/rx/[id]` page accepts. On the
@@ -199,7 +199,7 @@ export default function PatientPrescriptionsPage() {
     return (
       <section
         data-testid="patient-prescriptions-loading"
-        className="flex min-h-[40vh] items-center justify-center text-sm text-slate-500"
+        className="flex min-h-[40vh] items-center justify-center text-sm text-slate-500 dark:text-gray-400"
       >
         Loading your prescriptions…
       </section>
@@ -213,7 +213,7 @@ export default function PatientPrescriptionsPage() {
         className="space-y-4 py-6"
       >
         <h1 className="text-2xl font-semibold tracking-tight">Sign in</h1>
-        <p className="text-base text-slate-600">
+        <p className="text-base text-slate-600 dark:text-gray-300">
           Please sign in to view your prescriptions.
         </p>
         <Link
@@ -232,7 +232,7 @@ export default function PatientPrescriptionsPage() {
       <section
         data-testid="patient-prescriptions-error"
         role="alert"
-        className="rounded-md border border-red-300 bg-red-50 p-4 text-sm text-red-800"
+        className="rounded-md border border-red-300 dark:border-red-800 bg-red-50 dark:bg-red-900/30 p-4 text-sm text-red-800 dark:text-red-200"
       >
         Something went wrong loading your prescriptions. Please refresh.
       </section>
@@ -255,7 +255,7 @@ export default function PatientPrescriptionsPage() {
           {total > 0 ? (
             <span
               data-testid="patient-prescriptions-count"
-              className="rounded-full bg-slate-100 px-2 py-1 text-xs font-medium text-slate-700"
+              className="rounded-full bg-slate-100 dark:bg-gray-800 px-2 py-1 text-xs font-medium text-slate-700 dark:text-gray-200"
             >
               {total}
             </span>
@@ -266,9 +266,9 @@ export default function PatientPrescriptionsPage() {
       {isEmpty ? (
         <div
           data-testid="patient-prescriptions-empty"
-          className="space-y-3 rounded-lg border border-slate-200 bg-white p-6 text-center shadow-sm"
+          className="space-y-3 rounded-lg border border-slate-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6 text-center shadow-sm"
         >
-          <p className="text-base text-slate-700">
+          <p className="text-base text-slate-700 dark:text-gray-200">
             No prescriptions yet. Your doctor will prescribe digital scripts
             here after a consult.
           </p>
@@ -293,7 +293,7 @@ export default function PatientPrescriptionsPage() {
             disabled={loadingMore}
             onClick={() => void fetchPage(page + 1, "append")}
             data-testid="patient-prescriptions-load-more"
-            className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 px-6 text-sm font-medium text-slate-800 disabled:opacity-60"
+            className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 dark:border-gray-600 px-6 text-sm font-medium text-slate-800 dark:text-gray-100 disabled:opacity-60"
           >
             {loadingMore ? "Loading…" : "Load more"}
           </button>
@@ -330,33 +330,33 @@ function PrescriptionCard({ prescription, onShare, sharing }: CardProps) {
     <li
       data-testid="patient-prescriptions-row"
       data-prescription-id={prescription.id}
-      className="space-y-2 rounded-lg border border-slate-200 bg-white p-4 shadow-sm"
+      className="space-y-2 rounded-lg border border-slate-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 shadow-sm"
     >
       <div className="flex flex-wrap items-start justify-between gap-2">
         <div className="space-y-1">
           <p
             data-testid="patient-prescriptions-row-date"
-            className="text-xs font-medium uppercase tracking-wide text-slate-500"
+            className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-gray-400"
           >
             {formatDate(prescription.createdAt)}
           </p>
-          <p className="text-base font-semibold text-slate-900">
+          <p className="text-base font-semibold text-slate-900 dark:text-gray-100">
             {doctorName ? `Dr. ${doctorName}` : "Doctor"}
           </p>
           {specialty ? (
-            <p className="text-sm text-slate-600">{specialty}</p>
+            <p className="text-sm text-slate-600 dark:text-gray-300">{specialty}</p>
           ) : null}
           <p
             data-testid="patient-prescriptions-row-items"
-            className="text-sm text-slate-700"
+            className="text-sm text-slate-700 dark:text-gray-200"
           >
             {first}
             {more > 0 ? (
-              <span className="text-slate-500"> · +{more} more</span>
+              <span className="text-slate-500 dark:text-gray-400"> · +{more} more</span>
             ) : null}
           </p>
           {prescription.diagnosis ? (
-            <p className="text-xs text-slate-500">
+            <p className="text-xs text-slate-500 dark:text-gray-400">
               Diagnosis: {prescription.diagnosis}
             </p>
           ) : null}
@@ -388,7 +388,7 @@ function PrescriptionCard({ prescription, onShare, sharing }: CardProps) {
           onClick={() => void onShare(prescription.id)}
           disabled={sharing}
           data-testid="patient-prescriptions-share-btn"
-          className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-emerald-300 bg-emerald-50 px-4 text-sm font-medium text-emerald-900 disabled:cursor-not-allowed disabled:opacity-60"
+          className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-emerald-300 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-900/30 px-4 text-sm font-medium text-emerald-900 dark:text-emerald-200 disabled:cursor-not-allowed disabled:opacity-60"
         >
           {sharing ? "Sharing…" : "Share via WhatsApp"}
         </button>
@@ -397,7 +397,7 @@ function PrescriptionCard({ prescription, onShare, sharing }: CardProps) {
           target="_blank"
           rel="noopener noreferrer"
           data-testid="patient-prescriptions-verify-btn"
-          className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 px-4 text-sm font-medium text-slate-800"
+          className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 dark:border-gray-600 px-4 text-sm font-medium text-slate-800 dark:text-gray-100"
         >
           Verify QR
         </a>

--- a/apps/web/src/app/patient/records/page.tsx
+++ b/apps/web/src/app/patient/records/page.tsx
@@ -124,9 +124,9 @@ const TYPE_LABEL: Record<EntryType, string> = {
 };
 
 const TYPE_PILL_CLASS: Record<EntryType, string> = {
-  appointment: "bg-blue-100 text-blue-900",
-  prescription: "bg-emerald-100 text-emerald-900",
-  lab: "bg-amber-100 text-amber-900",
+  appointment: "bg-blue-100 dark:bg-blue-900/40 text-blue-900 dark:text-blue-200",
+  prescription: "bg-emerald-100 dark:bg-emerald-900/40 text-emerald-900 dark:text-emerald-200",
+  lab: "bg-amber-100 dark:bg-amber-900/40 text-amber-900 dark:text-amber-200",
 };
 
 const TYPE_ICON: Record<EntryType, string> = {
@@ -373,7 +373,7 @@ export default function PatientRecordsPage() {
     return (
       <section
         data-testid="patient-records-loading"
-        className="flex min-h-[40vh] items-center justify-center text-sm text-slate-500"
+        className="flex min-h-[40vh] items-center justify-center text-sm text-slate-500 dark:text-gray-400"
       >
         Loading your records…
       </section>
@@ -384,7 +384,7 @@ export default function PatientRecordsPage() {
     return (
       <section data-testid="patient-records-unauth" className="space-y-4 py-6">
         <h1 className="text-2xl font-semibold tracking-tight">Sign in</h1>
-        <p className="text-base text-slate-600">
+        <p className="text-base text-slate-600 dark:text-gray-300">
           Please sign in to view your health records.
         </p>
         <Link
@@ -403,7 +403,7 @@ export default function PatientRecordsPage() {
       <section
         data-testid="patient-records-error"
         role="alert"
-        className="rounded-md border border-red-300 bg-red-50 p-4 text-sm text-red-800"
+        className="rounded-md border border-red-300 dark:border-red-800 bg-red-50 dark:bg-red-900/30 p-4 text-sm text-red-800 dark:text-red-200"
       >
         Something went wrong loading your records. Please refresh.
       </section>
@@ -418,7 +418,7 @@ export default function PatientRecordsPage() {
         <h1 className="text-2xl font-semibold tracking-tight">
           My health records
         </h1>
-        <p className="text-sm text-slate-600">
+        <p className="text-sm text-slate-600 dark:text-gray-300">
           Your appointments, prescriptions, and lab results in one place.
           Stage 1 shows local Pearl records; Stage 2 will federate
           ABDM-linked records via HIU.
@@ -445,7 +445,7 @@ export default function PatientRecordsPage() {
               className={`inline-flex h-11 min-w-[44px] items-center justify-center gap-2 rounded-full px-4 text-sm font-medium ${
                 on
                   ? "bg-slate-900 text-white"
-                  : "border border-slate-300 bg-white text-slate-700"
+                  : "border border-slate-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-slate-700 dark:text-gray-200"
               }`}
             >
               <span aria-hidden="true">{TYPE_ICON[t]}</span>
@@ -458,10 +458,10 @@ export default function PatientRecordsPage() {
       {isEmpty ? (
         <div
           data-testid="patient-records-empty"
-          className="space-y-3 rounded-lg border border-slate-200 bg-white p-6 text-center shadow-sm"
+          className="space-y-3 rounded-lg border border-slate-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6 text-center shadow-sm"
         >
-          <p className="text-base text-slate-700">No records yet.</p>
-          <p className="text-xs text-slate-500">
+          <p className="text-base text-slate-700 dark:text-gray-200">No records yet.</p>
+          <p className="text-xs text-slate-500 dark:text-gray-400">
             Your appointments, prescriptions, and lab results will show up
             here once they&apos;re entered by the hospital.
           </p>
@@ -480,7 +480,7 @@ export default function PatientRecordsPage() {
             >
               <h2
                 data-testid="patient-records-day-header"
-                className="sticky top-0 z-10 bg-white py-1 text-xs font-semibold uppercase tracking-wide text-slate-500"
+                className="sticky top-0 z-10 bg-white dark:bg-gray-800 py-1 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-gray-400"
               >
                 {formatDateHeader(g.ts)}
               </h2>
@@ -505,7 +505,7 @@ export default function PatientRecordsPage() {
               void fetchWindow(next, "append");
             }}
             data-testid="patient-records-load-more"
-            className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 px-6 text-sm font-medium text-slate-800 disabled:opacity-60"
+            className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 dark:border-gray-600 px-6 text-sm font-medium text-slate-800 dark:text-gray-100 disabled:opacity-60"
           >
             {loadingMore ? "Loading…" : "Load older records"}
           </button>
@@ -525,26 +525,26 @@ function RecordCard({ entry }: CardProps) {
       data-testid="patient-records-row"
       data-entry-id={entry.id}
       data-entry-type={entry.type}
-      className="space-y-2 rounded-lg border border-slate-200 bg-white p-4 shadow-sm"
+      className="space-y-2 rounded-lg border border-slate-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 shadow-sm"
     >
       <div className="flex flex-wrap items-start justify-between gap-2">
         <div className="space-y-1">
           <p
             data-testid="patient-records-row-time"
-            className="text-xs font-medium uppercase tracking-wide text-slate-500"
+            className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-gray-400"
           >
             {formatTime(entry.when)}
           </p>
           <p
             data-testid="patient-records-row-title"
-            className="text-base font-semibold text-slate-900"
+            className="text-base font-semibold text-slate-900 dark:text-gray-100"
           >
             {entry.title}
           </p>
           {entry.body ? (
             <p
               data-testid="patient-records-row-body"
-              className="text-sm text-slate-700"
+              className="text-sm text-slate-700 dark:text-gray-200"
             >
               {entry.body}
             </p>
@@ -565,7 +565,7 @@ function RecordCard({ entry }: CardProps) {
         <Link
           href={entry.href}
           data-testid="patient-records-row-view-btn"
-          className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 px-4 text-sm font-medium text-slate-800"
+          className="inline-flex h-11 min-w-[44px] items-center justify-center rounded-md border border-slate-300 dark:border-gray-600 px-4 text-sm font-medium text-slate-800 dark:text-gray-100"
         >
           View detail
         </Link>


### PR DESCRIPTION
Every patient PWA page was built light-only (hardcoded bg-white / text-slate-* / border-slate-* with no dark: variants), so toggling the theme to dark left white cards on a dark background.

Added dark: variants across all patient pages — dashboard, appointments, prescriptions, records, book, and bills (list + detail + pay) — covering card surfaces, every text shade, status pills (BOOKED / PARTIAL / PENDING / COMPLETED / NO_SHOW / DRAFT / SIGNED), dividers, disabled states, and the amber/red/emerald/blue/violet/sky info + error boxes. Dark-on-light primary buttons (white text on slate-900 / emerald-700) are left as-is — they read correctly in both modes.

Pure CSS-class changes; no logic touched. tsc --noEmit clean. Verified no bare light tokens, missed tokens, or duplicate dark variants remain.

<!--
PR template. Fill in each section; delete sections that don't apply.
Keep it short — the PR description should be skimmable.
-->

## Summary

<!-- 1-2 sentences on what this changes and why. -->

## Test plan

<!--
Bulleted checklist of what you verified. Cover the happy path and the
edge case that motivated the change. If a code path can only be
exercised in CI / on the dev server, say so explicitly.
-->

- [ ]
- [ ]

## Risk

<!--
Anything risky a reviewer should look for? Examples:
  - Touches production-critical code (auth, billing, RBAC, migrations)
  - Changes a deploy script or CI workflow
  - Drops or narrows a database column (REQUIRES `[allow-destructive-migration]` in commit message)
  - Modifies a feature flag's default
  - Bumps a dependency major version

If "low risk" — say so. Don't leave this blank.
-->

## Screenshots / output

<!--
Frontend changes: before/after screenshots.
API changes: a curl invocation + the response body.
Backend behavior: a paste of the test output that proves it works.
-->

## Linked issues

<!-- Closes #N for each issue this PR resolves. -->
