### PR TITLE
fix: allow unique indexes on new migration tables

### DIFF
--- a/e2e/migration-safety.spec.ts
+++ b/e2e/migration-safety.spec.ts
@@ -121,6 +121,7 @@ test.describe("Migration safety gate — detector regression suite", () => {
     for (const f of [
       "baseline.prisma",
       "safe.prisma",
+      "safe-new-unique.prisma",
       "dangerous-not-null.prisma",
       "dangerous-drop.prisma",
       "dangerous-narrowing.prisma",
@@ -137,6 +138,16 @@ test.describe("Migration safety gate — detector regression suite", () => {
     ]);
     expect(exitCode, "safe schema must pass the gate").toBe(0);
     expect(stdout).toMatch(/\[OK\]/);
+    expect(stdout).toMatch(/No migration risks detected/);
+  });
+
+  test("UNIQUE_ADDITION detector - allows a unique index on a newly created table", () => {
+    const { exitCode, stdout } = runScript([
+      "--schema", fx("safe-new-unique.prisma"),
+      "--against", fx("baseline.prisma"),
+      "--no-commit-blessings",
+    ]);
+    expect(exitCode, "a new table cannot contain pre-existing duplicates").toBe(0);
     expect(stdout).toMatch(/No migration risks detected/);
   });
 

--- a/packages/db/scripts/check-migration-safety.js
+++ b/packages/db/scripts/check-migration-safety.js
@@ -427,7 +427,7 @@ function detectTypeNarrowing(stmt) {
   return risks;
 }
 
-function detectUniqueAddition(stmt) {
+function detectUniqueAddition(stmt, ctx) {
   const risks = [];
   // Postgres patterns:
   //   CREATE UNIQUE INDEX "name" ON "schema"."Foo"("col")
@@ -439,6 +439,11 @@ function detectUniqueAddition(stmt) {
   }
   if (m) {
     const [, table, cols] = m;
+    // A unique index created alongside a brand-new table cannot encounter
+    // pre-existing duplicates. Keep guarding additions to existing tables.
+    if (ctx && ctx.createdTables && ctx.createdTables.has(table)) {
+      return risks;
+    }
     risks.push({
       class: 'UNIQUE_ADDITION',
       table,
@@ -478,13 +483,19 @@ function analyse(sql, opts) {
   const stmts = splitStatements(sql);
   const ctx = {
     fromFields: opts && opts.against ? parseFromSchema(opts.against) : {},
+    createdTables: new Set(
+      stmts
+        .map(stmt => stmt.match(/CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:"[^"]+"\s*\.\s*)?"([A-Za-z0-9_]+)"/i))
+        .filter(Boolean)
+        .map(match => match[1]),
+    ),
   };
   const allRisks = [];
   for (const stmt of stmts) {
     allRisks.push(...detectNotNullWithoutDefault(stmt, ctx));
     allRisks.push(...detectColumnDrop(stmt));
     allRisks.push(...detectTypeNarrowing(stmt));
-    allRisks.push(...detectUniqueAddition(stmt));
+    allRisks.push(...detectUniqueAddition(stmt, ctx));
     allRisks.push(...detectForeignKeyWithoutOnDelete(stmt));
   }
 

--- a/packages/db/scripts/fixtures/migration-safety/safe-new-unique.prisma
+++ b/packages/db/scripts/fixtures/migration-safety/safe-new-unique.prisma
@@ -1,0 +1,37 @@
+// A unique constraint on a newly created table is safe: the table has no
+// pre-existing rows that could violate the constraint.
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model FixtureUser {
+  id       Int     @id @default(autoincrement())
+  email    String  @unique
+  name     String? @db.VarChar(255)
+  bio      String? @db.Text
+  age      Int?
+  tenantId Int
+}
+
+model FixturePost {
+  id        Int      @id @default(autoincrement())
+  title     String   @db.VarChar(255)
+  body      String   @db.Text
+  authorId  Int?
+  tenantId  Int
+  createdAt DateTime @default(now())
+}
+
+model FixtureHolding {
+  id           Int @id @default(autoincrement())
+  departmentId Int
+  materialId   Int
+
+  @@unique([departmentId, materialId])
+}


### PR DESCRIPTION
## Summary

- allow unique indexes created alongside brand-new tables
- keep blocking unique additions on existing tables
- add a regression fixture for the safe new-table case

## Verification

- migration safety production schema diff: 0 risks
- migration-safety regression suite: 15 passed